### PR TITLE
Add intersection module and CLI command

### DIFF
--- a/survey_cad/src/intersection.rs
+++ b/survey_cad/src/intersection.rs
@@ -1,0 +1,129 @@
+use crate::alignment::{HorizontalAlignment, HorizontalElement, VerticalAlignment};
+use crate::geometry::{Arc, Line, Point};
+use crate::surveying::line_intersection;
+
+/// Description of a curb return connecting two approach tangents.
+#[derive(Debug, Clone)]
+pub struct CurbReturn {
+    pub start: Point,
+    pub end: Point,
+    pub arc: Arc,
+}
+
+fn unit(v: (f64, f64)) -> (f64, f64) {
+    let len = (v.0 * v.0 + v.1 * v.1).sqrt();
+    if len.abs() < f64::EPSILON {
+        (0.0, 0.0)
+    } else {
+        (v.0 / len, v.1 / len)
+    }
+}
+
+fn rotate90(v: (f64, f64), sign: f64) -> (f64, f64) {
+    if sign >= 0.0 {
+        (-v.1, v.0)
+    } else {
+        (v.1, -v.0)
+    }
+}
+
+/// Builds a curb return arc between two lines.
+pub fn build_curb_return_arc(line_in: &Line, line_out: &Line, radius: f64) -> Option<CurbReturn> {
+    let pi = line_intersection(line_in.start, line_in.end, line_out.start, line_out.end)?;
+    let t1 = unit((
+        line_in.end.x - line_in.start.x,
+        line_in.end.y - line_in.start.y,
+    ));
+    let t2 = unit((
+        line_out.end.x - line_out.start.x,
+        line_out.end.y - line_out.start.y,
+    ));
+
+    let ang1 = t1.1.atan2(t1.0);
+    let ang2 = t2.1.atan2(t2.0);
+    let mut phi = ang2 - ang1;
+    while phi <= -std::f64::consts::PI {
+        phi += 2.0 * std::f64::consts::PI;
+    }
+    while phi > std::f64::consts::PI {
+        phi -= 2.0 * std::f64::consts::PI;
+    }
+    let phi = phi.abs();
+    if phi.abs() < f64::EPSILON || phi >= std::f64::consts::PI {
+        return None;
+    }
+    let tangent = radius * (phi / 2.0).tan();
+
+    let pc = Point::new(pi.x - t1.0 * tangent, pi.y - t1.1 * tangent);
+    let pt = Point::new(pi.x + t2.0 * tangent, pi.y + t2.1 * tangent);
+
+    let sign = (t1.0 * t2.1 - t1.1 * t2.0).signum();
+    let n1 = unit(rotate90(t1, sign));
+    let n2 = unit(rotate90(t2, sign));
+
+    let center = line_intersection(
+        pc,
+        Point::new(pc.x + n1.0 * radius * 2.0, pc.y + n1.1 * radius * 2.0),
+        pt,
+        Point::new(pt.x + n2.0 * radius * 2.0, pt.y + n2.1 * radius * 2.0),
+    )?;
+
+    let start_angle = (pc.y - center.y).atan2(pc.x - center.x);
+    let end_angle = (pt.y - center.y).atan2(pt.x - center.x);
+    let arc = if sign >= 0.0 {
+        Arc::new(center, radius, start_angle, end_angle)
+    } else {
+        Arc::new(center, radius, end_angle, start_angle)
+    };
+
+    Some(CurbReturn {
+        start: pc,
+        end: pt,
+        arc,
+    })
+}
+
+/// Creates a curb return between two alignments using their last and first tangent segments.
+pub fn curb_return_between_alignments(
+    a: &HorizontalAlignment,
+    b: &HorizontalAlignment,
+    radius: f64,
+) -> Option<CurbReturn> {
+    let line_a = match a.elements.last()? {
+        HorizontalElement::Tangent { start, end } => Line::new(*start, *end),
+        _ => return None,
+    };
+    let line_b = match b.elements.first()? {
+        HorizontalElement::Tangent { start, end } => Line::new(*start, *end),
+        _ => return None,
+    };
+    build_curb_return_arc(&line_a, &line_b, radius)
+}
+
+/// Applies a constant grade adjustment after the given station.
+pub fn apply_grade_adjustment(alignment: &mut VerticalAlignment, station: f64, delta: f64) {
+    for elem in &mut alignment.elements {
+        match elem {
+            crate::alignment::VerticalElement::Grade {
+                start_station,
+                start_elev,
+                end_elev,
+                ..
+            } => {
+                if *start_station >= station {
+                    *start_elev += delta;
+                    *end_elev += delta;
+                }
+            }
+            crate::alignment::VerticalElement::Parabola {
+                start_station,
+                start_elev,
+                ..
+            } => {
+                if *start_station >= station {
+                    *start_elev += delta;
+                }
+            }
+        }
+    }
+}

