### PR TITLE
Add 3D shapefile support

### DIFF
--- a/survey_cad/src/io/shp.rs
+++ b/survey_cad/src/io/shp.rs
@@ -1,117 +1,230 @@
-use crate::geometry::Point;
+use crate::geometry::{Point, Point3};
 use shapefile::{
-    Point as ShpPoint, Polygon as ShpPolygon, PolygonRing, Polyline as ShpPolyline, Shape,
-    ShapeReader, ShapeWriter,
+    Point as ShpPoint, PointZ as ShpPointZ, Polygon as ShpPolygon, PolygonRing, PolygonZ,
+    Polyline as ShpPolyline, PolylineZ, Shape, ShapeReader, ShapeWriter, NO_DATA,
 };
 use std::io;
 
 /// Reads a shapefile containing Point geometries and returns them as [`Point`] values.
-pub fn read_points_shp(path: &str) -> io::Result<Vec<Point>> {
+pub fn read_points_shp(path: &str) -> io::Result<(Vec<Point>, Option<Vec<Point3>>)> {
     let mut reader =
         ShapeReader::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     let mut pts = Vec::new();
+    let mut pts3: Option<Vec<Point3>> = None;
     for record in reader.iter_shapes() {
         match record.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))? {
-            Shape::Point(p) => pts.push(Point::new(p.x, p.y)),
+            Shape::Point(p) => {
+                pts.push(Point::new(p.x, p.y));
+                if let Some(ref mut list) = pts3 {
+                    list.push(Point3::new(p.x, p.y, 0.0));
+                }
+            }
+            Shape::PointZ(p) => {
+                pts.push(Point::new(p.x, p.y));
+                match pts3 {
+                    Some(ref mut list) => list.push(Point3::new(p.x, p.y, p.z)),
+                    None => {
+                        pts3 = Some(vec![Point3::new(p.x, p.y, p.z)]);
+                    }
+                }
+            }
             _ => {}
         }
     }
-    Ok(pts)
+    Ok((pts, pts3))
 }
 
 /// Writes a list of [`Point`]s to a shapefile.
