### PR TITLE
Add shapefile record roundtrip support

### DIFF
--- a/survey_cad/src/io/shp.rs
+++ b/survey_cad/src/io/shp.rs
@@ -1,9 +1,57 @@
 use crate::geometry::{Point, Point3};
+use std::collections::BTreeMap;
 use shapefile::{
     Point as ShpPoint, PointZ as ShpPointZ, Polygon as ShpPolygon, PolygonRing, PolygonZ,
-    Polyline as ShpPolyline, PolylineZ, Shape, ShapeReader, ShapeWriter, NO_DATA,
+    Polyline as ShpPolyline, PolylineZ, Shape, ShapeReader, ShapeWriter, Reader, Writer, NO_DATA,
 };
+use shapefile::dbase::{FieldName, FieldValue, Record};
+use shapefile::dbase::TableWriterBuilder;
 use std::io;
+
+/// Record type for a point geometry and its attributes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PointRecord {
+    pub geom: Point,
+    pub geom_z: Option<Point3>,
+    pub attrs: BTreeMap<String, FieldValue>,
+}
+
+/// Record type for a polyline geometry and its attributes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PolylineRecord {
+    pub geom: crate::geometry::Polyline,
+    pub geom_z: Option<Vec<Point3>>, // vertices with Z if present
+    pub attrs: BTreeMap<String, FieldValue>,
+}
+
+/// Record type for a polygon geometry and its attributes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PolygonRecord {
+    pub geom: Vec<Point>,
+    pub geom_z: Option<Vec<Point3>>, // vertices with Z if present
+    pub attrs: BTreeMap<String, FieldValue>,
+}
+
+fn build_table_builder(attrs: &BTreeMap<String, FieldValue>) -> TableWriterBuilder {
+    use std::convert::TryFrom;
+    let mut builder = TableWriterBuilder::new();
+    for (name, value) in attrs {
+        let field_name = FieldName::try_from(name.as_str()).unwrap_or_else(|_| FieldName::try_from("FIELD").unwrap());
+        builder = match value {
+            FieldValue::Character(_) | FieldValue::Memo(_) =>
+                builder.add_character_field(field_name, 64),
+            FieldValue::Numeric(_) => builder.add_numeric_field(field_name, 18, 5),
+            FieldValue::Logical(_) => builder.add_logical_field(field_name),
+            FieldValue::Integer(_) => builder.add_integer_field(field_name),
+            FieldValue::Float(_) => builder.add_float_field(field_name, 18, 5),
+            FieldValue::Double(_) => builder.add_double_field(field_name),
+            FieldValue::Date(_) => builder.add_date_field(field_name),
+            FieldValue::Currency(_) => builder.add_currency_field(field_name),
+            FieldValue::DateTime(_) => builder.add_datetime_field(field_name),
+        };
+    }
+    builder
+}
 
 /// Reads a shapefile containing Point geometries and returns them as [`Point`] values.
 pub fn read_points_shp(path: &str) -> io::Result<(Vec<Point>, Option<Vec<Point3>>)> {
@@ -227,4 +275,159 @@ pub fn write_polygons_shp(
         }
     }
     writer.finalize().map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+}
