### PR TITLE
Add vertical angle & leveling commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ View points from a CSV file:
 $ cargo run -p survey_cad_cli -- view-points points.csv
 ```
 
+Compute the vertical angle between two stations:
+
+```bash
+$ cargo run -p survey_cad_cli -- vertical-angle A 0.0 0.0 10.0 B 3.0 4.0 14.0
+```
+
+Calculate a new elevation using differential leveling:
+
+```bash
+$ cargo run -p survey_cad_cli -- level-elevation 100.0 1.2 0.8
+```
+
 ## Continuous Integration
 
 GitHub Actions automatically runs `cargo clippy` and `cargo test` for every push

--- a/survey_cad/src/lib.rs
+++ b/survey_cad/src/lib.rs
@@ -1,9 +1,9 @@
 //! Core library for the Survey CAD application.
 
 pub mod geometry;
-pub mod surveying;
 pub mod io;
 pub mod render;
+pub mod surveying;
 
 /// Adds two numbers together. Example function.
 #[allow(dead_code)]

--- a/survey_cad_cli/src/main.rs
+++ b/survey_cad_cli/src/main.rs
@@ -6,7 +6,7 @@ use survey_cad::{
         write_points_geojson, write_string,
     },
     render::{render_point, render_points},
-    surveying::{station_distance, Station, Traverse},
+    surveying::{level_elevation, station_distance, vertical_angle, Station, Traverse},
 };
 
 fn no_render() -> bool {
@@ -46,6 +46,23 @@ enum Commands {
     ExportDxf { input: String, output: String },
     /// View points from a CSV file.
     ViewPoints { input: String },
+    /// Compute the vertical angle between two stations given their elevations.
+    VerticalAngle {
+        name_a: String,
+        x1: f64,
+        y1: f64,
+        elev_a: f64,
+        name_b: String,
+        x2: f64,
+        y2: f64,
+        elev_b: f64,
+    },
+    /// Compute a new elevation using differential leveling.
+    LevelElevation {
+        start_elev: f64,
+        backsight: f64,
+        foresight: f64,
+    },
 }
 
 fn main() {
@@ -117,5 +134,31 @@ fn main() {
             }
             Err(e) => eprintln!("Error reading {}: {}", input, e),
         },
+        Commands::VerticalAngle {
+            name_a,
+            x1,
+            y1,
+            elev_a,
+            name_b,
+            x2,
+            y2,
+            elev_b,
+        } => {
+            let a = Station::new(name_a, Point::new(x1, y1));
+            let b = Station::new(name_b, Point::new(x2, y2));
+            let ang = vertical_angle(&a, elev_a, &b, elev_b);
+            println!(
+                "Vertical angle between {} and {} is {:.3} rad",
+                a.name, b.name, ang
+            );
+        }
+        Commands::LevelElevation {
+            start_elev,
+            backsight,
+            foresight,
+        } => {
+            let elev = level_elevation(start_elev, backsight, foresight);
+            println!("New elevation: {:.3}", elev);
+        }
     }
 }

--- a/survey_cad_cli/tests/cli.rs
+++ b/survey_cad_cli/tests/cli.rs
@@ -5,19 +5,24 @@ use std::process::Command;
 
 #[test]
 fn station_distance_command() {
-    Command::cargo_bin("survey_cad_cli").unwrap()
+    Command::cargo_bin("survey_cad_cli")
+        .unwrap()
         .args(["station-distance", "A", "0.0", "0.0", "B", "3.0", "4.0"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Distance between A and B is 5.000"));
+        .stdout(predicate::str::contains(
+            "Distance between A and B is 5.000",
+        ));
 }
 
 #[test]
 fn traverse_area_command() {
     let file = assert_fs::NamedTempFile::new("traverse.csv").unwrap();
-    file.write_str("0.0,0.0\n1.0,0.0\n1.0,1.0\n0.0,1.0\n").unwrap();
+    file.write_str("0.0,0.0\n1.0,0.0\n1.0,1.0\n0.0,1.0\n")
+        .unwrap();
 
-    Command::cargo_bin("survey_cad_cli").unwrap()
+    Command::cargo_bin("survey_cad_cli")
+        .unwrap()
         .args(["traverse-area", file.path().to_str().unwrap()])
         .assert()
         .success()
@@ -31,8 +36,13 @@ fn copy_command() {
     src.write_str("hello world").unwrap();
     let dest = dir.child("dest.txt");
 
-    Command::cargo_bin("survey_cad_cli").unwrap()
-        .args(["copy", src.path().to_str().unwrap(), dest.path().to_str().unwrap()])
+    Command::cargo_bin("survey_cad_cli")
+        .unwrap()
+        .args([
+            "copy",
+            src.path().to_str().unwrap(),
+            dest.path().to_str().unwrap(),
+        ])
         .assert()
         .success()
         .stdout(predicate::str::contains("Copied"));
@@ -45,9 +55,7 @@ fn copy_command() {
 fn export_geojson_command() {
     let dir = assert_fs::TempDir::new().unwrap();
     let input = dir.child("pts.csv");
-    input
-        .write_str("1.0,2.0\n3.0,4.0\n")
-        .unwrap();
+    input.write_str("1.0,2.0\n3.0,4.0\n").unwrap();
     let output = dir.child("pts.geojson");
 
     Command::cargo_bin("survey_cad_cli")
@@ -128,4 +136,36 @@ fn view_points_command() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Rendering 2 points"));
+}
+
+#[test]
+fn vertical_angle_command() {
+    Command::cargo_bin("survey_cad_cli")
+        .unwrap()
+        .args([
+            "vertical-angle",
+            "A",
+            "0.0",
+            "0.0",
+            "10.0",
+            "B",
+            "3.0",
+            "4.0",
+            "14.0",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Vertical angle between A and B is 0.675 rad",
+        ));
+}
+
+#[test]
+fn level_elevation_command() {
+    Command::cargo_bin("survey_cad_cli")
+        .unwrap()
+        .args(["level-elevation", "100.0", "1.2", "0.8"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("New elevation: 100.400"));
 }


### PR DESCRIPTION
## Summary
- extend CLI with `vertical-angle` and `level-elevation` commands
- support new commands in `main`
- document in README
- test new commands

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6841e1b88c9883289a21c11c5183a1a0