### PR TITLE
Add intersection alignment tools

### DIFF
--- a/survey_cad/tests/intersection.rs
+++ b/survey_cad/tests/intersection.rs
@@ -1,8 +1,8 @@
 use survey_cad::{
-    alignment::{HorizontalAlignment, VerticalAlignment},
+    alignment::{Alignment, HorizontalAlignment, VerticalAlignment},
     geometry::Point,
     intersection::{
-        curb_return_between_alignments, crest_curve_between_alignments,
+        crest_curve_between_alignments, curb_return_between_alignments, intersection_alignment,
         sag_curve_between_alignments,
     },
 };
@@ -49,4 +49,17 @@ fn sag_curve_geometry() {
     assert!((res.high_low_station - 50.0).abs() < 1e-6);
     assert!((res.high_low_elev + 1.0).abs() < 1e-6);
     assert!(res.grade_adjustment.abs() < 1e-6);
+}
+
+#[test]
+fn intersection_alignment_basic() {
+    let ha = HorizontalAlignment::new(vec![Point::new(-10.0, 0.0), Point::new(0.0, 0.0)]);
+    let hb = HorizontalAlignment::new(vec![Point::new(0.0, 0.0), Point::new(0.0, 10.0)]);
+    let va = VerticalAlignment::new(vec![(0.0, 0.0), (10.0, 0.0)]);
+    let vb = VerticalAlignment::new(vec![(10.0, 0.0), (20.0, 0.0)]);
+    let a = Alignment::new(ha, va);
+    let b = Alignment::new(hb, vb);
+    let res = intersection_alignment(&a, &b, 5.0).unwrap();
+    assert_eq!(res.horizontal.elements.len(), 3);
+    assert_eq!(res.vertical.elements.len(), 1);
 }

--- a/survey_cad_cli/tests/cli.rs
+++ b/survey_cad_cli/tests/cli.rs
@@ -253,3 +253,30 @@ fn create_intersection_command() {
         .stdout(predicate::str::contains("center:"));
     dir.close().unwrap();
 }
+
+#[test]
+fn create_full_intersection_command() {
+    let dir = assert_fs::TempDir::new().unwrap();
+    let ha = dir.child("ha.csv");
+    ha.write_str("-10.0,0.0\n0.0,0.0\n").unwrap();
+    let va = dir.child("va.csv");
+    va.write_str("0.0,0.0\n10.0,0.0\n").unwrap();
+    let hb = dir.child("hb.csv");
+    hb.write_str("0.0,0.0\n0.0,10.0\n").unwrap();
+    let vb = dir.child("vb.csv");
+    vb.write_str("10.0,0.0\n20.0,0.0\n").unwrap();
+    Command::cargo_bin("survey_cad_cli")
+        .unwrap()
+        .args([
+            "create-full-intersection",
+            ha.path().to_str().unwrap(),
+            va.path().to_str().unwrap(),
+            hb.path().to_str().unwrap(),
+            vb.path().to_str().unwrap(),
+            "5.0",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Horizontal alignment:"));
+    dir.close().unwrap();
+}


### PR DESCRIPTION
## Summary
- add intersection alignment generator using curb returns and vertical curves
- expose CLI subcommand `create-full-intersection`
- test horizontal/vertical intersection generation in library and CLI

## Testing
- `cargo test --quiet --workspace --exclude survey_cad_gui` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6843aca1c02c83288ef13ae7450c8de0