### PR TITLE
Add shapefile roundtrip tests

### DIFF
--- a/survey_cad/tests/shp_roundtrip.rs
+++ b/survey_cad/tests/shp_roundtrip.rs
@@ -1,0 +1,50 @@
+#[cfg(feature = "shapefile")]
+use survey_cad::io::shp::{
+    read_points_shp, write_points_shp,
+    read_polylines_shp, write_polylines_shp,
+    read_polygons_shp, write_polygons_shp,
+};
+#[cfg(feature = "shapefile")]
+use survey_cad::geometry::{Point, Polyline};
+
+#[cfg(feature = "shapefile")]
+#[test]
+fn points_roundtrip() {
+    use tempfile::NamedTempFile;
+    let pts = vec![Point::new(1.0, 2.0), Point::new(3.0, 4.0)];
+    let file = NamedTempFile::new().unwrap();
+    write_points_shp(file.path().to_str().unwrap(), &pts, None).unwrap();
+    let (pts_read, z) = read_points_shp(file.path().to_str().unwrap()).unwrap();
+    assert_eq!(pts_read, pts);
+    assert!(z.is_none());
+}
+
+#[cfg(feature = "shapefile")]
+#[test]
+fn polylines_roundtrip() {
+    use tempfile::NamedTempFile;
+    let pl = Polyline::new(vec![Point::new(0.0,0.0), Point::new(1.0,0.0), Point::new(2.0,1.0)]);
+    let file = NamedTempFile::new().unwrap();
+    write_polylines_shp(file.path().to_str().unwrap(), &[pl.clone()], None).unwrap();
+    let (lines, z) = read_polylines_shp(file.path().to_str().unwrap()).unwrap();
+    assert_eq!(lines[0], pl);
+    assert!(z.is_none());
+}
+
+#[cfg(feature = "shapefile")]
+#[test]
+fn polygons_roundtrip() {
+    use tempfile::NamedTempFile;
+    let poly = vec![
+        Point::new(0.0,0.0),
+        Point::new(1.0,1.0),
+        Point::new(1.0,0.0),
+        Point::new(0.0,0.0),
+    ];
+    let file = NamedTempFile::new().unwrap();
+    write_polygons_shp(file.path().to_str().unwrap(), &[poly.clone()], None).unwrap();
+    let (polys, z) = read_polygons_shp(file.path().to_str().unwrap()).unwrap();
+    assert_eq!(polys[0], poly);
+    assert!(z.is_none());
+}
+

--- a/survey_cad/tests/shp_z.rs
+++ b/survey_cad/tests/shp_z.rs
@@ -33,8 +33,8 @@ fn polygons_z_roundtrip() {
     use tempfile::NamedTempFile;
     let poly3 = vec![
         Point3::new(0.0,0.0,0.0),
-        Point3::new(1.0,0.0,0.0),
         Point3::new(1.0,1.0,0.0),
+        Point3::new(1.0,0.0,0.0),
         Point3::new(0.0,0.0,0.0),
     ];
     let poly2: Vec<Point> = poly3.iter().map(|p| Point::new(p.x,p.y)).collect();


### PR DESCRIPTION
## Summary
- test 2D shapefile read/write for points, polylines and polygons
- fix polygon orientation in existing Z shapefile tests

## Testing
- `cargo test -p survey_cad --features shapefile --test shp_roundtrip --test shp_z`

------
https://chatgpt.com/codex/tasks/task_e_68438f74362083288dd5c26aa05003ed