### PR TITLE
Add CI workflow with clippy and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          components: clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Run cargo test
+        run: cargo test --all

--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ View points from a CSV file:
 ```bash
 $ cargo run -p survey_cad_cli -- view-points points.csv
 ```
+
+## Continuous Integration
+
+GitHub Actions automatically runs `cargo clippy` and `cargo test` for every push
+and pull request. The workflow fails if clippy reports warnings or any tests
+fail.


### PR DESCRIPTION
## Summary
- automate testing and linting with GitHub Actions
- document CI workflow in README

## Testing
- `cargo test --quiet`
- `cargo clippy --all-targets --all-features -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_6841dc925e74832886c48774b483b345