### PR TITLE
Add WCS options to CLI and GUI

### DIFF
--- a/survey_cad/src/io/mod.rs
+++ b/survey_cad/src/io/mod.rs
@@ -455,7 +455,7 @@ mod tests {
     }
 
     #[test]
-    fn write_dxf() {
+    fn write_points_dxf_test() {
         let path = std::env::temp_dir().join("cad_points.dxf");
         let path_str = path.to_str().unwrap();
         let pts = vec![Point::new(1.0, 1.0), Point::new(2.0, 2.0)];

--- a/survey_cad_cli/src/main.rs
+++ b/survey_cad_cli/src/main.rs
@@ -2,6 +2,7 @@ use cad_import::{read_point_file, PointFileFormat};
 use clap::{Parser, Subcommand};
 use std::str::FromStr;
 use survey_cad::{
+    crs::Crs,
     geometry::Point,
     io::{
         read_points_csv, read_points_geojson, read_to_string, write_points_csv, write_points_dxf,
@@ -22,6 +23,9 @@ fn no_render() -> bool {
 #[derive(Parser)]
 #[command(name = "survey_cad_cli", version)]
 struct Cli {
+    /// EPSG code for the working coordinate system
+    #[arg(long, default_value_t = 4326, global = true)]
+    epsg: u32,
     #[command(subcommand)]
     command: Commands,
 }
@@ -119,6 +123,8 @@ enum Commands {
 
 fn main() {
     let cli = Cli::parse();
+    let _working_crs = Crs::from_epsg(cli.epsg);
+    println!("Using EPSG {}", cli.epsg);
     match cli.command {
         Commands::StationDistance {
             name_a,

--- a/survey_cad_gui/Cargo.toml
+++ b/survey_cad_gui/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 bevy = { version = "0.15", default-features = false, features = ["bevy_winit", "bevy_sprite", "x11", "bevy_ui"] }
-bevy_input = "0.15"
 survey_cad = { path = "../survey_cad" }
+clap = { version = "4", features = ["derive"] }
 


### PR DESCRIPTION
## Summary
- add `--epsg` flag to `survey_cad_cli`
- parse `--epsg` for GUI and expose as `WorkingCrs` resource
- print working CRS at startup
- rename DXF writer test to avoid name clash

## Testing
- `cargo clippy --workspace -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6842ba2c365083288d1c1de2478ef968