### PR TITLE
Add external DWG conversion hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4018,6 +4018,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shapefile",
+ "tempfile",
  "truck-geometry",
  "truck-modeling",
  "truck-topology",

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ differential leveling helpers.
 
 Supported file formats include CSV, GeoJSON, simple DXF and LandXML. Optional
 features provide shapefile and LAS point cloud readers to ease interoperability
-with other CAD and GIS tools.
-Bridging directly to DWG files remains future work and would further broaden
-compatibility with proprietary CAD ecosystems.
+with other CAD and GIS tools. Basic DWG interoperability is available through
+the `dwg2dxf` and `dxf2dwg` command line tools from the LibreDWG project. The
+library converts DWG files to DXF and back using these utilities when present,
+returning an error if they are missing.
 
 ## Architecture Overview
 

--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -23,6 +23,7 @@ proj = "0.30"
 shapefile = { version = "0.7", optional = true }
 las = { version = "0.9", optional = true }
 nalgebra = { version = "0.32", default-features = false, features = ["std"] }
+tempfile = "3.10"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- document minimal DWG interoperability using LibreDWG tools
- add `tempfile` dependency
- add `read_dwg` and `write_dwg` helpers
- tweak CLI import to avoid formatting issues

## Testing
- `cargo fmt`
- `cargo test -p survey_cad --no-default-features --no-run` *(fails: build cancelled due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684354493b0083288cb9e142af2ae902