### PR TITLE
Expose shapefile and LAS in CLI

### DIFF
--- a/survey_cad_cli/Cargo.toml
+++ b/survey_cad_cli/Cargo.toml
@@ -12,6 +12,8 @@ cad_import = { path = "../cad_import" }
 [features]
 default = ["render"]
 render = ["survey_cad/render"]
+shapefile = ["survey_cad/shapefile"]
+las = ["survey_cad/las"]
 
 [dev-dependencies]
 assert_cmd = "2"


### PR DESCRIPTION
## Summary
- add optional `shapefile` and `las` features to the CLI
- support importing/exporting shapefiles and importing LAS files

## Testing
- `cargo test -p survey_cad_cli --no-default-features` *(fails: unrecognized subcommand `view-points`)*

------
https://chatgpt.com/codex/tasks/task_e_6843614998e08328afe76de565d3de8b