### PR TITLE
Add TIN support with contours and volume tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,6 +1713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "delaunator"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab46e386c7a38300a0d93b0f3e484bc2ee0aded66c47b14762ec9ab383934fa"
+dependencies = [
+ "robust",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3422,6 +3431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "robust"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5864e7ef1a6b7bcf1d6ca3f655e65e724ed3b52546a0d0a663c991522f552ea"
+
+[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3697,6 +3712,7 @@ dependencies = [
  "bevy_editor_cam",
  "bevy_picking",
  "bevy_pmetra",
+ "delaunator",
  "env_logger",
  "geojson",
  "log",

--- a/bevy_pmetra/src/lib.rs
+++ b/bevy_pmetra/src/lib.rs
@@ -1,5 +1,6 @@
+#![allow(deprecated)]
 use bevy::prelude::*;
-use bevy::prelude::{Mesh3d, MeshMaterial3d, Cuboid};
+use bevy::prelude::{Cuboid, Mesh3d, MeshMaterial3d};
 
 /// Plugin spawning a parametric box mesh.
 pub struct ParametricBox {
@@ -9,17 +10,20 @@ pub struct ParametricBox {
 impl Plugin for ParametricBox {
     fn build(&self, app: &mut App) {
         let size = self.size;
-        app.add_systems(Startup, move |mut commands: Commands,
-                                         mut meshes: ResMut<Assets<Mesh>>,
-                                         mut materials: ResMut<Assets<StandardMaterial>>| {
-            commands.spawn(PbrBundle {
-                mesh: Mesh3d::from(meshes.add(Mesh::from(Cuboid::new(size.x, size.y, size.z)))),
-                material: MeshMaterial3d::from(materials.add(StandardMaterial {
-                    base_color: Color::srgb(0.8, 0.8, 0.8),
+        app.add_systems(
+            Startup,
+            move |mut commands: Commands,
+                  mut meshes: ResMut<Assets<Mesh>>,
+                  mut materials: ResMut<Assets<StandardMaterial>>| {
+                commands.spawn(PbrBundle {
+                    mesh: Mesh3d::from(meshes.add(Mesh::from(Cuboid::new(size.x, size.y, size.z)))),
+                    material: MeshMaterial3d::from(materials.add(StandardMaterial {
+                        base_color: Color::srgb(0.8, 0.8, 0.8),
+                        ..default()
+                    })),
                     ..default()
-                })),
-                ..default()
-            });
-        });
+                });
+            },
+        );
     }
 }

--- a/cad_import/src/lib.rs
+++ b/cad_import/src/lib.rs
@@ -63,20 +63,23 @@ pub enum PointFileFormat {
     ENZD,
 }
 
-impl PointFileFormat {
+impl std::str::FromStr for PointFileFormat {
+    type Err = ();
+
     /// Parses a string to a [`PointFileFormat`]. Case insensitive.
-    pub fn from_str(s: &str) -> Option<Self> {
-        match s.to_ascii_lowercase().as_str() {
-            "pnezd" => Some(Self::PNEZD),
-            "penzd" => Some(Self::PENZD),
-            "pnez" => Some(Self::PNEZ),
-            "penz" => Some(Self::PENZ),
-            "nez" => Some(Self::NEZ),
-            "enz" => Some(Self::ENZ),
-            "nezd" => Some(Self::NEZD),
-            "enzd" => Some(Self::ENZD),
-            _ => None,
-        }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let fmt = match s.to_ascii_lowercase().as_str() {
+            "pnezd" => Self::PNEZD,
+            "penzd" => Self::PENZD,
+            "pnez" => Self::PNEZ,
+            "penz" => Self::PENZ,
+            "nez" => Self::NEZ,
+            "enz" => Self::ENZ,
+            "nezd" => Self::NEZD,
+            "enzd" => Self::ENZD,
+            _ => return Err(()),
+        };
+        Ok(fmt)
     }
 }
 
@@ -93,12 +96,23 @@ pub fn read_point_file(path: &str, format: PointFileFormat) -> io::Result<Vec<Su
         } else {
             line.split_whitespace().collect()
         };
-        let parse_f64 = |s: &str| s.trim().parse::<f64>().map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e));
-        let parse_u32 = |s: &str| s.trim().parse::<u32>().map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e));
+        let parse_f64 = |s: &str| {
+            s.trim()
+                .parse::<f64>()
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        };
+        let parse_u32 = |s: &str| {
+            s.trim()
+                .parse::<u32>()
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        };
         let p = match format {
             PointFileFormat::PNEZD => {
                 if fields.len() < 4 {
-                    return Err(io::Error::new(io::ErrorKind::InvalidData, "expected at least 4 fields"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "expected at least 4 fields",
+                    ));
                 }
                 let number = parse_u32(fields[0]).ok();
                 let n = parse_f64(fields[1])?;
@@ -109,11 +123,18 @@ pub fn read_point_file(path: &str, format: PointFileFormat) -> io::Result<Vec<Su
                 } else {
                     None
                 };
-                SurveyPoint { number, point: Point3::new(e, n, z), description: desc }
+                SurveyPoint {
+                    number,
+                    point: Point3::new(e, n, z),
+                    description: desc,
+                }
             }
             PointFileFormat::PENZD => {
                 if fields.len() < 4 {
-                    return Err(io::Error::new(io::ErrorKind::InvalidData, "expected at least 4 fields"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "expected at least 4 fields",
+                    ));
                 }
                 let number = parse_u32(fields[0]).ok();
                 let e = parse_f64(fields[1])?;
@@ -124,65 +145,111 @@ pub fn read_point_file(path: &str, format: PointFileFormat) -> io::Result<Vec<Su
                 } else {
                     None
                 };
-                SurveyPoint { number, point: Point3::new(e, n, z), description: desc }
+                SurveyPoint {
+                    number,
+                    point: Point3::new(e, n, z),
+                    description: desc,
+                }
             }
             PointFileFormat::PNEZ => {
                 if fields.len() < 4 {
-                    return Err(io::Error::new(io::ErrorKind::InvalidData, "expected 4 fields"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "expected 4 fields",
+                    ));
                 }
                 let number = parse_u32(fields[0]).ok();
                 let n = parse_f64(fields[1])?;
                 let e = parse_f64(fields[2])?;
                 let z = parse_f64(fields[3])?;
-                SurveyPoint { number, point: Point3::new(e, n, z), description: None }
+                SurveyPoint {
+                    number,
+                    point: Point3::new(e, n, z),
+                    description: None,
+                }
             }
             PointFileFormat::PENZ => {
                 if fields.len() < 4 {
-                    return Err(io::Error::new(io::ErrorKind::InvalidData, "expected 4 fields"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "expected 4 fields",
+                    ));
                 }
                 let number = parse_u32(fields[0]).ok();
                 let e = parse_f64(fields[1])?;
                 let n = parse_f64(fields[2])?;
                 let z = parse_f64(fields[3])?;
-                SurveyPoint { number, point: Point3::new(e, n, z), description: None }
+                SurveyPoint {
+                    number,
+                    point: Point3::new(e, n, z),
+                    description: None,
+                }
             }
             PointFileFormat::NEZ => {
                 if fields.len() < 3 {
-                    return Err(io::Error::new(io::ErrorKind::InvalidData, "expected 3 fields"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "expected 3 fields",
+                    ));
                 }
                 let n = parse_f64(fields[0])?;
                 let e = parse_f64(fields[1])?;
                 let z = parse_f64(fields[2])?;
-                SurveyPoint { number: None, point: Point3::new(e, n, z), description: None }
+                SurveyPoint {
+                    number: None,
+                    point: Point3::new(e, n, z),
+                    description: None,
+                }
             }
             PointFileFormat::ENZ => {
                 if fields.len() < 3 {
-                    return Err(io::Error::new(io::ErrorKind::InvalidData, "expected 3 fields"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "expected 3 fields",
+                    ));
                 }
                 let e = parse_f64(fields[0])?;
                 let n = parse_f64(fields[1])?;
                 let z = parse_f64(fields[2])?;
-                SurveyPoint { number: None, point: Point3::new(e, n, z), description: None }
+                SurveyPoint {
+                    number: None,
+                    point: Point3::new(e, n, z),
+                    description: None,
+                }
             }
             PointFileFormat::NEZD => {
                 if fields.len() < 4 {
-                    return Err(io::Error::new(io::ErrorKind::InvalidData, "expected at least 4 fields"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "expected at least 4 fields",
+                    ));
                 }
                 let n = parse_f64(fields[0])?;
                 let e = parse_f64(fields[1])?;
                 let z = parse_f64(fields[2])?;
                 let desc = Some(fields[3..].join(" "));
-                SurveyPoint { number: None, point: Point3::new(e, n, z), description: desc }
+                SurveyPoint {
+                    number: None,
+                    point: Point3::new(e, n, z),
+                    description: desc,
+                }
             }
             PointFileFormat::ENZD => {
                 if fields.len() < 4 {
-                    return Err(io::Error::new(io::ErrorKind::InvalidData, "expected at least 4 fields"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "expected at least 4 fields",
+                    ));
                 }
                 let e = parse_f64(fields[0])?;
                 let n = parse_f64(fields[1])?;
                 let z = parse_f64(fields[2])?;
                 let desc = Some(fields[3..].join(" "));
-                SurveyPoint { number: None, point: Point3::new(e, n, z), description: desc }
+                SurveyPoint {
+                    number: None,
+                    point: Point3::new(e, n, z),
+                    description: desc,
+                }
             }
         };
         pts.push(p);

