### PR TITLE
Add COGO utilities and CLI commands

### DIFF
--- a/survey_cad/src/surveying/cogo.rs
+++ b/survey_cad/src/surveying/cogo.rs
@@ -1,0 +1,64 @@
+//! Basic coordinate geometry (COGO) utilities used in surveying operations.
+
+use crate::geometry::Point;
+
+/// Computes the bearing in radians from point `a` to point `b` measured from the
+/// positive X axis.
+pub fn bearing(a: Point, b: Point) -> f64 {
+    (b.y - a.y).atan2(b.x - a.x)
+}
+
+/// Computes a new point from a starting point, a bearing (radians from the
+/// positive X axis) and a distance.
+pub fn forward(start: Point, bearing: f64, distance: f64) -> Point {
+    Point::new(
+        start.x + distance * bearing.cos(),
+        start.y + distance * bearing.sin(),
+    )
+}
+
+/// Determines the intersection of two infinite lines defined by points
+/// `(p1, p2)` and `(p3, p4)`. Returns `None` if the lines are parallel.
+pub fn line_intersection(p1: Point, p2: Point, p3: Point, p4: Point) -> Option<Point> {
+    let denom = (p1.x - p2.x) * (p3.y - p4.y) - (p1.y - p2.y) * (p3.x - p4.x);
+    if denom.abs() < f64::EPSILON {
+        return None;
+    }
+    let x_num =
+        (p1.x * p2.y - p1.y * p2.x) * (p3.x - p4.x) - (p1.x - p2.x) * (p3.x * p4.y - p3.y * p4.x);
+    let y_num =
+        (p1.x * p2.y - p1.y * p2.x) * (p3.y - p4.y) - (p1.y - p2.y) * (p3.x * p4.y - p3.y * p4.x);
+    Some(Point::new(x_num / denom, y_num / denom))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bearing_works() {
+        let a = Point::new(0.0, 0.0);
+        let b = Point::new(1.0, 1.0);
+        let bng = bearing(a, b);
+        assert!((bng - std::f64::consts::FRAC_PI_4).abs() < 1e-6);
+    }
+
+    #[test]
+    fn forward_works() {
+        let start = Point::new(0.0, 0.0);
+        let p = forward(start, std::f64::consts::FRAC_PI_2, 2.0);
+        assert!((p.x - 0.0).abs() < 1e-6);
+        assert!((p.y - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn line_intersection_works() {
+        let p1 = Point::new(0.0, 0.0);
+        let p2 = Point::new(1.0, 1.0);
+        let p3 = Point::new(0.0, 1.0);
+        let p4 = Point::new(1.0, 0.0);
+        let int = line_intersection(p1, p2, p3, p4).unwrap();
+        assert!((int.x - 0.5).abs() < 1e-6);
+        assert!((int.y - 0.5).abs() < 1e-6);
+    }
+}

--- a/survey_cad/src/surveying/mod.rs
+++ b/survey_cad/src/surveying/mod.rs
@@ -2,6 +2,9 @@
 
 use crate::geometry::{self, Point};
 
+pub mod cogo;
+pub use cogo::{bearing, forward, line_intersection};
+
 /// Representation of a simple survey station.
 #[derive(Debug)]
 pub struct Station {

--- a/survey_cad_cli/src/main.rs
+++ b/survey_cad_cli/src/main.rs
@@ -6,7 +6,10 @@ use survey_cad::{
         write_points_geojson, write_string,
     },
     render::{render_point, render_points},
-    surveying::{level_elevation, station_distance, vertical_angle, Station, Traverse},
+    surveying::{
+        bearing, forward, level_elevation, line_intersection, station_distance, vertical_angle,
+        Station, Traverse,
+    },
 };
 
 fn no_render() -> bool {
@@ -56,6 +59,26 @@ enum Commands {
         x2: f64,
         y2: f64,
         elev_b: f64,
+    },
+    /// Compute the bearing between two points.
+    Bearing { x1: f64, y1: f64, x2: f64, y2: f64 },
+    /// Compute a new point from a start point, bearing and distance.
+    Forward {
+        x: f64,
+        y: f64,
+        bearing: f64,
+        distance: f64,
+    },
+    /// Determine the intersection point of two lines.
+    Intersection {
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        x3: f64,
+        y3: f64,
+        x4: f64,
+        y4: f64,
     },
     /// Compute a new elevation using differential leveling.
     LevelElevation {
@@ -152,6 +175,37 @@ fn main() {
                 a.name, b.name, ang
             );
         }
+        Commands::Bearing { x1, y1, x2, y2 } => {
+            let bng = bearing(Point::new(x1, y1), Point::new(x2, y2));
+            println!("Bearing: {:.3} rad", bng);
+        }
+        Commands::Forward {
+            x,
+            y,
+            bearing: bng,
+            distance,
+        } => {
+            let p = forward(Point::new(x, y), bng, distance);
+            println!("Point: {:.3},{:.3}", p.x, p.y);
+        }
+        Commands::Intersection {
+            x1,
+            y1,
+            x2,
+            y2,
+            x3,
+            y3,
+            x4,
+            y4,
+        } => match line_intersection(
+            Point::new(x1, y1),
+            Point::new(x2, y2),
+            Point::new(x3, y3),
+            Point::new(x4, y4),
+        ) {
+            Some(pt) => println!("Intersection: {:.3},{:.3}", pt.x, pt.y),
+            None => println!("Lines are parallel"),
+        },
         Commands::LevelElevation {
             start_elev,
             backsight,

--- a/survey_cad_cli/tests/cli.rs
+++ b/survey_cad_cli/tests/cli.rs
@@ -169,3 +169,43 @@ fn level_elevation_command() {
         .success()
         .stdout(predicate::str::contains("New elevation: 100.400"));
 }
+
+#[test]
+fn bearing_command() {
+    Command::cargo_bin("survey_cad_cli")
+        .unwrap()
+        .args(["bearing", "0.0", "0.0", "1.0", "1.0"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Bearing:"));
+}
+
+#[test]
+fn forward_command() {
+    Command::cargo_bin("survey_cad_cli")
+        .unwrap()
+        .args(["forward", "0.0", "0.0", "1.57079632679", "2.0"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Point:"));
+}
+
+#[test]
+fn intersection_command() {
+    Command::cargo_bin("survey_cad_cli")
+        .unwrap()
+        .args([
+            "intersection",
+            "0.0",
+            "0.0",
+            "1.0",
+            "1.0",
+            "0.0",
+            "1.0",
+            "1.0",
+            "0.0",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Intersection:"));
+}


### PR DESCRIPTION
## Summary
- implement basic COGO operations (bearing, forward, line intersection)
- re-export new functions from surveying module
- add CLI commands to call the COGO functions
- cover new features with unit and integration tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68421f06e1c8832888a348332c774e1d