### PR TITLE
Add CLI build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build CLI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Build survey_cad_cli
+        run: cargo build -p survey_cad_cli --release
+      - name: Upload binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: survey_cad_cli
+          path: target/release/survey_cad_cli


### PR DESCRIPTION
## Summary
- add new GitHub Actions workflow to compile the `survey_cad_cli` binary
- upload the built executable as an artifact

## Testing
- `cargo test -p survey_cad_cli` *(fails: compilation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6842d43f54d88328a8d06c6f31f307dc