### PR TITLE
Add CLI demo commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,144 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "survey_cad"
 version = "0.1.0"
 
@@ -10,5 +148,102 @@ version = "0.1.0"
 name = "survey_cad_cli"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "survey_cad",
 ]
+
+[[package]]
+name = "syn"
+version = "2.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/README.md
+++ b/README.md
@@ -3,3 +3,36 @@
 Prototype structure for a surveying-specific CAD application written in Rust.
 
 This repository is organized as a Cargo workspace with a core library and a CLI binary.
+
+## CLI Examples
+
+The `survey_cad_cli` binary provides several small commands demonstrating the
+geometry, surveying and I/O utilities.
+
+```bash
+$ cargo run -p survey_cad_cli -- --help
+```
+
+### Station distance
+
+```bash
+$ cargo run -p survey_cad_cli -- station-distance A 0.0 0.0 B 3.0 4.0
+```
+
+### Traverse area from CSV
+
+```bash
+$ cargo run -p survey_cad_cli -- traverse-area points.csv
+```
+
+### Copy a file
+
+```bash
+$ cargo run -p survey_cad_cli -- copy src.txt dest.txt
+```
+
+### Render a point
+
+```bash
+$ cargo run -p survey_cad_cli -- render-point 1.0 2.0
+```

--- a/survey_cad_cli/Cargo.toml
+++ b/survey_cad_cli/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 survey_cad = { path = "../survey_cad" }
+clap = { version = "4", features = ["derive"] }

--- a/survey_cad_cli/src/main.rs
+++ b/survey_cad_cli/src/main.rs
@@ -1,3 +1,71 @@
+use clap::{Parser, Subcommand};
+use survey_cad::{
+    geometry::Point,
+    io::{read_points_csv, read_to_string, write_string},
+    render::render_point,
+    surveying::{station_distance, Station, Traverse},
+};
+
+/// Simple command line interface demonstrating the survey CAD utilities.
+#[derive(Parser)]
+#[command(name = "survey_cad_cli", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Compute the distance between two survey stations.
+    StationDistance {
+        name_a: String,
+        x1: f64,
+        y1: f64,
+        name_b: String,
+        x2: f64,
+        y2: f64,
+    },
+    /// Compute the area of a traverse defined in a CSV file of x,y pairs.
+    TraverseArea { path: String },
+    /// Copy a text file from src to dest.
+    Copy { src: String, dest: String },
+    /// Render a point (prints to stdout).
+    RenderPoint { x: f64, y: f64 },
+}
+
 fn main() {
-    println!("Survey CAD CLI");
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::StationDistance {
+            name_a,
+            x1,
+            y1,
+            name_b,
+            x2,
+            y2,
+        } => {
+            let a = Station::new(name_a, Point::new(x1, y1));
+            let b = Station::new(name_b, Point::new(x2, y2));
+            let dist = station_distance(&a, &b);
+            println!("Distance between {} and {} is {:.3}", a.name, b.name, dist);
+        }
+        Commands::TraverseArea { path } => match read_points_csv(&path) {
+            Ok(pts) => {
+                let traverse = Traverse::new(pts);
+                println!("Area: {:.3}", traverse.area());
+            }
+            Err(e) => eprintln!("Error reading {}: {}", path, e),
+        },
+        Commands::Copy { src, dest } => match read_to_string(&src) {
+            Ok(contents) => match write_string(&dest, &contents) {
+                Ok(()) => println!("Copied {} to {}", src, dest),
+                Err(e) => eprintln!("Error writing {}: {}", dest, e),
+            },
+            Err(e) => eprintln!("Error reading {}: {}", src, e),
+        },
+        Commands::RenderPoint { x, y } => {
+            let p = Point::new(x, y);
+            render_point(p);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add Clap to `survey_cad_cli`
- implement small CLI demo for geometry/surveying IO
- document example usage in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6841d1209660832885dcc7f4fdf7b5ab