+
+/// Reads Point records with attributes from a shapefile.
+pub fn read_point_records_shp(path: &str) -> io::Result<Vec<PointRecord>> {
+    let mut reader = Reader::from_path(path)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let mut out = Vec::new();
+    for res in reader.iter_shapes_and_records() {
+        let (shape, record) = res.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let attrs: BTreeMap<_, _> = record.into_iter().collect();
+        match shape {
+            Shape::Point(p) => out.push(PointRecord { geom: Point::new(p.x, p.y), geom_z: None, attrs }),
+            Shape::PointZ(p) => out.push(PointRecord { geom: Point::new(p.x, p.y), geom_z: Some(Point3::new(p.x, p.y, p.z)), attrs }),
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
+/// Writes Point records with attributes to a shapefile.
+pub fn write_point_records_shp(path: &str, records: &[PointRecord]) -> io::Result<()> {
+    if records.is_empty() {
+        return Ok(());
+    }
+    let builder = build_table_builder(&records[0].attrs);
+    let mut writer = Writer::from_path(path, builder)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    for rec in records {
+        let mut r = Record::default();
+        for (k, v) in &rec.attrs {
+            r.insert(k.clone(), v.clone());
+        }
+        if let Some(z) = &rec.geom_z {
+            let shp = ShpPointZ::new(z.x, z.y, z.z, NO_DATA);
+            writer.write_shape_and_record(&shp, &r).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        } else {
+            let shp = ShpPoint { x: rec.geom.x, y: rec.geom.y };
+            writer.write_shape_and_record(&shp, &r).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        }
+    }
+    Ok(())
+}
+
+/// Reads Polyline records with attributes from a shapefile.
+pub fn read_polyline_records_shp(path: &str) -> io::Result<Vec<PolylineRecord>> {
+    let mut reader = Reader::from_path(path)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let mut out = Vec::new();
+    for res in reader.iter_shapes_and_records() {
+        let (shape, record) = res.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let attrs: BTreeMap<_, _> = record.into_iter().collect();
+        match shape {
+            Shape::Polyline(pl) => {
+                for part in pl.parts() {
+                    let verts: Vec<Point> = part.iter().map(|p| Point::new(p.x, p.y)).collect();
+                    out.push(PolylineRecord { geom: crate::geometry::Polyline::new(verts), geom_z: None, attrs: attrs.clone() });
+                }
+            }
+            Shape::PolylineZ(pl) => {
+                for part in pl.parts() {
+                    let verts2: Vec<Point> = part.iter().map(|p| Point::new(p.x, p.y)).collect();
+                    let verts3: Vec<Point3> = part.iter().map(|p| Point3::new(p.x, p.y, p.z)).collect();
+                    out.push(PolylineRecord { geom: crate::geometry::Polyline::new(verts2), geom_z: Some(verts3), attrs: attrs.clone() });
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
+/// Writes Polyline records with attributes to a shapefile.
+pub fn write_polyline_records_shp(path: &str, records: &[PolylineRecord]) -> io::Result<()> {
+    if records.is_empty() {
+        return Ok(());
+    }
+    let builder = build_table_builder(&records[0].attrs);
+    let mut writer = Writer::from_path(path, builder)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    for rec in records {
+        let mut r = Record::default();
+        for (k, v) in &rec.attrs {
+            r.insert(k.clone(), v.clone());
+        }
+        if let Some(ref zs) = rec.geom_z {
+            if zs.len() < 2 { continue; }
+            let shp_pts: Vec<ShpPointZ> = zs.iter().map(|p| ShpPointZ::new(p.x, p.y, p.z, NO_DATA)).collect();
+            let shp_pl = PolylineZ::new(shp_pts);
+            writer.write_shape_and_record(&shp_pl, &r).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        } else {
+            if rec.geom.vertices.len() < 2 { continue; }
+            let shp_pts: Vec<ShpPoint> = rec.geom.vertices.iter().map(|p| ShpPoint { x: p.x, y: p.y }).collect();
+            let shp_pl = ShpPolyline::new(shp_pts);
+            writer.write_shape_and_record(&shp_pl, &r).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        }
+    }
+    Ok(())
+}
+
+/// Reads Polygon records with attributes from a shapefile.
+pub fn read_polygon_records_shp(path: &str) -> io::Result<Vec<PolygonRecord>> {
+    let mut reader = Reader::from_path(path)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let mut out = Vec::new();
+    for res in reader.iter_shapes_and_records() {
+        let (shape, record) = res.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let attrs: BTreeMap<_, _> = record.into_iter().collect();
+        match shape {
+            Shape::Polygon(pg) => {
+                for ring in pg.rings() {
+                    let verts: Vec<Point> = ring.points().iter().map(|p| Point::new(p.x, p.y)).collect();
+                    out.push(PolygonRecord { geom: verts, geom_z: None, attrs: attrs.clone() });
+                }
+            }
+            Shape::PolygonZ(pg) => {
+                for ring in pg.rings() {
+                    let verts2: Vec<Point> = ring.points().iter().map(|p| Point::new(p.x, p.y)).collect();
+                    let verts3: Vec<Point3> = ring.points().iter().map(|p| Point3::new(p.x, p.y, p.z)).collect();
+                    out.push(PolygonRecord { geom: verts2, geom_z: Some(verts3), attrs: attrs.clone() });
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
+/// Writes Polygon records with attributes to a shapefile.
+pub fn write_polygon_records_shp(path: &str, records: &[PolygonRecord]) -> io::Result<()> {
+    if records.is_empty() {
+        return Ok(());
+    }
+    let builder = build_table_builder(&records[0].attrs);
+    let mut writer = Writer::from_path(path, builder)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    for rec in records {
+        let mut r = Record::default();
+        for (k, v) in &rec.attrs {
+            r.insert(k.clone(), v.clone());
+        }
+        if let Some(ref zs) = rec.geom_z {
+            if zs.len() < 3 { continue; }
+            let shp_pts: Vec<ShpPointZ> = zs.iter().map(|p| ShpPointZ::new(p.x, p.y, p.z, NO_DATA)).collect();
+            let ring = PolygonRing::Outer(shp_pts);
+            let shp_poly = PolygonZ::new(ring);
+            writer.write_shape_and_record(&shp_poly, &r).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        } else {
+            if rec.geom.len() < 3 { continue; }
+            let shp_pts: Vec<ShpPoint> = rec.geom.iter().map(|p| ShpPoint { x: p.x, y: p.y }).collect();
+            let ring = PolygonRing::Outer(shp_pts);
+            let shp_poly = ShpPolygon::new(ring);
+            writer.write_shape_and_record(&shp_poly, &r).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        }
+    }
+    Ok(())
 }

--- a/survey_cad/tests/shp_records.rs
+++ b/survey_cad/tests/shp_records.rs
@@ -1,0 +1,62 @@
+#[cfg(feature = "shapefile")]
+use survey_cad::io::shp::{
+    PointRecord, PolylineRecord, PolygonRecord,
+    write_point_records_shp, read_point_records_shp,
+    write_polyline_records_shp, read_polyline_records_shp,
+    write_polygon_records_shp, read_polygon_records_shp,
+};
+#[cfg(feature = "shapefile")]
+use survey_cad::geometry::{Point, Point3, Polyline};
+use shapefile::dbase::FieldValue;
+
+#[cfg(feature = "shapefile")]
+#[test]
+fn point_record_roundtrip() {
+    use tempfile::NamedTempFile;
+    use std::collections::BTreeMap;
+    let mut attrs = BTreeMap::new();
+    attrs.insert("Name".to_string(), FieldValue::Character(Some("Pt".to_string())));
+    let rec = PointRecord { geom: Point::new(1.0,2.0), geom_z: None, attrs };
+    let file = NamedTempFile::new().unwrap();
+    write_point_records_shp(file.path().to_str().unwrap(), &[rec.clone()]).unwrap();
+    let records = read_point_records_shp(file.path().to_str().unwrap()).unwrap();
+    assert_eq!(records[0].geom, rec.geom);
+    assert_eq!(records[0].attrs, rec.attrs);
+}
+
+#[cfg(feature = "shapefile")]
+#[test]
+fn polyline_record_roundtrip() {
+    use tempfile::NamedTempFile;
+    use std::collections::BTreeMap;
+    let mut attrs = BTreeMap::new();
+    attrs.insert("ID".to_string(), FieldValue::Numeric(Some(1.0)));
+    let pl = Polyline::new(vec![Point::new(0.0,0.0), Point::new(1.0,0.0)]);
+    let rec = PolylineRecord { geom: pl.clone(), geom_z: None, attrs };
+    let file = NamedTempFile::new().unwrap();
+    write_polyline_records_shp(file.path().to_str().unwrap(), &[rec.clone()]).unwrap();
+    let records = read_polyline_records_shp(file.path().to_str().unwrap()).unwrap();
+    assert_eq!(records[0].geom, rec.geom);
+    assert_eq!(records[0].attrs, rec.attrs);
+}
+
+#[cfg(feature = "shapefile")]
+#[test]
+fn polygon_record_roundtrip() {
+    use tempfile::NamedTempFile;
+    use std::collections::BTreeMap;
+    let mut attrs = BTreeMap::new();
+    attrs.insert("Val".to_string(), FieldValue::Integer(5));
+    let poly = vec![
+        Point::new(0.0,0.0),
+        Point::new(1.0,0.0),
+        Point::new(1.0,1.0),
+        Point::new(0.0,0.0),
+    ];
+    let rec = PolygonRecord { geom: poly.clone(), geom_z: None, attrs };
+    let file = NamedTempFile::new().unwrap();
+    write_polygon_records_shp(file.path().to_str().unwrap(), &[rec.clone()]).unwrap();
+    let records = read_polygon_records_shp(file.path().to_str().unwrap()).unwrap();
+    assert_eq!(records[0].geom.len(), rec.geom.len());
+    assert_eq!(records[0].attrs, rec.attrs);
+}


### PR DESCRIPTION
## Summary
- extend shapefile I/O with Point/Polyline/Polygon record structs
- handle reading/writing of geometries with DBF attributes
- add new tests verifying record roundtrip

## Testing
- `cargo test -p survey_cad --features shapefile --test shp_records`
- `cargo test -p survey_cad --features shapefile point_record_roundtrip`
- `cargo test -p survey_cad --features shapefile polyline_record_roundtrip`
- `cargo test -p survey_cad --features shapefile polygon_record_roundtrip`


------
https://chatgpt.com/codex/tasks/task_e_6843995c0af08328b7779fc7a1de80dd