### PR TITLE
Add CLI integration tests and documentation update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "assert_fs"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +261,17 @@ checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
 dependencies = [
  "block-sys",
  "objc2",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -452,6 +494,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +555,12 @@ checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
  "libloading 0.8.8",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "downcast-rs"
@@ -522,6 +595,21 @@ checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -606,6 +694,30 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.9.1",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -745,6 +857,22 @@ dependencies = [
  "block2",
  "dispatch",
  "objc2",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1000,6 +1128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1316,36 @@ name = "pollster"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "presser"
@@ -1530,7 +1694,10 @@ dependencies = [
 name = "survey_cad_cli"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
+ "assert_fs",
  "clap",
+ "predicates",
  "survey_cad",
 ]
 
@@ -1557,6 +1724,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,6 +1744,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -1713,6 +1899,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/README.md
+++ b/README.md
@@ -2,53 +2,63 @@
 
 Prototype structure for a surveying-specific CAD application written in Rust.
 
-This repository is organized as a Cargo workspace with a core library and a CLI binary.
+This repository is organized as a Cargo workspace with a core library and a CLI
+binary.
 
 The library exposes basic geometry types (points and lines) along with more
 advanced primitives like arcs, polylines and polygonal surfaces. Surveying
 utilities cover traverse area calculations as well as vertical angle and
 differential leveling helpers.
 
-## CLI Examples
+## Architecture Overview
 
-The `survey_cad_cli` binary provides several small commands demonstrating the
-geometry, surveying and I/O utilities.
+The workspace contains two crates:
+
+- `survey_cad` &mdash; core library with modules for geometry, surveying, file I/O and simple rendering utilities.
+- `survey_cad_cli` &mdash; small command line tool that demonstrates the library capabilities.
+
+Each module in the library is focused on a specific set of tasks and can be used
+independently within other Rust projects.
+
+## CLI Tutorial
+
+Build the workspace and view available commands:
 
 ```bash
 $ cargo run -p survey_cad_cli -- --help
 ```
 
-### Station distance
+Compute the distance between two stations:
 
 ```bash
 $ cargo run -p survey_cad_cli -- station-distance A 0.0 0.0 B 3.0 4.0
 ```
 
-### Traverse area from CSV
+Calculate the area of a traverse defined in a CSV file:
 
 ```bash
 $ cargo run -p survey_cad_cli -- traverse-area points.csv
 ```
 
-### Copy a file
+Copy a file using the CLI:
 
 ```bash
 $ cargo run -p survey_cad_cli -- copy src.txt dest.txt
 ```
 
-### Render a point
+Render a single point (opens a window):
 
 ```bash
 $ cargo run -p survey_cad_cli -- render-point 1.0 2.0
 ```
 
-### Export points to GeoJSON
+Export survey points to GeoJSON:
 
 ```bash
 $ cargo run -p survey_cad_cli -- export-geojson points.csv points.geojson
 ```
 
-### View points from CSV
+View points from a CSV file:
 
 ```bash
 $ cargo run -p survey_cad_cli -- view-points points.csv

--- a/survey_cad_cli/Cargo.toml
+++ b/survey_cad_cli/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2021"
 [dependencies]
 survey_cad = { path = "../survey_cad" }
 clap = { version = "4", features = ["derive"] }
+
+[dev-dependencies]
+assert_cmd = "2"
+assert_fs = "1"
+predicates = "3"

--- a/survey_cad_cli/tests/cli.rs
+++ b/survey_cad_cli/tests/cli.rs
@@ -1,0 +1,42 @@
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+#[test]
+fn station_distance_command() {
+    Command::cargo_bin("survey_cad_cli").unwrap()
+        .args(["station-distance", "A", "0.0", "0.0", "B", "3.0", "4.0"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Distance between A and B is 5.000"));
+}
+
+#[test]
+fn traverse_area_command() {
+    let file = assert_fs::NamedTempFile::new("traverse.csv").unwrap();
+    file.write_str("0.0,0.0\n1.0,0.0\n1.0,1.0\n0.0,1.0\n").unwrap();
+
+    Command::cargo_bin("survey_cad_cli").unwrap()
+        .args(["traverse-area", file.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Area: 1.000"));
+}
+
+#[test]
+fn copy_command() {
+    let dir = assert_fs::TempDir::new().unwrap();
+    let src = dir.child("src.txt");
+    src.write_str("hello world").unwrap();
+    let dest = dir.child("dest.txt");
+
+    Command::cargo_bin("survey_cad_cli").unwrap()
+        .args(["copy", src.path().to_str().unwrap(), dest.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Copied"));
+
+    dest.assert("hello world");
+    dir.close().unwrap();
+}


### PR DESCRIPTION
## Summary
- expand README with architecture overview and tutorial
- add assert_cmd-based integration tests for CLI
- wire up test deps in survey_cad_cli

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6841db0ce4548328baeaedfbf72adb7f