### PR TITLE
Add vertical curve helpers

### DIFF
--- a/survey_cad/tests/intersection.rs
+++ b/survey_cad/tests/intersection.rs
@@ -1,5 +1,10 @@
 use survey_cad::{
-    alignment::HorizontalAlignment, geometry::Point, intersection::curb_return_between_alignments,
+    alignment::{HorizontalAlignment, VerticalAlignment},
+    geometry::Point,
+    intersection::{
+        curb_return_between_alignments, crest_curve_between_alignments,
+        sag_curve_between_alignments,
+    },
 };
 
 #[test]
@@ -22,4 +27,26 @@ fn curb_return_cross_intersection() {
     assert!((res.end.y + 3.0).abs() < 1e-6);
     assert!((res.arc.center.x + 3.0).abs() < 1e-6);
     assert!((res.arc.center.y + 3.0).abs() < 1e-6);
+}
+
+#[test]
+fn crest_curve_geometry() {
+    let a = VerticalAlignment::new(vec![(0.0, 0.0), (50.0, 1.0)]);
+    let b = VerticalAlignment::new(vec![(50.0, 1.0), (100.0, 0.0)]);
+    let res = crest_curve_between_alignments(&a, &b, 50.0, 0.02, -0.02).unwrap();
+    assert!((res.length - 100.0).abs() < 1e-6);
+    assert!((res.high_low_station - 50.0).abs() < 1e-6);
+    assert!((res.high_low_elev - 1.0).abs() < 1e-6);
+    assert!(res.grade_adjustment.abs() < 1e-6);
+}
+
+#[test]
+fn sag_curve_geometry() {
+    let a = VerticalAlignment::new(vec![(0.0, 0.0), (50.0, -1.0)]);
+    let b = VerticalAlignment::new(vec![(50.0, -1.0), (100.0, 0.0)]);
+    let res = sag_curve_between_alignments(&a, &b, 50.0, -0.02, 0.02).unwrap();
+    assert!((res.length - 100.0).abs() < 1e-6);
+    assert!((res.high_low_station - 50.0).abs() < 1e-6);
+    assert!((res.high_low_elev + 1.0).abs() < 1e-6);
+    assert!(res.grade_adjustment.abs() < 1e-6);
 }


### PR DESCRIPTION
## Summary
- create `VerticalCurveInfo` for return data
- implement functions to build crest/sag parabolic curves between vertical alignments
- test vertical curve geometry

## Testing
- `cargo test --quiet` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6843832718c08328b0e249868968a433