### PR TITLE
Add flexible CRS definitions

### DIFF
--- a/survey_cad/src/crs.rs
+++ b/survey_cad/src/crs.rs
@@ -2,28 +2,77 @@
 
 use proj::Proj;
 
-/// Simple wrapper representing a coordinate reference system identified by an EPSG code.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Representation of a coordinate reference system.
+///
+/// A CRS is stored internally as a definition string which can be an EPSG
+/// identifier (`"EPSG:4326"`), a Proj4 definition or a WKT definition.  When
+/// created from an EPSG code the numeric value is retained so that callers can
+/// inspect it if necessary.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Crs {
-    code: u32,
+    definition: String,
+    epsg: Option<u32>,
 }
 
 impl Crs {
     /// Creates a new CRS from the given EPSG code.
     pub fn from_epsg(code: u32) -> Self {
-        Self { code }
+        Self {
+            definition: format!("EPSG:{}", code),
+            epsg: Some(code),
+        }
     }
 
-    /// Returns the EPSG code for this CRS.
-    pub fn epsg(&self) -> u32 {
-        self.code
+    /// Creates a CRS from a Proj4 definition string.
+    pub fn from_proj4(definition: &str) -> Self {
+        Self {
+            definition: definition.to_string(),
+            epsg: None,
+        }
+    }
+
+    /// Creates a CRS from a WKT definition string.
+    pub fn from_wkt(definition: &str) -> Self {
+        Self {
+            definition: definition.to_string(),
+            epsg: None,
+        }
+    }
+
+    /// Returns the EPSG code for this CRS, if available.
+    pub fn epsg(&self) -> Option<u32> {
+        self.epsg
+    }
+
+    /// Returns the underlying definition string.
+    pub fn definition(&self) -> &str {
+        &self.definition
+    }
+
+    /// Common global CRS definition: WGS84 (EPSG:4326).
+    pub fn wgs84() -> Self {
+        Self::from_epsg(4326)
+    }
+
+    /// Common global CRS definition: Web Mercator (EPSG:3857).
+    pub fn web_mercator() -> Self {
+        Self::from_epsg(3857)
+    }
+
+    /// Example national CRS definition (NAD83 / Canada CSRS).
+    pub fn nad83_csrs() -> Self {
+        Self::from_epsg(4617)
+    }
+
+    /// Example provincial CRS definition (NAD83 / Alberta 10TM). This is just a
+    /// representative sample of a provincial CRS.
+    pub fn alberta_10tm() -> Self {
+        Self::from_epsg(3400)
     }
 
     /// Transforms an `(x, y)` coordinate from this CRS to the target CRS.
     pub fn transform_point(&self, target: &Crs, x: f64, y: f64) -> Option<(f64, f64)> {
-        let from_def = format!("EPSG:{}", self.code);
-        let to_def = format!("EPSG:{}", target.code);
-        let proj = Proj::new_known_crs(&from_def, &to_def, None).ok()?;
+        let proj = Proj::new_known_crs(&self.definition, &target.definition, None).ok()?;
         proj.convert((x, y)).ok()
     }
 }
@@ -34,8 +83,8 @@ mod tests {
 
     #[test]
     fn wgs84_to_web_mercator() {
-        let wgs84 = Crs::from_epsg(4326);
-        let webm = Crs::from_epsg(3857);
+        let wgs84 = Crs::wgs84();
+        let webm = Crs::web_mercator();
         let (x, y) = wgs84.transform_point(&webm, 0.0, 0.0).unwrap();
         assert!(x.abs() < 1e-6 && y.abs() < 1e-6);
     }

--- a/survey_cad/src/io/mod.rs
+++ b/survey_cad/src/io/mod.rs
@@ -100,7 +100,7 @@ pub fn write_points_csv(
     let to = dst_epsg.map(Crs::from_epsg);
     for p in points {
         let (x, y) = match (&from, &to) {
-            (Some(f), Some(t)) if f.epsg() != t.epsg() => {
+            (Some(f), Some(t)) if f != t => {
                 f.transform_point(t, p.x, p.y).unwrap_or((p.x, p.y))
             }
             _ => (p.x, p.y),
@@ -169,7 +169,7 @@ pub fn write_points_geojson(
         .iter()
         .map(|p| {
             let (x, y) = match (&from, &to) {
-                (Some(f), Some(t)) if f.epsg() != t.epsg() => {
+                (Some(f), Some(t)) if f != t => {
                     f.transform_point(t, p.x, p.y).unwrap_or((p.x, p.y))
                 }
                 _ => (p.x, p.y),
@@ -208,7 +208,7 @@ pub fn write_points_dxf(
     writeln!(file, "ENTITIES")?;
     for p in points {
         let (x, y) = match (&from, &to) {
-            (Some(f), Some(t)) if f.epsg() != t.epsg() => {
+            (Some(f), Some(t)) if f != t => {
                 f.transform_point(t, p.x, p.y).unwrap_or((p.x, p.y))
             }
             _ => (p.x, p.y),

--- a/survey_cad_cli/src/main.rs
+++ b/survey_cad_cli/src/main.rs
@@ -411,7 +411,7 @@ enum Commands {
 fn main() {
     let cli = Cli::parse();
     let _working_crs = Crs::from_epsg(cli.epsg);
-    println!("Using EPSG {}", cli.epsg);
+    println!("Using CRS: {}", _working_crs.definition());
     match cli.command {
         Commands::StationDistance {
             name_a,

--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -280,7 +280,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, working: Res<WorkingCrs>) {
-    println!("GUI working CRS EPSG: {}", working.0.epsg());
+    println!("GUI working CRS: {}", working.0.definition());
     commands.spawn(Camera2dBundle::default());
     commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(0.0, -50.0, 50.0).looking_at(Vec3::ZERO, Vec3::Z),


### PR DESCRIPTION
## Summary
- extend `Crs` structure so it can be created from EPSG codes, Proj4 or WKT
- expose some built-in CRS helpers (WGS84, Web Mercator, national and provincial examples)
- update IO utilities and applications to use the new CRS API

## Testing
- `cargo test --quiet` *(fails: adjusting parcel tests etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6844c515585c832886ccd5a01f2a6816