### PR TITLE
Improve optional rendering feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ The workspace contains two crates:
 - `survey_cad_cli` &mdash; small command line tool that demonstrates the library capabilities.
 
 Each module in the library is focused on a specific set of tasks and can be used
-independently within other Rust projects.
+independently within other Rust projects. Heavy rendering dependencies are
+optional and enabled with the `render` feature.
 
 ## CLI Tutorial
 

--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -9,9 +9,9 @@ env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 geojson = "0.24"
-bevy = { version = "0.15", default-features = false, features = ["bevy_winit", "bevy_sprite", "x11"] }
-bevy_editor_cam = "0.5"
-bevy_picking = { version = "0.15", features = ["bevy_mesh_picking_backend"] }
+bevy = { version = "0.15", default-features = false, features = ["bevy_winit", "bevy_sprite", "x11"], optional = true }
+bevy_editor_cam = { version = "0.5", optional = true }
+bevy_picking = { version = "0.15", features = ["bevy_mesh_picking_backend"], optional = true }
 bevy_pmetra = { path = "../bevy_pmetra", optional = true }
 truck-modeling = "0.6"
 truck-topology = "0.6"
@@ -22,4 +22,6 @@ roxmltree = "0.20"
 proj = "0.30"
 
 [features]
-pmetra = ["bevy/bevy_pbr", "dep:bevy_pmetra"]
+default = []
+render = ["dep:bevy", "dep:bevy_editor_cam", "dep:bevy_picking"]
+pmetra = ["render", "bevy/bevy_pbr", "dep:bevy_pmetra"]

--- a/survey_cad/src/lib.rs
+++ b/survey_cad/src/lib.rs
@@ -8,6 +8,7 @@ pub mod crs;
 pub mod io;
 #[cfg(feature = "pmetra")]
 pub mod pmetra;
+#[cfg(feature = "render")]
 pub mod render;
 pub mod surveying;
 pub mod truck_integration;

--- a/survey_cad_cli/Cargo.toml
+++ b/survey_cad_cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-survey_cad = { path = "../survey_cad" }
+survey_cad = { path = "../survey_cad", features = ["render"] }
 clap = { version = "4", features = ["derive"] }
 cad_import = { path = "../cad_import" }
 


### PR DESCRIPTION
## Summary
- make Bevy based rendering optional in `survey_cad`
- enable the feature for the CLI
- document the new `render` feature

## Testing
- `cargo check -p cad_import --quiet` *(fails: took too long and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68430a5c3ba48328a6dffd4262339550