--- a/survey_cad/src/lib.rs
+++ b/survey_cad/src/lib.rs
@@ -5,12 +5,13 @@ pub mod corridor;
 pub mod crs;
 pub mod dtm;
 pub mod geometry;
+pub mod intersection;
 pub mod io;
 #[cfg(feature = "pmetra")]
 pub mod pmetra;
 #[cfg(feature = "render")]
 pub mod render;
 pub mod superelevation;
-pub mod variable_offset;
 pub mod surveying;
 pub mod truck_integration;
+pub mod variable_offset;

--- a/survey_cad/tests/intersection.rs
+++ b/survey_cad/tests/intersection.rs
@@ -1,0 +1,25 @@
+use survey_cad::{
+    alignment::HorizontalAlignment, geometry::Point, intersection::curb_return_between_alignments,
+};
+
+#[test]
+fn curb_return_t_intersection() {
+    let a = HorizontalAlignment::new(vec![Point::new(-10.0, 0.0), Point::new(0.0, 0.0)]);
+    let b = HorizontalAlignment::new(vec![Point::new(0.0, -10.0), Point::new(0.0, 0.0)]);
+    let res = curb_return_between_alignments(&a, &b, 5.0).unwrap();
+    assert!((res.start.x + 5.0).abs() < 1e-6);
+    assert!((res.end.y - 5.0).abs() < 1e-6);
+    assert!((res.arc.center.x + 5.0).abs() < 1e-6);
+    assert!((res.arc.center.y - 5.0).abs() < 1e-6);
+}
+
+#[test]
+fn curb_return_cross_intersection() {
+    let a = HorizontalAlignment::new(vec![Point::new(-10.0, 0.0), Point::new(0.0, 0.0)]);
+    let b = HorizontalAlignment::new(vec![Point::new(0.0, 10.0), Point::new(0.0, 0.0)]);
+    let res = curb_return_between_alignments(&a, &b, 3.0).unwrap();
+    assert!((res.start.x + 3.0).abs() < 1e-6);
+    assert!((res.end.y + 3.0).abs() < 1e-6);
+    assert!((res.arc.center.x + 3.0).abs() < 1e-6);
+    assert!((res.arc.center.y + 3.0).abs() < 1e-6);
+}

--- a/survey_cad_cli/tests/cli.rs
+++ b/survey_cad_cli/tests/cli.rs
@@ -232,3 +232,24 @@ fn intersection_command() {
         .success()
         .stdout(predicate::str::contains("Intersection:"));
 }
+
+#[test]
+fn create_intersection_command() {
+    let dir = assert_fs::TempDir::new().unwrap();
+    let a = dir.child("a.csv");
+    a.write_str("-10.0,0.0\n0.0,0.0\n").unwrap();
+    let b = dir.child("b.csv");
+    b.write_str("0.0,-10.0\n0.0,0.0\n").unwrap();
+    Command::cargo_bin("survey_cad_cli")
+        .unwrap()
+        .args([
+            "create-intersection",
+            a.path().to_str().unwrap(),
+            b.path().to_str().unwrap(),
+            "5.0",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("center:"));
+    dir.close().unwrap();
+}


### PR DESCRIPTION
## Summary
- implement `intersection` module for curb return arcs
- expose module in crate root
- add CLI command `create-intersection`
- test curb return computations and CLI command

## Testing
- `cargo test -p survey_cad --no-default-features` *(failed: compilation took too long)*

------
https://chatgpt.com/codex/tasks/task_e_68436ccedd50832896c457e6b2b71fe4