### PR TITLE
Add shapefile and LAS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ advanced primitives like arcs, polylines and polygonal surfaces. Surveying
 utilities cover traverse area calculations as well as vertical angle and
 differential leveling helpers.
 
+Supported file formats include CSV, GeoJSON, simple DXF and LandXML. Optional
+features provide shapefile and LAS point cloud readers to ease interoperability
+with other CAD and GIS tools.
+Bridging directly to DWG files remains future work and would further broaden
+compatibility with proprietary CAD ecosystems.
+
 ## Architecture Overview
 
 The workspace contains two crates:

--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -20,8 +20,12 @@ delaunator = "1"
 cdt = "0.1"
 roxmltree = "0.20"
 proj = "0.30"
+shapefile = { version = "0.7", optional = true }
+las = { version = "0.9", optional = true }
 
 [features]
 default = []
 render = ["dep:bevy", "dep:bevy_editor_cam", "dep:bevy_picking"]
 pmetra = ["render", "bevy/bevy_pbr", "dep:bevy_pmetra"]
+shapefile = ["dep:shapefile"]
+las = ["dep:las"]

--- a/survey_cad/src/io/las.rs
+++ b/survey_cad/src/io/las.rs
@@ -1,0 +1,15 @@
+use crate::geometry::Point3;
+use las::{point::Point as LasPoint, Reader, Write as _};
+use std::io;
+
+/// Reads a LAS file and returns the contained points.
+pub fn read_points_las(path: &str) -> io::Result<Vec<Point3>> {
+    let mut reader =
+        Reader::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let mut pts = Vec::new();
+    for wrapped in reader.points() {
+        let p: LasPoint = wrapped.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        pts.push(Point3::new(p.x, p.y, p.z));
+    }
+    Ok(pts)
+}

--- a/survey_cad/src/io/mod.rs
+++ b/survey_cad/src/io/mod.rs
@@ -8,6 +8,10 @@ use crate::crs::Crs;
 use crate::geometry::{Arc, Point, Polyline};
 
 pub mod landxml;
+#[cfg(feature = "las")]
+pub mod las;
+#[cfg(feature = "shapefile")]
+pub mod shp;
 
 /// Reads a file to string.
 pub fn read_to_string(path: &str) -> io::Result<String> {

--- a/survey_cad/src/io/shp.rs
+++ b/survey_cad/src/io/shp.rs
@@ -1,0 +1,32 @@
+use super::read_points_csv;
+use crate::geometry::Point;
+use shapefile::{Point as ShpPoint, Shape, ShapeReader, ShapeWriter};
+use std::io::{self, Write};
+
+/// Reads a shapefile containing Point geometries and returns them as [`Point`] values.
+pub fn read_points_shp(path: &str) -> io::Result<Vec<Point>> {
+    let mut reader =
+        ShapeReader::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let mut pts = Vec::new();
+    for record in reader.iter_shapes() {
+        match record.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))? {
+            Shape::Point(p) => pts.push(Point::new(p.x, p.y)),
+            _ => {}
+        }
+    }
+    Ok(pts)
+}
+
+/// Writes a list of [`Point`]s to a shapefile.
+pub fn write_points_shp(path: &str, points: &[Point]) -> io::Result<()> {
+    let mut writer =
+        ShapeWriter::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    for p in points {
+        writer
+            .write_shape(Shape::Point(ShpPoint { x: p.x, y: p.y }))
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    }
+    writer
+        .close()
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+}


### PR DESCRIPTION
## Summary
- enable optional `shapefile` and `las` crates
- support shapefile and LAS point cloud formats
- document optional format support and future DWG bridging

## Testing
- `cargo fmt` *(fails: command requires network)*
- `cargo clippy` *(fails: command requires network)*
- `cargo test` *(fails: command requires network)*

------
https://chatgpt.com/codex/tasks/task_e_68432c7b0f2c8328ab03cc32c5e1af27