### PR TITLE
Add observation database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,6 +1605,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -2197,6 +2198,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,6 +2637,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,10 +3037,11 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.32.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4264,6 +4287,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.9.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4630,6 +4667,7 @@ dependencies = [
  "bevy_picking",
  "bevy_pmetra",
  "cdt",
+ "chrono",
  "delaunator",
  "env_logger",
  "fresnel",
@@ -4640,6 +4678,7 @@ dependencies = [
  "proj",
  "proj-sys",
  "roxmltree",
+ "rusqlite",
  "serde",
  "serde_json",
  "shapefile",

--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -8,6 +8,8 @@ log = "0.4"
 env_logger = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
+rusqlite = { version = "0.31", features = ["bundled"] }
+chrono = { version = "0.4", features = ["serde"] }
 geojson = "0.24"
 bevy = { version = "0.15", default-features = false, features = ["bevy_winit", "bevy_sprite", "x11"], optional = true }
 bevy_editor_cam = { version = "0.5", optional = true }

--- a/survey_cad/src/surveying/mod.rs
+++ b/survey_cad/src/surveying/mod.rs
@@ -17,6 +17,12 @@ pub use code_library::{BlockRef, CodeEntry, CodeLibrary};
 pub mod point_db;
 pub use point_db::{PointDatabase, SurveyPoint};
 
+pub mod observation_db;
+pub use observation_db::{
+    ObservationDB, ObservationRecord, ObsType, ObservationData, QueryFilter,
+    TraverseLeg,
+};
+
 /// Representation of a simple survey station.
 #[derive(Debug)]
 pub struct Station {

--- a/survey_cad/src/surveying/observation_db.rs
+++ b/survey_cad/src/surveying/observation_db.rs
@@ -1,0 +1,188 @@
+use rusqlite::{Connection, params};
+use serde::{Serialize, Deserialize};
+use chrono::NaiveDate;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ObsType {
+    TotalStation,
+    Gnss,
+    LevelRun,
+    Traverse,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TraverseLeg {
+    pub from: String,
+    pub to: String,
+    pub bearing: f64,
+    pub distance: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", content = "data")]
+pub enum ObservationData {
+    TotalStation {
+        from: String,
+        to: String,
+        horiz_angle: f64,
+        vert_angle: f64,
+        slope_distance: f64,
+    },
+    Gnss {
+        point: String,
+        northing: f64,
+        easting: f64,
+        elevation: f64,
+    },
+    LevelRun {
+        from: String,
+        to: String,
+        backsight: f64,
+        foresight: f64,
+    },
+    Traverse {
+        name: String,
+        legs: Vec<TraverseLeg>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ObservationRecord {
+    pub id: Option<i64>,
+    pub obs_type: ObsType,
+    pub date: NaiveDate,
+    pub instrument: Option<String>,
+    pub crew: Option<String>,
+    pub control_point: Option<String>,
+    pub data: ObservationData,
+}
+
+#[derive(Default)]
+pub struct QueryFilter {
+    pub date_from: Option<NaiveDate>,
+    pub date_to: Option<NaiveDate>,
+    pub instrument: Option<String>,
+    pub crew: Option<String>,
+    pub control_point: Option<String>,
+    pub obs_type: Option<ObsType>,
+}
+
+pub struct ObservationDB {
+    conn: Connection,
+}
+
+impl ObservationDB {
+    pub fn open(path: &str) -> rusqlite::Result<Self> {
+        let conn = Connection::open(path)?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS observations (
+                id INTEGER PRIMARY KEY,
+                obs_type TEXT NOT NULL,
+                date TEXT NOT NULL,
+                instrument TEXT,
+                crew TEXT,
+                control_point TEXT,
+                data TEXT NOT NULL
+            )",
+        )?;
+        Ok(Self { conn })
+    }
+
+    pub fn insert(&self, rec: &ObservationRecord) -> rusqlite::Result<i64> {
+        let data_json = serde_json::to_string(&rec.data).unwrap();
+        self.conn.execute(
+            "INSERT INTO observations (obs_type, date, instrument, crew, control_point, data)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                format!("{:?}", rec.obs_type),
+                rec.date.to_string(),
+                rec.instrument,
+                rec.crew,
+                rec.control_point,
+                data_json
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    pub fn query(&self, filter: &QueryFilter) -> rusqlite::Result<Vec<ObservationRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, obs_type, date, instrument, crew, control_point, data FROM observations",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let data_str: String = row.get(6)?;
+            let obs_type_str: String = row.get(1)?;
+            let rec = ObservationRecord {
+                id: row.get(0)?,
+                obs_type: match obs_type_str.as_str() {
+                    "TotalStation" => ObsType::TotalStation,
+                    "Gnss" => ObsType::Gnss,
+                    "LevelRun" => ObsType::LevelRun,
+                    "Traverse" => ObsType::Traverse,
+                    _ => ObsType::TotalStation,
+                },
+                date: NaiveDate::parse_from_str(row.get::<_, String>(2)?.as_str(), "%Y-%m-%d").unwrap(),
+                instrument: row.get(3)?,
+                crew: row.get(4)?,
+                control_point: row.get(5)?,
+                data: serde_json::from_str(&data_str).unwrap(),
+            };
+            Ok(rec)
+        })?;
+        let mut res = Vec::new();
+        for r in rows {
+            let rec = r?;
+            if let Some(ref t) = filter.obs_type {
+                if &rec.obs_type != t { continue; }
+            }
+            if let Some(ref s) = filter.instrument {
+                if rec.instrument.as_deref() != Some(s.as_str()) { continue; }
+            }
+            if let Some(ref s) = filter.crew {
+                if rec.crew.as_deref() != Some(s.as_str()) { continue; }
+            }
+            if let Some(ref s) = filter.control_point {
+                if rec.control_point.as_deref() != Some(s.as_str()) { continue; }
+            }
+            if let Some(from) = filter.date_from {
+                if rec.date < from { continue; }
+            }
+            if let Some(to) = filter.date_to {
+                if rec.date > to { continue; }
+            }
+            res.push(rec);
+        }
+        Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn insert_and_query() {
+        let file = NamedTempFile::new().unwrap();
+        let db = ObservationDB::open(file.path().to_str().unwrap()).unwrap();
+        let rec = ObservationRecord {
+            id: None,
+            obs_type: ObsType::Gnss,
+            date: NaiveDate::from_ymd_opt(2024,1,1).unwrap(),
+            instrument: Some("GNSS1".into()),
+            crew: Some("crew1".into()),
+            control_point: Some("CP1".into()),
+            data: ObservationData::Gnss {
+                point: "P1".into(),
+                northing: 100.0,
+                easting: 200.0,
+                elevation: 50.0,
+            },
+        };
+        db.insert(&rec).unwrap();
+        let filter = QueryFilter { instrument: Some("GNSS1".into()), ..Default::default() };
+        let res = db.query(&filter).unwrap();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].instrument.as_deref(), Some("GNSS1"));
+    }
+}


### PR DESCRIPTION
## Summary
- add rusqlite and chrono dependencies
- implement observation database with SQLite backend
- expose new module from surveying library

## Testing
- `cargo test -p survey_cad --no-default-features --features shapefile --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6844d58001dc832893acc7a8bf595af1