### PR TITLE
Add LandXML corridor data support

### DIFF
--- a/survey_cad/src/io/mod.rs
+++ b/survey_cad/src/io/mod.rs
@@ -420,13 +420,12 @@ pub fn read_dxf(path: &str) -> io::Result<Vec<DxfEntity>> {
 mod tests {
     use super::*;
     use crate::alignment::{
-        HorizontalAlignment,
-        HorizontalElement,
-        VerticalAlignment,
-        VerticalElement,
+        HorizontalAlignment, HorizontalElement, VerticalAlignment, VerticalElement,
     };
+    use crate::corridor::CrossSection;
     use crate::dtm::Tin;
     use crate::geometry::Point3;
+    use crate::superelevation::SuperelevationPoint;
 
     #[test]
     fn write_and_read_string() {
@@ -598,6 +597,46 @@ mod tests {
         landxml::write_landxml_profile(path.to_str().unwrap(), &valign).unwrap();
         let read = landxml::read_landxml_profile(path.to_str().unwrap()).unwrap();
         assert_eq!(read.elements.len(), 2);
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn write_and_read_landxml_cross_sections() {
+        let path = std::env::temp_dir().join("cross.xml");
+        let secs = vec![
+            CrossSection::new(
+                0.0,
+                vec![Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 0.0, 0.0)],
+            ),
+            CrossSection::new(
+                10.0,
+                vec![Point3::new(0.0, 1.0, 0.0), Point3::new(1.0, 1.0, 0.0)],
+            ),
+        ];
+        landxml::write_landxml_cross_sections(path.to_str().unwrap(), &secs).unwrap();
+        let read = landxml::read_landxml_cross_sections(path.to_str().unwrap()).unwrap();
+        assert_eq!(read.len(), 2);
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn write_and_read_landxml_superelevation() {
+        let path = std::env::temp_dir().join("sup.xml");
+        let table = vec![
+            SuperelevationPoint {
+                station: 0.0,
+                left_slope: 0.02,
+                right_slope: -0.02,
+            },
+            SuperelevationPoint {
+                station: 10.0,
+                left_slope: 0.03,
+                right_slope: -0.03,
+            },
+        ];
+        landxml::write_landxml_superelevation(path.to_str().unwrap(), &table).unwrap();
+        let read = landxml::read_landxml_superelevation(path.to_str().unwrap()).unwrap();
+        assert_eq!(read.len(), 2);
         std::fs::remove_file(path).ok();
     }
 }

--- a/survey_cad/src/lib.rs
+++ b/survey_cad/src/lib.rs
@@ -1,14 +1,15 @@
 //! Core library for the Survey CAD application.
 
-pub mod dtm;
-pub mod geometry;
 pub mod alignment;
 pub mod corridor;
 pub mod crs;
+pub mod dtm;
+pub mod geometry;
 pub mod io;
 #[cfg(feature = "pmetra")]
 pub mod pmetra;
 #[cfg(feature = "render")]
 pub mod render;
+pub mod superelevation;
 pub mod surveying;
 pub mod truck_integration;

--- a/survey_cad/src/superelevation.rs
+++ b/survey_cad/src/superelevation.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SuperelevationPoint {
+    pub station: f64,
+    pub left_slope: f64,
+    pub right_slope: f64,
+}
+
+pub type SuperelevationTable = Vec<SuperelevationPoint>;


### PR DESCRIPTION
## Summary
- support new superelevation module
- extend LandXML parser with cross section and superelevation handling
- expose new module and add tests

## Testing
- `cargo test --all --no-run` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68431cfd035883289956940d99f3203b