### PR TITLE
Add EPSG reprojection to I/O and CLI

### DIFF
--- a/cad_import/src/lib.rs
+++ b/cad_import/src/lib.rs
@@ -10,13 +10,21 @@ use survey_cad::{
 };
 
 /// Reads a CSV file of `x,y` pairs into [`Point`]s.
-pub fn read_points_csv(path: &str) -> io::Result<Vec<Point>> {
-    sc_read_csv(path)
+pub fn read_points_csv(
+    path: &str,
+    src_epsg: Option<u32>,
+    dst_epsg: Option<u32>,
+) -> io::Result<Vec<Point>> {
+    sc_read_csv(path, src_epsg, dst_epsg)
 }
 
 /// Reads a GeoJSON file of Point features into [`Point`]s.
-pub fn read_points_geojson(path: &str) -> io::Result<Vec<Point>> {
-    sc_read_geojson(path)
+pub fn read_points_geojson(
+    path: &str,
+    src_epsg: Option<u32>,
+    dst_epsg: Option<u32>,
+) -> io::Result<Vec<Point>> {
+    sc_read_geojson(path, src_epsg, dst_epsg)
 }
 
 /// Reads a DXF file and extracts all `POINT` entities.
@@ -255,7 +263,7 @@ mod tests {
     fn read_written_dxf_points() {
         let path = std::env::temp_dir().join("import_pts.dxf");
         let pts = vec![Point::new(1.0, 2.0), Point::new(3.0, 4.0)];
-        write_points_dxf(path.to_str().unwrap(), &pts).unwrap();
+        write_points_dxf(path.to_str().unwrap(), &pts, None, None).unwrap();
         let read = read_points_dxf(path.to_str().unwrap()).unwrap();
         assert_eq!(read, pts);
         std::fs::remove_file(path).ok();

--- a/survey_cad/src/truck_integration.rs
+++ b/survey_cad/src/truck_integration.rs
@@ -50,11 +50,11 @@ mod tests {
             }
         }
         let tmp_csv = std::env::temp_dir().join("cube_pts.csv");
-        write_points_csv(tmp_csv.to_str().unwrap(), &points).unwrap();
+        write_points_csv(tmp_csv.to_str().unwrap(), &points, None, None).unwrap();
         fs::remove_file(tmp_csv).ok();
 
         let tmp_json = std::env::temp_dir().join("cube_pts.geojson");
-        write_points_geojson(tmp_json.to_str().unwrap(), &points).unwrap();
+        write_points_geojson(tmp_json.to_str().unwrap(), &points, None, None).unwrap();
         fs::remove_file(tmp_json).ok();
     }
 }


### PR DESCRIPTION
## Summary
- allow passing EPSG codes for point I/O functions
- support EPSG options in CLI export/import commands

## Testing
- `cargo test -p survey_cad_cli --no-run` *(fails: build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6842b52588748328b4c154ebe30a93de