### PR TITLE
Add file I/O to GUI

### DIFF
--- a/survey_cad_gui/Cargo.toml
+++ b/survey_cad_gui/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 bevy = { version = "0.15", default-features = false, features = ["bevy_winit", "bevy_sprite", "x11", "bevy_ui", "bevy_pbr"] }
-survey_cad = { path = "../survey_cad" }
+survey_cad = { path = "../survey_cad", features = ["shapefile"] }
+rfd = "0.15"
 clap = { version = "4", features = ["derive"] }
 


### PR DESCRIPTION
## Summary
- enable shapefile IO and add rfd dependency for dialogs
- add Open and Save buttons in the GUI toolbar
- implement handlers that load points, surfaces and alignments via `survey_cad::io`
- support saving current entities to CSV, LandXML or shapefile

## Testing
- `cargo test --workspace --exclude survey_cad_gui --features "shapefile las" -q` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68439c80219083288510c0e4118cdcce