### PR TITLE
Add survey network automation helpers

### DIFF
--- a/survey_cad/src/parcel.rs
+++ b/survey_cad/src/parcel.rs
@@ -1,12 +1,20 @@
-use crate::geometry::{polygon_area, Point};
 use crate::dtm::Tin;
-use crate::surveying::Traverse;
+use crate::geometry::{polygon_area, Point};
+use crate::surveying::{bearing, Traverse};
 use std::collections::HashMap;
 
 /// Representation of a land parcel defined by a closed boundary.
 #[derive(Debug, Clone)]
 pub struct Parcel {
     pub boundary: Vec<Point>,
+}
+
+/// Summary of the closure accuracy for a parcel boundary.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ClosureReport {
+    pub delta_x: f64,
+    pub delta_y: f64,
+    pub misclosure: f64,
 }
 
 impl Parcel {
@@ -25,11 +33,52 @@ impl Parcel {
         Self::new(tr.points.clone())
     }
 
+    /// Returns the bearing in radians of each boundary segment.
+    pub fn deed_bearings(&self) -> Vec<f64> {
+        if self.boundary.len() < 2 {
+            return Vec::new();
+        }
+        let mut bearings = Vec::with_capacity(self.boundary.len());
+        for win in self.boundary.windows(2) {
+            bearings.push(bearing(win[0], win[1]));
+        }
+        let first = self.boundary.first().unwrap();
+        let last = self.boundary.last().unwrap();
+        bearings.push(bearing(*last, *first));
+        bearings
+    }
+
+    /// Generates a closure report summarizing misclosure of the boundary.
+    pub fn closure_report(&self) -> ClosureReport {
+        if self.boundary.len() < 2 {
+            return ClosureReport {
+                delta_x: 0.0,
+                delta_y: 0.0,
+                misclosure: 0.0,
+            };
+        }
+        let mut dx = 0.0;
+        let mut dy = 0.0;
+        for win in self.boundary.windows(2) {
+            dx += win[1].x - win[0].x;
+            dy += win[1].y - win[0].y;
+        }
+        let first = self.boundary.first().unwrap();
+        let last = self.boundary.last().unwrap();
+        dx += first.x - last.x;
+        dy += first.y - last.y;
+        ClosureReport {
+            delta_x: dx,
+            delta_y: dy,
+            misclosure: (dx * dx + dy * dy).sqrt(),
+        }
+    }
+
     /// Builds a parcel from the outer boundary edges of a TIN surface.
     pub fn from_tin_boundary(tin: &Tin) -> Self {
         let mut edge_count: HashMap<(usize, usize), usize> = HashMap::new();
         for tri in &tin.triangles {
-            for &(a, b) in [ (tri[0], tri[1]), (tri[1], tri[2]), (tri[2], tri[0]) ].iter() {
+            for &(a, b) in [(tri[0], tri[1]), (tri[1], tri[2]), (tri[2], tri[0])].iter() {
                 let e = if a < b { (a, b) } else { (b, a) };
                 *edge_count.entry(e).or_insert(0) += 1;
             }
@@ -95,5 +144,23 @@ mod tests {
         let tin = Tin::from_points(pts);
         let p = Parcel::from_tin_boundary(&tin);
         assert!((p.area() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parcel_bearings_and_closure() {
+        let p = Parcel::new(vec![
+            Point::new(0.0, 0.0),
+            Point::new(1.0, 0.0),
+            Point::new(1.0, 1.0),
+            Point::new(0.0, 1.0),
+        ]);
+        let b = p.deed_bearings();
+        assert_eq!(b.len(), 4);
+        assert!((b[0] - 0.0).abs() < 1e-6);
+        assert!((b[1] - std::f64::consts::FRAC_PI_2).abs() < 1e-6);
+        assert!((b[2] - std::f64::consts::PI).abs() < 1e-6);
+        assert!((b[3] + std::f64::consts::FRAC_PI_2).abs() < 1e-6);
+        let rep = p.closure_report();
+        assert!(rep.misclosure.abs() < 1e-6);
     }
 }


### PR DESCRIPTION
## Summary
- add closure report and deed bearing utilities for parcels
- integrate network adjustment with traverse and parcel generation
- test new surveying features

## Testing
- `cargo test --quiet -p survey_cad --lib --no-default-features` *(fails: build interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684468e7cb3c83289d67099b11f4de7e