### PR TITLE
Add GeoJSON/DXF I/O and viewing commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -130,6 +130,15 @@ dependencies = [
  "anstyle",
  "once_cell_polyfill",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -252,7 +261,7 @@ dependencies = [
  "polling",
  "rustix 0.38.44",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -543,6 +552,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "geo-types"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ddb1950450d67efee2bbc5e429c68d052a822de3aad010d28b351fbb705224"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "geojson"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26f3c45b36fccc9cf2805e61d4da6bc4bbd5a3a9589b01afa3a40eff703bd79"
+dependencies = [
+ "geo-types",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,7 +656,7 @@ checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
 dependencies = [
  "log",
  "presser",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
  "windows",
 ]
@@ -674,7 +707,7 @@ dependencies = [
  "com",
  "libc",
  "libloading 0.8.8",
- "thiserror",
+ "thiserror 1.0.69",
  "widestring",
  "winapi",
 ]
@@ -742,6 +775,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,7 +791,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -825,6 +864,12 @@ dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -920,7 +965,7 @@ dependencies = [
  "rustc-hash",
  "spirv",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-xid",
 ]
 
@@ -936,7 +981,7 @@ dependencies = [
  "ndk-sys",
  "num_enum",
  "raw-window-handle",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -961,6 +1006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1105,7 +1151,7 @@ dependencies = [
  "bytemuck",
  "pollster",
  "raw-window-handle",
- "thiserror",
+ "thiserror 1.0.69",
  "ultraviolet",
  "wgpu",
 ]
@@ -1296,6 +1342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "safe_arch"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1359,6 +1411,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,7 +1466,7 @@ dependencies = [
  "log",
  "memmap2",
  "rustix 0.38.44",
- "thiserror",
+ "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -1454,8 +1518,11 @@ name = "survey_cad"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "geojson",
  "log",
  "pixels",
+ "serde",
+ "serde_json",
  "winit",
 ]
 
@@ -1504,7 +1571,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1512,6 +1588,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1891,7 +1978,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "web-sys",
  "wgpu-hal",
  "wgpu-types",
@@ -1935,7 +2022,7 @@ dependencies = [
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",

--- a/README.md
+++ b/README.md
@@ -41,3 +41,15 @@ $ cargo run -p survey_cad_cli -- copy src.txt dest.txt
 ```bash
 $ cargo run -p survey_cad_cli -- render-point 1.0 2.0
 ```
+
+### Export points to GeoJSON
+
+```bash
+$ cargo run -p survey_cad_cli -- export-geojson points.csv points.geojson
+```
+
+### View points from CSV
+
+```bash
+$ cargo run -p survey_cad_cli -- view-points points.csv
+```

--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -8,3 +8,6 @@ pixels = "0.15"
 winit = "0.29"
 log = "0.4"
 env_logger = "0.10"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
+geojson = "0.24"

--- a/survey_cad/src/geometry/mod.rs
+++ b/survey_cad/src/geometry/mod.rs
@@ -1,7 +1,7 @@
 //! Basic geometry primitives for CAD operations.
 
 /// Representation of a 2D point.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Point {
     pub x: f64,
     pub y: f64,

--- a/survey_cad/src/render/mod.rs
+++ b/survey_cad/src/render/mod.rs
@@ -2,13 +2,13 @@
 
 use crate::geometry::Point;
 
+use log::error;
 use pixels::{Pixels, SurfaceTexture};
 use std::sync::Arc;
 use winit::dpi::LogicalSize;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::EventLoop;
 use winit::window::WindowBuilder;
-use log::error;
 
 const WIDTH: u32 = 640;
 const HEIGHT: u32 = 480;
@@ -34,27 +34,83 @@ pub fn render_point(p: Point) {
         Pixels::new(WIDTH, HEIGHT, surface_texture).expect("Failed to create pixel buffer")
     };
 
-    let _ = event_loop.run(move |event, elwt| {
-
-        match event {
-            Event::WindowEvent { event: WindowEvent::CloseRequested, .. } => {
+    let _ = event_loop.run(move |event, elwt| match event {
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            ..
+        } => {
+            elwt.exit();
+        }
+        Event::WindowEvent {
+            event: WindowEvent::Resized(size),
+            ..
+        } => {
+            let _ = pixels.resize_surface(size.width, size.height);
+        }
+        Event::WindowEvent {
+            event: WindowEvent::RedrawRequested,
+            ..
+        } => {
+            draw_point(pixels.frame_mut(), WIDTH as usize, HEIGHT as usize, p);
+            if let Err(err) = pixels.render() {
+                error!("pixels.render() failed: {err}");
                 elwt.exit();
             }
-            Event::WindowEvent { event: WindowEvent::Resized(size), .. } => {
-                let _ = pixels.resize_surface(size.width, size.height);
-            }
-            Event::WindowEvent { event: WindowEvent::RedrawRequested, .. } => {
-                draw_point(pixels.frame_mut(), WIDTH as usize, HEIGHT as usize, p);
-                if let Err(err) = pixels.render() {
-                    error!("pixels.render() failed: {err}");
-                    elwt.exit();
-                }
-            }
-            Event::AboutToWait => {
-                window.request_redraw();
-            }
-            _ => {}
         }
+        Event::AboutToWait => {
+            window.request_redraw();
+        }
+        _ => {}
+    });
+}
+
+/// Renders a collection of points. The window will close when requested.
+pub fn render_points(points: &[Point]) {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let event_loop = EventLoop::new().unwrap();
+    let window = {
+        let size = LogicalSize::new(WIDTH as f64, HEIGHT as f64);
+        WindowBuilder::new()
+            .with_title("Survey Points")
+            .with_inner_size(size)
+            .with_min_inner_size(size)
+            .build(&event_loop)
+            .unwrap()
+    };
+    let window = Arc::new(window);
+
+    let mut pixels = {
+        let surface_texture = SurfaceTexture::new(WIDTH, HEIGHT, window.clone());
+        Pixels::new(WIDTH, HEIGHT, surface_texture).expect("Failed to create pixel buffer")
+    };
+
+    let points = points.to_vec();
+    let _ = event_loop.run(move |event, elwt| match event {
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            ..
+        } => elwt.exit(),
+        Event::WindowEvent {
+            event: WindowEvent::Resized(size),
+            ..
+        } => {
+            let _ = pixels.resize_surface(size.width, size.height);
+        }
+        Event::WindowEvent {
+            event: WindowEvent::RedrawRequested,
+            ..
+        } => {
+            draw_points(pixels.frame_mut(), WIDTH as usize, HEIGHT as usize, &points);
+            if let Err(err) = pixels.render() {
+                error!("pixels.render() failed: {err}");
+                elwt.exit();
+            }
+        }
+        Event::AboutToWait => {
+            window.request_redraw();
+        }
+        _ => {}
     });
 }
 
@@ -71,5 +127,23 @@ fn draw_point(frame: &mut [u8], width: usize, height: usize, point: Point) {
         frame[idx + 1] = 0x00;
         frame[idx + 2] = 0x00;
         frame[idx + 3] = 0xff;
+    }
+}
+
+fn draw_points(frame: &mut [u8], width: usize, height: usize, points: &[Point]) {
+    for pix in frame.chunks_exact_mut(4) {
+        pix.copy_from_slice(&[0x20, 0x20, 0x20, 0xff]);
+    }
+
+    for point in points {
+        let x = point.x.round() as i32;
+        let y = point.y.round() as i32;
+        if x >= 0 && x < width as i32 && y >= 0 && y < height as i32 {
+            let idx = ((y as usize) * width + x as usize) * 4;
+            frame[idx] = 0xff;
+            frame[idx + 1] = 0x00;
+            frame[idx + 2] = 0x00;
+            frame[idx + 3] = 0xff;
+        }
     }
 }

--- a/survey_cad_cli/src/main.rs
+++ b/survey_cad_cli/src/main.rs
@@ -1,8 +1,11 @@
 use clap::{Parser, Subcommand};
 use survey_cad::{
     geometry::Point,
-    io::{read_points_csv, read_to_string, write_string},
-    render::render_point,
+    io::{
+        read_points_csv, read_points_geojson, read_to_string, write_points_csv, write_points_dxf,
+        write_points_geojson, write_string,
+    },
+    render::{render_point, render_points},
     surveying::{station_distance, Station, Traverse},
 };
 
@@ -31,6 +34,14 @@ enum Commands {
     Copy { src: String, dest: String },
     /// Render a point (prints to stdout).
     RenderPoint { x: f64, y: f64 },
+    /// Export points from a CSV file to GeoJSON.
+    ExportGeojson { input: String, output: String },
+    /// Import points from a GeoJSON file to CSV.
+    ImportGeojson { input: String, output: String },
+    /// Export points from a CSV file to a simple DXF.
+    ExportDxf { input: String, output: String },
+    /// View points from a CSV file.
+    ViewPoints { input: String },
 }
 
 fn main() {
@@ -67,5 +78,32 @@ fn main() {
             let p = Point::new(x, y);
             render_point(p);
         }
+        Commands::ExportGeojson { input, output } => match read_points_csv(&input) {
+            Ok(pts) => match write_points_geojson(&output, &pts) {
+                Ok(()) => println!("Wrote {}", output),
+                Err(e) => eprintln!("Error writing {}: {}", output, e),
+            },
+            Err(e) => eprintln!("Error reading {}: {}", input, e),
+        },
+        Commands::ImportGeojson { input, output } => match read_points_geojson(&input) {
+            Ok(pts) => match write_points_csv(&output, &pts) {
+                Ok(()) => println!("Wrote {}", output),
+                Err(e) => eprintln!("Error writing {}: {}", output, e),
+            },
+            Err(e) => eprintln!("Error reading {}: {}", input, e),
+        },
+        Commands::ExportDxf { input, output } => match read_points_csv(&input) {
+            Ok(pts) => match write_points_dxf(&output, &pts) {
+                Ok(()) => println!("Wrote {}", output),
+                Err(e) => eprintln!("Error writing {}: {}", output, e),
+            },
+            Err(e) => eprintln!("Error reading {}: {}", input, e),
+        },
+        Commands::ViewPoints { input } => match read_points_csv(&input) {
+            Ok(pts) => {
+                render_points(&pts);
+            }
+            Err(e) => eprintln!("Error reading {}: {}", input, e),
+        },
     }
 }


### PR DESCRIPTION
## Summary
- support GeoJSON and DXF in the library
- add new CLI subcommands for importing/exporting formats and viewing points
- extend rendering utilities with a `render_points` helper
- document new commands in README
- include basic tests for the new I/O helpers

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6841d7d62bd88328b2bfa08fd1308cf1