### PR TITLE
Add rust-cache to CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
+      - uses: Swatinem/rust-cache@v2
       - name: Build survey_cad_cli
         run: cargo build -p survey_cad_cli --release
       - name: Upload binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           profile: minimal
           override: true
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Run cargo test


### PR DESCRIPTION
## Summary
- speed up CI by caching Rust build artifacts

## Testing
- `cargo test --all` *(fails: build takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_6842ff0e08508328b6effff5d7094fc6