### PR TITLE
Remove unused add() example

### DIFF
--- a/survey_cad/src/lib.rs
+++ b/survey_cad/src/lib.rs
@@ -11,20 +11,3 @@ pub mod pmetra;
 pub mod render;
 pub mod surveying;
 pub mod truck_integration;
-
-/// Adds two numbers together. Example function.
-#[allow(dead_code)]
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}


### PR DESCRIPTION
## Summary
- delete the sample `add` function from the core library
- remove the associated unit test

## Testing
- `cargo test -p survey_cad` *(fails: build could not complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_6842c9d2da1c8328a181ee81aebcfecb