### PR TITLE
Add LandXML parsing for pipe networks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,6 +3309,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pipe_network"
+version = "0.1.0"
+dependencies = [
+ "roxmltree",
+ "serde",
+ "tempfile",
+]
+
+[[package]]
 name = "piper"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/pipe_network/Cargo.toml
+++ b/pipe_network/Cargo.toml
@@ -5,3 +5,7 @@ version.workspace = true
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+roxmltree = "0.20"
+
+[dev-dependencies]
+tempfile = "3.10"


### PR DESCRIPTION
## Summary
- add `read_network_landxml` with roxmltree
- write tests that round-trip a network to LandXML
- depend on roxmltree for parsing and tempfile for tests

## Testing
- `~/.cargo/bin/cargo test -p pipe_network --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684379f9e4b883289c7ec33b4f489cd9