-pub fn write_points_shp(path: &str, points: &[Point]) -> io::Result<()> {
+pub fn write_points_shp(path: &str, points: &[Point], points_z: Option<&[Point3]>) -> io::Result<()> {
     let mut writer =
         ShapeWriter::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-    for p in points {
-        let shp = ShpPoint { x: p.x, y: p.y };
-        writer
-            .write_shape(&shp)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    if let Some(zpts) = points_z {
+        for p in zpts {
+            let shp = ShpPointZ::new(p.x, p.y, p.z, NO_DATA);
+            writer
+                .write_shape(&shp)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        }
+    } else {
+        for p in points {
+            let shp = ShpPoint { x: p.x, y: p.y };
+            writer
+                .write_shape(&shp)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        }
     }
     writer.finalize().map_err(|e| io::Error::new(io::ErrorKind::Other, e))
 }
 
 /// Reads a shapefile containing PolyLine geometries and returns them as [`Polyline`] values.
-pub fn read_polylines_shp(path: &str) -> io::Result<Vec<crate::geometry::Polyline>> {
+pub fn read_polylines_shp(
+    path: &str,
+) -> io::Result<(Vec<crate::geometry::Polyline>, Option<Vec<Vec<Point3>>>)> {
     let mut reader =
         ShapeReader::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     let mut lines = Vec::new();
+    let mut lines3: Option<Vec<Vec<Point3>>> = None;
     for record in reader.iter_shapes() {
         match record.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))? {
             Shape::Polyline(pl) => {
                 for part in pl.parts() {
-                    let verts = part
-                        .iter()
-                        .map(|p| Point::new(p.x, p.y))
-                        .collect();
+                    let verts: Vec<Point> = part.iter().map(|p| Point::new(p.x, p.y)).collect();
+                    if let Some(ref mut v3) = lines3 {
+                        v3.push(part.iter().map(|p| Point3::new(p.x, p.y, 0.0)).collect());
+                    }
+                    lines.push(crate::geometry::Polyline::new(verts));
+                }
+            }
+            Shape::PolylineZ(pl) => {
+                for part in pl.parts() {
+                    let verts: Vec<Point> = part.iter().map(|p| Point::new(p.x, p.y)).collect();
+                    match lines3 {
+                        Some(ref mut v3) => v3.push(part.iter().map(|p| Point3::new(p.x, p.y, p.z)).collect()),
+                        None => {
+                            lines3 = Some(vec![part.iter().map(|p| Point3::new(p.x, p.y, p.z)).collect()]);
+                        }
+                    }
                     lines.push(crate::geometry::Polyline::new(verts));
                 }
             }
             _ => {}
         }
     }
-    Ok(lines)
+    Ok((lines, lines3))
 }
 
 /// Writes a list of [`Polyline`]s to a shapefile.
-pub fn write_polylines_shp(path: &str, polylines: &[crate::geometry::Polyline]) -> io::Result<()> {
+pub fn write_polylines_shp(
+    path: &str,
+    polylines: &[crate::geometry::Polyline],
+    polylines_z: Option<&[Vec<Point3>]>,
+) -> io::Result<()> {
     let mut writer =
         ShapeWriter::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-    for pl in polylines {
-        if pl.vertices.len() < 2 {
-            continue;
+    if let Some(pl3s) = polylines_z {
+        for pl in pl3s {
+            if pl.len() < 2 {
+                continue;
+            }
+            let shp_pts: Vec<ShpPointZ> = pl
+                .iter()
+                .map(|p| ShpPointZ::new(p.x, p.y, p.z, NO_DATA))
+                .collect();
+            let shp_pl = PolylineZ::new(shp_pts);
+            writer
+                .write_shape(&shp_pl)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         }
-        let shp_pts: Vec<ShpPoint> = pl
-            .vertices
-            .iter()
-            .map(|p| ShpPoint { x: p.x, y: p.y })
-            .collect();
-        let shp_pl = ShpPolyline::new(shp_pts);
-        writer
-            .write_shape(&shp_pl)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    } else {
+        for pl in polylines {
+            if pl.vertices.len() < 2 {
+                continue;
+            }
+            let shp_pts: Vec<ShpPoint> = pl
+                .vertices
+                .iter()
+                .map(|p| ShpPoint { x: p.x, y: p.y })
+                .collect();
+            let shp_pl = ShpPolyline::new(shp_pts);
+            writer
+                .write_shape(&shp_pl)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        }
     }
     writer.finalize().map_err(|e| io::Error::new(io::ErrorKind::Other, e))
 }
 
 /// Reads a shapefile containing Polygon geometries and returns them as vectors of [`Point`].
-pub fn read_polygons_shp(path: &str) -> io::Result<Vec<Vec<Point>>> {
+pub fn read_polygons_shp(path: &str) -> io::Result<(Vec<Vec<Point>>, Option<Vec<Vec<Point3>>>)> {
     let mut reader =
         ShapeReader::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     let mut polys = Vec::new();
+    let mut polys3: Option<Vec<Vec<Point3>>> = None;
     for record in reader.iter_shapes() {
         match record.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))? {
             Shape::Polygon(pg) => {
                 for ring in pg.rings() {
-                    let verts = ring
+                    let verts: Vec<Point> = ring
                         .points()
                         .iter()
                         .map(|p| Point::new(p.x, p.y))
                         .collect();
+                    if let Some(ref mut v3) = polys3 {
+                        v3.push(
+                            ring.points()
+                                .iter()
+                                .map(|p| Point3::new(p.x, p.y, 0.0))
+                                .collect(),
+                        );
+                    }
+                    polys.push(verts);
+                }
+            }
+            Shape::PolygonZ(pg) => {
+                for ring in pg.rings() {
+                    let verts: Vec<Point> = ring
+                        .points()
+                        .iter()
+                        .map(|p| Point::new(p.x, p.y))
+                        .collect();
+                    match polys3 {
+                        Some(ref mut v3) => v3.push(
+                            ring.points()
+                                .iter()
+                                .map(|p| Point3::new(p.x, p.y, p.z))
+                                .collect(),
+                        ),
+                        None => {
+                            polys3 = Some(vec![
+                                ring.points()
+                                    .iter()
+                                    .map(|p| Point3::new(p.x, p.y, p.z))
+                                    .collect(),
+                            ]);
+                        }
+                    }
                     polys.push(verts);
                 }
             }
             _ => {}
         }
     }
-    Ok(polys)
+    Ok((polys, polys3))
 }
 
 /// Writes a list of polygons to a shapefile.
-pub fn write_polygons_shp(path: &str, polygons: &[Vec<Point>]) -> io::Result<()> {
+pub fn write_polygons_shp(
+    path: &str,
+    polygons: &[Vec<Point>],
+    polygons_z: Option<&[Vec<Point3>]>,
+) -> io::Result<()> {
     let mut writer =
         ShapeWriter::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-    for poly in polygons {
-        if poly.len() < 3 {
-            continue;
+    if let Some(polys3) = polygons_z {
+        for poly in polys3 {
+            if poly.len() < 3 {
+                continue;
+            }
+            let shp_pts: Vec<ShpPointZ> =
+                poly.iter().map(|p| ShpPointZ::new(p.x, p.y, p.z, NO_DATA)).collect();
+            let ring = PolygonRing::Outer(shp_pts);
+            let shp_poly = PolygonZ::new(ring);
+            writer
+                .write_shape(&shp_poly)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         }
-        let shp_pts: Vec<ShpPoint> = poly.iter().map(|p| ShpPoint { x: p.x, y: p.y }).collect();
-        let ring = PolygonRing::Outer(shp_pts);
-        let shp_poly = ShpPolygon::new(ring);
-        writer
-            .write_shape(&shp_poly)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    } else {
+        for poly in polygons {
+            if poly.len() < 3 {
+                continue;
+            }
+            let shp_pts: Vec<ShpPoint> = poly.iter().map(|p| ShpPoint { x: p.x, y: p.y }).collect();
+            let ring = PolygonRing::Outer(shp_pts);
+            let shp_poly = ShpPolygon::new(ring);
+            writer
+                .write_shape(&shp_poly)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        }
     }
     writer.finalize().map_err(|e| io::Error::new(io::ErrorKind::Other, e))
 }

--- a/survey_cad/tests/shp_z.rs
+++ b/survey_cad/tests/shp_z.rs
@@ -1,0 +1,45 @@
+#[cfg(feature = "shapefile")]
+use survey_cad::io::shp::{read_points_shp, write_points_shp, read_polylines_shp, write_polylines_shp, read_polygons_shp, write_polygons_shp};
+#[cfg(feature = "shapefile")]
+use survey_cad::geometry::{Point, Point3, Polyline};
+
+#[cfg(feature = "shapefile")]
+#[test]
+fn points_z_roundtrip() {
+    use tempfile::NamedTempFile;
+    let pts3 = vec![Point3::new(1.0,2.0,3.0), Point3::new(4.0,5.0,6.0)];
+    let pts2: Vec<Point> = pts3.iter().map(|p| Point::new(p.x,p.y)).collect();
+    let file = NamedTempFile::new().unwrap();
+    write_points_shp(file.path().to_str().unwrap(), &pts2, Some(&pts3)).unwrap();
+    let (_pts, pts_read) = read_points_shp(file.path().to_str().unwrap()).unwrap();
+    assert_eq!(pts_read.unwrap(), pts3);
+}
+
+#[cfg(feature = "shapefile")]
+#[test]
+fn polylines_z_roundtrip() {
+    use tempfile::NamedTempFile;
+    let line3 = vec![Point3::new(0.0,0.0,0.0), Point3::new(1.0,0.0,1.0)];
+    let line2: Vec<Point> = line3.iter().map(|p| Point::new(p.x,p.y)).collect();
+    let file = NamedTempFile::new().unwrap();
+    write_polylines_shp(file.path().to_str().unwrap(), &[Polyline::new(line2.clone())], Some(&[line3.clone()])).unwrap();
+    let (_lines, lines3) = read_polylines_shp(file.path().to_str().unwrap()).unwrap();
+    assert_eq!(lines3.unwrap()[0], line3);
+}
+
+#[cfg(feature = "shapefile")]
+#[test]
+fn polygons_z_roundtrip() {
+    use tempfile::NamedTempFile;
+    let poly3 = vec![
+        Point3::new(0.0,0.0,0.0),
+        Point3::new(1.0,0.0,0.0),
+        Point3::new(1.0,1.0,0.0),
+        Point3::new(0.0,0.0,0.0),
+    ];
+    let poly2: Vec<Point> = poly3.iter().map(|p| Point::new(p.x,p.y)).collect();
+    let file = NamedTempFile::new().unwrap();
+    write_polygons_shp(file.path().to_str().unwrap(), &[poly2.clone()], Some(&[poly3.clone()])).unwrap();
+    let (_polys, polys3) = read_polygons_shp(file.path().to_str().unwrap()).unwrap();
+    assert_eq!(polys3.unwrap()[0], poly3);
+}

--- a/survey_cad_cli/src/main.rs
+++ b/survey_cad_cli/src/main.rs
@@ -468,7 +468,7 @@ fn main() {
         },
         #[cfg(feature = "shapefile")]
         Commands::ExportShp { input, output } => match read_points_csv(&input, None, None) {
-            Ok(pts) => match write_points_shp(&output, &pts) {
+            Ok(pts) => match write_points_shp(&output, &pts, None) {
                 Ok(()) => println!("Wrote {}", output),
                 Err(e) => eprintln!("Error writing {}: {}", output, e),
             },
@@ -476,15 +476,24 @@ fn main() {
         },
         #[cfg(feature = "shapefile")]
         Commands::ImportShp { input, output } => match read_points_shp(&input) {
-            Ok(pts) => match write_points_csv(&output, &pts, None, None) {
-                Ok(()) => println!("Wrote {}", output),
-                Err(e) => eprintln!("Error writing {}: {}", output, e),
-            },
+            Ok((pts, pts3)) => {
+                if let Some(z) = pts3 {
+                    match write_points_csv_3d(&output, &z) {
+                        Ok(()) => println!("Wrote {}", output),
+                        Err(e) => eprintln!("Error writing {}: {}", output, e),
+                    }
+                } else {
+                    match write_points_csv(&output, &pts, None, None) {
+                        Ok(()) => println!("Wrote {}", output),
+                        Err(e) => eprintln!("Error writing {}: {}", output, e),
+                    }
+                }
+            }
             Err(e) => eprintln!("Error reading {}: {}", input, e),
         },
         #[cfg(feature = "shapefile")]
         Commands::ExportPolylinesShp { input, output } => match read_polylines_csv(&input) {
-            Ok(lines) => match write_polylines_shp(&output, &lines) {
+            Ok(lines) => match write_polylines_shp(&output, &lines, None) {
                 Ok(()) => println!("Wrote {}", output),
                 Err(e) => eprintln!("Error writing {}: {}", output, e),
             },
@@ -492,7 +501,7 @@ fn main() {
         },
         #[cfg(feature = "shapefile")]
         Commands::ImportPolylinesShp { input, output } => match read_polylines_shp(&input) {
-            Ok(lines) => match write_polylines_csv(&output, &lines) {
+            Ok((lines, _)) => match write_polylines_csv(&output, &lines) {
                 Ok(()) => println!("Wrote {}", output),
                 Err(e) => eprintln!("Error writing {}: {}", output, e),
             },
@@ -500,7 +509,7 @@ fn main() {
         },
         #[cfg(feature = "shapefile")]
         Commands::ExportPolygonsShp { input, output } => match read_polygons_csv(&input) {
-            Ok(polys) => match write_polygons_shp(&output, &polys) {
+            Ok(polys) => match write_polygons_shp(&output, &polys, None) {
                 Ok(()) => println!("Wrote {}", output),
                 Err(e) => eprintln!("Error writing {}: {}", output, e),
             },
@@ -508,7 +517,7 @@ fn main() {
         },
         #[cfg(feature = "shapefile")]
         Commands::ImportPolygonsShp { input, output } => match read_polygons_shp(&input) {
-            Ok(polys) => match write_polygons_csv(&output, &polys) {
+            Ok((polys, _)) => match write_polygons_csv(&output, &polys) {
                 Ok(()) => println!("Wrote {}", output),
                 Err(e) => eprintln!("Error writing {}: {}", output, e),
             },


### PR DESCRIPTION
## Summary
- handle PointZ/PolylineZ/PolygonZ in shapefile I/O
- include optional 3D data in read/write APIs
- update CLI to use new signatures
- add tests for 3D shapefile roundtrips

## Testing
- `cargo test -p survey_cad --features shapefile` *(fails: build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68438a47e4888328a9af7c53b66a60e8