### PR TITLE
Implement basic layer & style system

### DIFF
--- a/survey_cad/src/layers.rs
+++ b/survey_cad/src/layers.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+
+use crate::geometry::LineType;
+use crate::styles::{LineWeight, TextStyle};
+
+/// Representation of a drawing layer.
+#[derive(Debug, Clone)]
+pub struct Layer {
+    pub name: String,
+    pub is_on: bool,
+    pub is_locked: bool,
+    pub dependencies: Vec<String>,
+    pub line_type: Option<LineType>,
+    pub line_weight: Option<LineWeight>,
+    pub text_style: Option<TextStyle>,
+}
+
+impl Layer {
+    /// Creates a new layer with default state.
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            is_on: true,
+            is_locked: false,
+            dependencies: Vec::new(),
+            line_type: None,
+            line_weight: None,
+            text_style: None,
+        }
+    }
+}
+
+/// Manager for an arbitrary number of layers.
+#[derive(Debug, Default)]
+pub struct LayerManager {
+    layers: HashMap<String, Layer>,
+}
+
+impl LayerManager {
+    /// Creates an empty layer manager.
+    pub fn new() -> Self {
+        Self {
+            layers: HashMap::new(),
+        }
+    }
+
+    /// Adds or replaces a layer by name.
+    pub fn add_layer(&mut self, layer: Layer) {
+        self.layers.insert(layer.name.clone(), layer);
+    }
+
+    /// Retrieves a layer by name.
+    pub fn layer(&self, name: &str) -> Option<&Layer> {
+        self.layers.get(name)
+    }
+
+    /// Retrieves a mutable reference to a layer by name.
+    pub fn layer_mut(&mut self, name: &str) -> Option<&mut Layer> {
+        self.layers.get_mut(name)
+    }
+
+    /// Sets the on/off state for the named layer.
+    pub fn set_layer_state(&mut self, name: &str, on: bool) {
+        if let Some(layer) = self.layers.get_mut(name) {
+            layer.is_on = on;
+        }
+    }
+
+    /// Returns all layers matching `predicate`.
+    pub fn filter<'a, F>(&'a self, predicate: F) -> Vec<&'a Layer>
+    where
+        F: Fn(&Layer) -> bool,
+    {
+        self.layers.values().filter(|l| predicate(l)).collect()
+    }
+}

--- a/survey_cad/src/lib.rs
+++ b/survey_cad/src/lib.rs
@@ -7,6 +7,7 @@ pub mod dtm;
 pub mod geometry;
 pub mod intersection;
 pub mod io;
+pub mod layers;
 pub mod parcel;
 #[cfg(feature = "pmetra")]
 pub mod pmetra;
@@ -14,6 +15,7 @@ pub mod pmetra;
 pub mod render;
 pub mod sheet;
 pub mod snap;
+pub mod styles;
 pub mod subassembly;
 pub mod superelevation;
 pub mod surveying;

--- a/survey_cad/src/styles.rs
+++ b/survey_cad/src/styles.rs
@@ -1,0 +1,67 @@
+/// Basic styling structures for drawing entities.
+
+/// Represents the weight of a line in millimeters.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LineWeight(pub f32);
+
+impl Default for LineWeight {
+    fn default() -> Self {
+        Self(0.25)
+    }
+}
+
+/// Text style definition.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextStyle {
+    pub name: String,
+    pub font: String,
+    pub height: f64,
+}
+
+impl TextStyle {
+    /// Creates a new text style.
+    pub fn new(name: &str, font: &str, height: f64) -> Self {
+        Self {
+            name: name.to_string(),
+            font: font.to_string(),
+            height,
+        }
+    }
+}
+
+/// Dimension style definition with optional overrides.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DimensionStyle {
+    pub name: String,
+    pub text_style: TextStyle,
+    pub scale: f64,
+}
+
+impl DimensionStyle {
+    pub fn new(name: &str, text_style: TextStyle, scale: f64) -> Self {
+        Self {
+            name: name.to_string(),
+            text_style,
+            scale,
+        }
+    }
+
+    /// Returns a new style with the provided overrides applied.
+    pub fn overridden(&self, ov: &DimensionStyleOverride) -> Self {
+        Self {
+            name: self.name.clone(),
+            text_style: ov
+                .text_style
+                .clone()
+                .unwrap_or_else(|| self.text_style.clone()),
+            scale: ov.scale.unwrap_or(self.scale),
+        }
+    }
+}
+
+/// Overrides for a dimension style.
+#[derive(Debug, Clone, Default)]
+pub struct DimensionStyleOverride {
+    pub text_style: Option<TextStyle>,
+    pub scale: Option<f64>,
+}

--- a/survey_cad/tests/layers_styles.rs
+++ b/survey_cad/tests/layers_styles.rs
@@ -1,0 +1,33 @@
+use survey_cad::{
+    layers::{Layer, LayerManager},
+    styles::{DimensionStyle, DimensionStyleOverride, TextStyle},
+};
+
+#[test]
+fn layer_manager_filter() {
+    let mut mgr = LayerManager::new();
+    mgr.add_layer(Layer::new("A"));
+    let mut off = Layer::new("B");
+    off.is_on = false;
+    mgr.add_layer(off);
+
+    let on_layers = mgr.filter(|l| l.is_on);
+    assert_eq!(on_layers.len(), 1);
+    assert_eq!(on_layers[0].name, "A");
+
+    mgr.set_layer_state("B", true);
+    let on_layers = mgr.filter(|l| l.is_on);
+    assert_eq!(on_layers.len(), 2);
+}
+
+#[test]
+fn dimension_style_override() {
+    let base = DimensionStyle::new("base", TextStyle::new("txt", "Arial", 2.5), 1.0);
+    let over = DimensionStyleOverride {
+        text_style: None,
+        scale: Some(2.0),
+    };
+    let result = base.overridden(&over);
+    assert_eq!(result.scale, 2.0);
+    assert_eq!(result.text_style.name, "txt");
+}


### PR DESCRIPTION
## Summary
- add new `layers` module for creating and managing drawing layers
- add new `styles` module for line weight, text style, and dimension style with overrides
- export these modules in the library API
- test layer filtering and dimension style overrides

## Testing
- `cargo test -p survey_cad --no-default-features --features shapefile` *(fails: dtm::classified_breaklines_ignore_soft, dtm::breakline_editing, dtm::slope_analysis_basic, subassembly::daylight_surface_table, surveying::adjustment::simple_distance_network, surveying::point_db::adjust_database, surveying::point_db::adjust_to_parcel_builds_traverse_and_parcel)*

------
https://chatgpt.com/codex/tasks/task_e_6844bcd87c3483288f1f475cdad9fa0e