### PR TITLE
Add pipe network design rules and detailed analysis

### DIFF
--- a/survey_cad/src/sheet.rs
+++ b/survey_cad/src/sheet.rs
@@ -298,8 +298,8 @@ pub fn write_cross_section_scaled_svg(
     grid: f64,
 ) -> io::Result<()> {
     let mut all_lines: Vec<(f64, f64, Vec<Point>, f64)> = Vec::new();
-    let mut max_width = 0.0;
-    let mut max_height = 0.0;
+    let mut max_width: f64 = 0.0;
+    let mut max_height: f64 = 0.0;
     for sec in sections {
         if let (Some(center), Some(dir), Some(grade)) = (
             alignment.horizontal.point_at(sec.station),


### PR DESCRIPTION
## Summary
- add slope rules and detailed analysis utilities for pipe networks
- expose new pipe network commands in CLI
- fix sheet SVG helper to compile on stable
- test slope rules and detailed pipe analysis

## Testing
- `cargo check -p survey_cad_cli`
- `cargo test -p pipe_network`

------
https://chatgpt.com/codex/tasks/task_e_6844ad4504e083288782e7777274c23a