### PR TITLE
Implement cad_import library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,6 +1357,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cad_import"
+version = "0.1.0"
+dependencies = [
+ "survey_cad",
+]
+
+[[package]]
 name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,11 @@
 [workspace]
-members = ["survey_cad", "survey_cad_cli", "bevy_pmetra", "survey_cad_gui"]
+members = [
+    "survey_cad",
+    "survey_cad_cli",
+    "bevy_pmetra",
+    "survey_cad_gui",
+    "cad_import",
+]
 resolver = "2"
 
 [workspace.package]

--- a/cad_import/Cargo.toml
+++ b/cad_import/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cad_import"
+edition.workspace = true
+version.workspace = true
+
+[dependencies]
+survey_cad = { path = "../survey_cad" }

--- a/cad_import/src/lib.rs
+++ b/cad_import/src/lib.rs
@@ -1,0 +1,58 @@
+use std::io;
+
+use survey_cad::{
+    geometry::Point,
+    io::{read_lines, read_points_csv as sc_read_csv, read_points_geojson as sc_read_geojson},
+};
+
+/// Reads a CSV file of `x,y` pairs into [`Point`]s.
+pub fn read_points_csv(path: &str) -> io::Result<Vec<Point>> {
+    sc_read_csv(path)
+}
+
+/// Reads a GeoJSON file of Point features into [`Point`]s.
+pub fn read_points_geojson(path: &str) -> io::Result<Vec<Point>> {
+    sc_read_geojson(path)
+}
+
+/// Reads a very simple ASCII DXF file containing only `POINT` entities and
+/// returns their coordinates as [`Point`]s.
+pub fn read_points_dxf(path: &str) -> io::Result<Vec<Point>> {
+    let lines = read_lines(path)?;
+    let mut pts = Vec::new();
+    let mut iter = lines.iter();
+    while let (Some(code), Some(value)) = (iter.next(), iter.next()) {
+        if code.trim() == "0" && value.trim() == "POINT" {
+            let mut x = None;
+            let mut y = None;
+            while let (Some(c), Some(v)) = (iter.next(), iter.next()) {
+                match c.trim() {
+                    "10" => x = v.trim().parse().ok(),
+                    "20" => y = v.trim().parse().ok(),
+                    "30" => break,
+                    _ => {}
+                }
+            }
+            if let (Some(x), Some(y)) = (x, y) {
+                pts.push(Point::new(x, y));
+            }
+        }
+    }
+    Ok(pts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use survey_cad::io::write_points_dxf;
+
+    #[test]
+    fn read_written_dxf_points() {
+        let path = std::env::temp_dir().join("import_pts.dxf");
+        let pts = vec![Point::new(1.0, 2.0), Point::new(3.0, 4.0)];
+        write_points_dxf(path.to_str().unwrap(), &pts).unwrap();
+        let read = read_points_dxf(path.to_str().unwrap()).unwrap();
+        assert_eq!(read, pts);
+        std::fs::remove_file(path).ok();
+    }
+}


### PR DESCRIPTION
## Summary
- add `cad_import` crate to the workspace
- implement CSV, GeoJSON and DXF import helpers
- test DXF import functionality

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6842275d0fcc8328a1c0ea5f9289a3f7