### PR TITLE
Add local grid definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4638,6 +4638,7 @@ dependencies = [
  "log",
  "nalgebra",
  "proj",
+ "proj-sys",
  "roxmltree",
  "serde",
  "serde_json",

--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -20,6 +20,7 @@ delaunator = "1"
 cdt = "0.1"
 roxmltree = "0.20"
 proj = { version = "0.30", features = ["network"] }
+proj-sys = "0.26"
 shapefile = { version = "0.7", optional = true }
 las = { version = "0.9", optional = true }
 nalgebra = { version = "0.32", default-features = false, features = ["std"] }

--- a/survey_cad/src/lib.rs
+++ b/survey_cad/src/lib.rs
@@ -7,6 +7,7 @@ pub mod dtm;
 pub mod geometry;
 pub mod intersection;
 pub mod io;
+pub mod local_grid;
 pub mod layers;
 pub mod parcel;
 #[cfg(feature = "pmetra")]
@@ -21,3 +22,5 @@ pub mod superelevation;
 pub mod surveying;
 pub mod truck_integration;
 pub mod variable_offset;
+
+pub use local_grid::LocalGrid;

--- a/survey_cad/src/local_grid.rs
+++ b/survey_cad/src/local_grid.rs
@@ -1,0 +1,82 @@
+//! Local grid definition with origin, rotation and scale.
+
+use crate::geometry::Point;
+
+/// Simple local grid definition.
+///
+/// A local grid transforms coordinates from a global CRS into
+/// project-specific values using a translation, rotation and scale.
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub struct LocalGrid {
+    /// Global coordinates of the local origin.
+    pub origin: Point,
+    /// Counter-clockwise rotation from global X axis to local East in radians.
+    pub rotation: f64,
+    /// Scale factor applied after rotation when converting to local coordinates.
+    pub scale: f64,
+}
+
+impl LocalGrid {
+    /// Creates a new local grid definition.
+    pub fn new(origin: Point, rotation: f64, scale: f64) -> Self {
+        Self {
+            origin,
+            rotation,
+            scale,
+        }
+    }
+
+    /// Converts a global coordinate to this local grid.
+    pub fn to_local(&self, p: Point) -> Point {
+        let dx = p.x - self.origin.x;
+        let dy = p.y - self.origin.y;
+        let cos = self.rotation.cos();
+        let sin = self.rotation.sin();
+        let x = (dx * cos + dy * sin) * self.scale;
+        let y = (-dx * sin + dy * cos) * self.scale;
+        Point::new(x, y)
+    }
+
+    /// Converts a local coordinate back to global coordinates.
+    pub fn from_local(&self, p: Point) -> Point {
+        let inv_scale = 1.0 / self.scale;
+        let x = p.x * inv_scale;
+        let y = p.y * inv_scale;
+        let cos = self.rotation.cos();
+        let sin = self.rotation.sin();
+        let gx = x * cos - y * sin + self.origin.x;
+        let gy = x * sin + y * cos + self.origin.y;
+        Point::new(gx, gy)
+    }
+
+    /// Saves this grid definition to a JSON file.
+    pub fn save(&self, path: &str) -> std::io::Result<()> {
+        let json = serde_json::to_string_pretty(self).unwrap();
+        std::fs::write(path, json)
+    }
+
+    /// Loads a grid definition from a JSON file.
+    pub fn load(path: &str) -> std::io::Result<Self> {
+        let data = std::fs::read_to_string(path)?;
+        let grid: LocalGrid = serde_json::from_str(&data).map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+        })?;
+        Ok(grid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let grid = LocalGrid::new(Point::new(100.0, 200.0), 0.78539816339, 2.0);
+        let global = Point::new(110.0, 210.0);
+        let local = grid.to_local(global);
+        let back = grid.from_local(local);
+        assert!((back.x - global.x).abs() < 1e-6);
+        assert!((back.y - global.y).abs() < 1e-6);
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce `LocalGrid` for customizable local grids
- allow saving/loading grid definitions via JSON files
- expose `LocalGrid` from library
- include `proj-sys` dependency to build

## Testing
- `cargo test -p survey_cad --lib local_grid`

------
https://chatgpt.com/codex/tasks/task_e_6844cdb578608328b9957b80da8e6c11