### PR TITLE
Fix build workflow artifact action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build survey_cad_cli
         run: cargo build -p survey_cad_cli --release
       - name: Upload binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: survey_cad_cli
           path: target/release/survey_cad_cli


### PR DESCRIPTION
## Summary
- update deprecated `actions/upload-artifact` to v4

## Testing
- `cargo test --all` *(fails: long compile time; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6842ddf327188328a2a8d284193ada52