### PR TITLE
Add corridor volume command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ Calculate a new elevation using differential leveling:
 $ cargo run -p survey_cad_cli -- level-elevation 100.0 1.2 0.8
 ```
 
+Compute cut/fill volume along an alignment:
+
+```bash
+$ cargo run -p survey_cad_cli -- corridor-volume design.csv ground.csv halign.csv valign.csv 10.0 --interval 10.0 --offset-step 1.0
+```
+
 ## Continuous Integration
 
 GitHub Actions automatically runs `cargo clippy` and `cargo test` for every push

--- a/survey_cad/tests/corridor_volume.rs
+++ b/survey_cad/tests/corridor_volume.rs
@@ -1,0 +1,43 @@
+use survey_cad::{
+    alignment::{Alignment, HorizontalAlignment, VerticalAlignment},
+    corridor::corridor_volume,
+    dtm::Tin,
+    geometry::{Point, Point3},
+};
+
+#[test]
+fn volume_zero_flat_surfaces() {
+    let design = Tin::from_points(vec![
+        Point3::new(0.0, -1.0, 0.0),
+        Point3::new(0.0, 1.0, 0.0),
+        Point3::new(10.0, -1.0, 0.0),
+        Point3::new(10.0, 1.0, 0.0),
+    ]);
+    let ground = design.clone();
+    let hal = HorizontalAlignment::new(vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+    let val = VerticalAlignment::new(vec![(0.0, 0.0), (10.0, 0.0)]);
+    let align = Alignment::new(hal, val);
+    let vol = corridor_volume(&design, &ground, &align, 1.0, 10.0, 1.0);
+    assert!(vol.abs() < 1e-6);
+}
+
+#[test]
+fn volume_simple_prism() {
+    let design = Tin::from_points(vec![
+        Point3::new(0.0, -1.0, 1.0),
+        Point3::new(0.0, 1.0, 1.0),
+        Point3::new(10.0, -1.0, 1.0),
+        Point3::new(10.0, 1.0, 1.0),
+    ]);
+    let ground = Tin::from_points(vec![
+        Point3::new(0.0, -1.0, 0.0),
+        Point3::new(0.0, 1.0, 0.0),
+        Point3::new(10.0, -1.0, 0.0),
+        Point3::new(10.0, 1.0, 0.0),
+    ]);
+    let hal = HorizontalAlignment::new(vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+    let val = VerticalAlignment::new(vec![(0.0, 0.0), (10.0, 0.0)]);
+    let align = Alignment::new(hal, val);
+    let vol = corridor_volume(&design, &ground, &align, 1.0, 10.0, 1.0);
+    assert!((vol - 20.0).abs() < 1e-6);
+}


### PR DESCRIPTION
## Summary
- compute corridor volume between design and ground surfaces
- expose `corridor-volume` subcommand
- document new command in README
- add tests for corridor volume calculations

## Testing
- `cargo test -p survey_cad corridor_volume -- --test-threads=1` *(fails: could not complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68431618c0288328bb1c9ca2034a3dde