### PR TITLE
Add DXF line/text entities and snapping

### DIFF
--- a/survey_cad/src/geometry/line.rs
+++ b/survey_cad/src/geometry/line.rs
@@ -43,6 +43,24 @@ impl Line {
     pub fn azimuth(&self) -> f64 {
         (self.end.y - self.start.y).atan2(self.end.x - self.start.x)
     }
+
+    /// Returns the closest point on the line segment to `p`.
+    pub fn nearest_point(&self, p: Point) -> Point {
+        let dx = self.end.x - self.start.x;
+        let dy = self.end.y - self.start.y;
+        let len_sq = dx * dx + dy * dy;
+        if len_sq.abs() < f64::EPSILON {
+            return self.start;
+        }
+        let t = ((p.x - self.start.x) * dx + (p.y - self.start.y) * dy) / len_sq;
+        if t <= 0.0 {
+            self.start
+        } else if t >= 1.0 {
+            self.end
+        } else {
+            Point::new(self.start.x + t * dx, self.start.y + t * dy)
+        }
+    }
 }
 
 /// Annotation describing line distance and azimuth.
@@ -61,4 +79,3 @@ impl LineAnnotation {
         }
     }
 }
-

--- a/survey_cad/src/lib.rs
+++ b/survey_cad/src/lib.rs
@@ -12,9 +12,10 @@ pub mod parcel;
 pub mod pmetra;
 #[cfg(feature = "render")]
 pub mod render;
+pub mod sheet;
+pub mod snap;
+pub mod subassembly;
 pub mod superelevation;
 pub mod surveying;
 pub mod truck_integration;
 pub mod variable_offset;
-pub mod subassembly;
-pub mod sheet;

--- a/survey_cad/src/snap.rs
+++ b/survey_cad/src/snap.rs
@@ -1,0 +1,112 @@
+use crate::geometry::{distance, Arc, Line, Point, Polyline};
+use crate::io::DxfEntity;
+use crate::surveying::line_intersection;
+
+/// Attempts to snap `target` to nearby geometry within `tol` units.
+///
+/// The function checks endpoints, midpoints, line intersections and
+/// nearest points on line or arc entities.
+pub fn snap_point(target: Point, entities: &[DxfEntity], tol: f64) -> Option<Point> {
+    let mut candidates: Vec<Point> = Vec::new();
+    let mut lines: Vec<Line> = Vec::new();
+
+    for e in entities {
+        match e {
+            DxfEntity::Point { point, .. } => candidates.push(*point),
+            DxfEntity::Line { line, .. } => {
+                candidates.push(line.start);
+                candidates.push(line.end);
+                candidates.push(line.midpoint());
+                lines.push(*line);
+            }
+            DxfEntity::Polyline { polyline, .. } => {
+                for seg in polyline.vertices.windows(2) {
+                    let l = Line::new(seg[0], seg[1]);
+                    candidates.push(l.start);
+                    candidates.push(l.end);
+                    candidates.push(l.midpoint());
+                    lines.push(l);
+                }
+            }
+            DxfEntity::Arc { arc, .. } => {
+                candidates.push(arc.start_point());
+                candidates.push(arc.end_point());
+                candidates.push(arc.midpoint());
+            }
+            DxfEntity::Text { position, .. } => candidates.push(*position),
+        }
+    }
+
+    // line-line intersections
+    for i in 0..lines.len() {
+        for j in (i + 1)..lines.len() {
+            if let Some(p) =
+                line_intersection(lines[i].start, lines[i].end, lines[j].start, lines[j].end)
+            {
+                candidates.push(p);
+            }
+        }
+    }
+
+    let mut best = None;
+    let mut best_dist = tol;
+
+    for c in &candidates {
+        let d = distance(target, *c);
+        if d < best_dist {
+            best_dist = d;
+            best = Some(*c);
+        }
+    }
+
+    // nearest on segments and arcs if nothing else
+    for l in &lines {
+        let p = l.nearest_point(target);
+        let d = distance(target, p);
+        if d < best_dist {
+            best_dist = d;
+            best = Some(p);
+        }
+    }
+    for e in entities {
+        if let DxfEntity::Arc { arc, .. } = e {
+            let p = arc.nearest_point(target);
+            let d = distance(target, p);
+            if d < best_dist {
+                best_dist = d;
+                best = Some(p);
+            }
+        }
+    }
+
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snap_to_intersection() {
+        let line1 = DxfEntity::Line {
+            line: Line::new(Point::new(-1.0, 0.0), Point::new(1.0, 0.0)),
+            layer: None,
+        };
+        let line2 = DxfEntity::Line {
+            line: Line::new(Point::new(0.0, -1.0), Point::new(0.0, 1.0)),
+            layer: None,
+        };
+        let snapped = snap_point(Point::new(0.1, 0.1), &[line1, line2], 0.5).unwrap();
+        assert!(distance(snapped, Point::new(0.0, 0.0)) < 0.2);
+    }
+
+    #[test]
+    fn snap_to_nearest_point() {
+        let line = DxfEntity::Line {
+            line: Line::new(Point::new(0.0, 0.0), Point::new(2.0, 0.0)),
+            layer: None,
+        };
+        let snapped = snap_point(Point::new(1.0, 2.0), &[line], 5.0).unwrap();
+        assert!((snapped.x - 1.0).abs() < 1e-6 && snapped.y.abs() < 1e-6);
+    }
+}


### PR DESCRIPTION
## Summary
- extend `DxfEntity` to include `Line` and `Text`
- support reading/writing these entities in DXF
- expose snapping helpers for selecting nearby geometry
- export new `snap` module
- basic unit tests for snapping

## Testing
- `cargo test -p survey_cad --no-default-features --lib snap::tests::snap_to_intersection -- --nocapture`
- `cargo test -p survey_cad --no-default-features --lib snap::tests::snap_to_nearest_point -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_6844b612c3e88328b8e7105be2a58825