### PR TITLE
Improve CLI build flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Each module in the library is focused on a specific set of tasks and can be used
 independently within other Rust projects. Heavy rendering dependencies are
 optional and enabled with the `render` feature.
 
+The command line tool depends on these rendering crates by default. To build a
+lightweight binary without them, disable default features:
+
+```bash
+$ cargo run -p survey_cad_cli --no-default-features -- <command>
+```
+Enable rendering explicitly with `--features render` when needed.
+
 ## CLI Tutorial
 
 Build the workspace and view available commands:

--- a/survey_cad_cli/Cargo.toml
+++ b/survey_cad_cli/Cargo.toml
@@ -3,10 +3,15 @@ name = "survey_cad_cli"
 version = "0.1.0"
 edition = "2021"
 
+
 [dependencies]
-survey_cad = { path = "../survey_cad", features = ["render"] }
+survey_cad = { path = "../survey_cad", default-features = false }
 clap = { version = "4", features = ["derive"] }
 cad_import = { path = "../cad_import" }
+
+[features]
+default = ["render"]
+render = ["survey_cad/render"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/survey_cad_cli/src/main.rs
+++ b/survey_cad_cli/src/main.rs
@@ -11,6 +11,7 @@ use survey_cad::{
         landxml::read_landxml_surface, read_lines, read_points_csv, read_points_geojson,
         read_to_string, write_points_csv, write_points_dxf, write_points_geojson, write_string,
     },
+    #[cfg(feature = "render")]
     render::{render_point, render_points},
     surveying::{
         bearing, forward, level_elevation, line_intersection, station_distance, vertical_angle,
@@ -81,6 +82,7 @@ enum Commands {
     /// Copy a text file from src to dest.
     Copy { src: String, dest: String },
     /// Render a point (prints to stdout).
+    #[cfg(feature = "render")]
     RenderPoint { x: f64, y: f64 },
     /// Export points from a CSV file to GeoJSON.
     ExportGeojson {
@@ -116,6 +118,7 @@ enum Commands {
         dst_epsg: Option<u32>,
     },
     /// View points from a CSV file.
+    #[cfg(feature = "render")]
     ViewPoints { input: String },
     /// Compute the vertical angle between two stations given their elevations.
     VerticalAngle {
@@ -205,6 +208,7 @@ fn main() {
             },
             Err(e) => eprintln!("Error reading {}: {}", src, e),
         },
+        #[cfg(feature = "render")]
         Commands::RenderPoint { x, y } => {
             let p = Point::new(x, y);
             if no_render() {
@@ -285,6 +289,7 @@ fn main() {
             },
             Err(e) => eprintln!("Error reading {}: {}", input, e),
         },
+        #[cfg(feature = "render")]
         Commands::ViewPoints { input } => match read_points_csv(&input, None, None) {
             Ok(pts) => {
                 if no_render() {


### PR DESCRIPTION
## Summary
- make Bevy rendering optional for `survey_cad_cli`
- document how to disable default features when building the CLI

## Testing
- `cargo test --workspace --locked` *(failed: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68434cb1bd7883289ffa97466d6821a6