--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -16,6 +16,7 @@ bevy_pmetra = { path = "../bevy_pmetra", optional = true }
 truck-modeling = "0.6"
 truck-topology = "0.6"
 truck-geometry = "0.5"
+delaunator = "1"
 
 [features]
 pmetra = ["bevy/bevy_pbr", "dep:bevy_pmetra"]

--- a/survey_cad/src/dtm.rs
+++ b/survey_cad/src/dtm.rs
@@ -1,0 +1,128 @@
+use crate::geometry::{polygon_area, Point, Point3};
+
+/// Triangulated Irregular Network constructed from 3D points.
+#[derive(Debug, Clone)]
+pub struct Tin {
+    /// Vertices of the TIN.
+    pub vertices: Vec<Point3>,
+    /// Indices into `vertices` forming triangles.
+    pub triangles: Vec<[usize; 3]>,
+}
+
+impl Tin {
+    /// Builds a TIN from the provided vertices using Delaunay triangulation on the XY plane.
+    pub fn from_points(points: Vec<Point3>) -> Self {
+        let coords: Vec<delaunator::Point> = points
+            .iter()
+            .map(|p| delaunator::Point { x: p.x, y: p.y })
+            .collect();
+        let triangulation = delaunator::triangulate(&coords);
+        let triangles = triangulation
+            .triangles
+            .chunks(3)
+            .map(|c| [c[0], c[1], c[2]])
+            .collect();
+        Self {
+            vertices: points,
+            triangles,
+        }
+    }
+
+    /// Generates contour line segments at the specified interval.
+    pub fn contour_segments(&self, interval: f64) -> Vec<(Point3, Point3)> {
+        if interval <= 0.0 || self.vertices.is_empty() {
+            return Vec::new();
+        }
+        let min_z = self
+            .vertices
+            .iter()
+            .map(|p| p.z)
+            .fold(f64::INFINITY, f64::min);
+        let max_z = self
+            .vertices
+            .iter()
+            .map(|p| p.z)
+            .fold(f64::NEG_INFINITY, f64::max);
+        let mut segments = Vec::new();
+        let mut level = (min_z / interval).ceil() * interval;
+        while level <= max_z {
+            for tri in &self.triangles {
+                let a = self.vertices[tri[0]];
+                let b = self.vertices[tri[1]];
+                let c = self.vertices[tri[2]];
+                let tmin = a.z.min(b.z).min(c.z);
+                let tmax = a.z.max(b.z).max(c.z);
+                if level < tmin || level > tmax {
+                    continue;
+                }
+                let mut pts = Vec::new();
+                if let Some(p) = intersect_edge(a, b, level) {
+                    pts.push(p);
+                }
+                if let Some(p) = intersect_edge(b, c, level) {
+                    pts.push(p);
+                }
+                if let Some(p) = intersect_edge(c, a, level) {
+                    pts.push(p);
+                }
+                if pts.len() == 2 {
+                    segments.push((pts[0], pts[1]));
+                }
+            }
+            level += interval;
+        }
+        segments
+    }
+
+    /// Calculates the volume between the TIN surface and a horizontal plane at `base_elev`.
+    pub fn volume_to_elevation(&self, base_elev: f64) -> f64 {
+        let mut volume = 0.0;
+        for tri in &self.triangles {
+            let a = self.vertices[tri[0]];
+            let b = self.vertices[tri[1]];
+            let c = self.vertices[tri[2]];
+            let area = polygon_area(&[
+                Point::new(a.x, a.y),
+                Point::new(b.x, b.y),
+                Point::new(c.x, c.y),
+            ])
+            .abs();
+            let avg_z = (a.z + b.z + c.z) / 3.0;
+            volume += area * (avg_z - base_elev);
+        }
+        volume
+    }
+}
+
+fn intersect_edge(a: Point3, b: Point3, level: f64) -> Option<Point3> {
+    let da = a.z - level;
+    let db = b.z - level;
+    if da * db > 0.0 || (da - db).abs() < f64::EPSILON {
+        None
+    } else {
+        let t = da / (da - db);
+        Some(Point3::new(
+            a.x + t * (b.x - a.x),
+            a.y + t * (b.y - a.y),
+            level,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tin_volume_flat_square() {
+        let pts = vec![
+            Point3::new(0.0, 0.0, 1.0),
+            Point3::new(1.0, 0.0, 1.0),
+            Point3::new(1.0, 1.0, 1.0),
+            Point3::new(0.0, 1.0, 1.0),
+        ];
+        let tin = Tin::from_points(pts);
+        let volume = tin.volume_to_elevation(0.0);
+        assert!((volume - 1.0).abs() < 1e-6);
+    }
+}

--- a/survey_cad/src/geometry/mod.rs
+++ b/survey_cad/src/geometry/mod.rs
@@ -12,17 +12,12 @@ pub enum LineType {
 }
 
 /// Symbol used when rendering a point entity.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PointSymbol {
+    #[default]
     Circle,
     Square,
     Cross,
-}
-
-impl Default for PointSymbol {
-    fn default() -> Self {
-        PointSymbol::Circle
-    }
 }
 
 /// Representation of a point with optional name and number.

--- a/survey_cad/src/lib.rs
+++ b/survey_cad/src/lib.rs
@@ -1,12 +1,13 @@
 //! Core library for the Survey CAD application.
 
+pub mod dtm;
 pub mod geometry;
 pub mod io;
+#[cfg(feature = "pmetra")]
+pub mod pmetra;
 pub mod render;
 pub mod surveying;
 pub mod truck_integration;
-#[cfg(feature = "pmetra")]
-pub mod pmetra;
 
 /// Adds two numbers together. Example function.
 #[allow(dead_code)]

--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use bevy::prelude::*;
 use survey_cad::geometry::Point;
 


### PR DESCRIPTION
## Summary
- implement `dtm` module for triangulated irregular networks
- derive `Default` for `PointSymbol`
- expose DTM module from library
- support parsing `PointFileFormat` via `FromStr`
- update CLI to use the new parsing API
- suppress Bevy deprecation warnings
- add `delaunator` dependency for triangulation

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68423285311c8328b8a023791139f8a9