### PR TITLE
Add audit history for survey data

### DIFF
--- a/survey_cad/src/surveying/observation_db.rs
+++ b/survey_cad/src/surveying/observation_db.rs
@@ -1,6 +1,6 @@
-use rusqlite::{Connection, params};
-use serde::{Serialize, Deserialize};
-use chrono::NaiveDate;
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+use chrono::{NaiveDate, DateTime, Utc};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum ObsType {
@@ -57,6 +57,16 @@ pub struct ObservationRecord {
     pub data: ObservationData,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ObservationAuditEntry {
+    pub id: Option<i64>,
+    pub observation_id: i64,
+    pub timestamp: DateTime<Utc>,
+    pub user: String,
+    pub comment: Option<String>,
+    pub data: ObservationRecord,
+}
+
 #[derive(Default)]
 pub struct QueryFilter {
     pub date_from: Option<NaiveDate>,
@@ -85,10 +95,29 @@ impl ObservationDB {
                 data TEXT NOT NULL
             )",
         )?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS observation_history (
+                id INTEGER PRIMARY KEY,
+                observation_id INTEGER NOT NULL,
+                timestamp TEXT NOT NULL,
+                user TEXT NOT NULL,
+                comment TEXT,
+                data TEXT NOT NULL
+            )",
+        )?;
         Ok(Self { conn })
     }
 
     pub fn insert(&self, rec: &ObservationRecord) -> rusqlite::Result<i64> {
+        self.insert_with_audit(rec, "system", None)
+    }
+
+    pub fn insert_with_audit(
+        &self,
+        rec: &ObservationRecord,
+        user: &str,
+        comment: Option<&str>,
+    ) -> rusqlite::Result<i64> {
         let data_json = serde_json::to_string(&rec.data).unwrap();
         self.conn.execute(
             "INSERT INTO observations (obs_type, date, instrument, crew, control_point, data)
@@ -102,7 +131,79 @@ impl ObservationDB {
                 data_json
             ],
         )?;
-        Ok(self.conn.last_insert_rowid())
+        let id = self.conn.last_insert_rowid();
+        let mut rec_with_id = rec.clone();
+        rec_with_id.id = Some(id);
+        let rec_json = serde_json::to_string(&rec_with_id).unwrap();
+        self.conn.execute(
+            "INSERT INTO observation_history (observation_id, timestamp, user, comment, data)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                id,
+                Utc::now().to_rfc3339(),
+                user,
+                comment,
+                rec_json
+            ],
+        )?;
+        Ok(id)
+    }
+
+    pub fn update(
+        &self,
+        rec: &ObservationRecord,
+        user: &str,
+        comment: Option<&str>,
+    ) -> rusqlite::Result<()> {
+        let id = rec.id.ok_or_else(|| rusqlite::Error::InvalidQuery)?;
+        let data_json = serde_json::to_string(&rec.data).unwrap();
+        self.conn.execute(
+            "UPDATE observations SET obs_type=?1, date=?2, instrument=?3, crew=?4, control_point=?5, data=?6 WHERE id=?7",
+            params![
+                format!("{:?}", rec.obs_type),
+                rec.date.to_string(),
+                rec.instrument,
+                rec.crew,
+                rec.control_point,
+                data_json,
+                id
+            ],
+        )?;
+        let rec_json = serde_json::to_string(rec).unwrap();
+        self.conn.execute(
+            "INSERT INTO observation_history (observation_id, timestamp, user, comment, data)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                id,
+                Utc::now().to_rfc3339(),
+                user,
+                comment,
+                rec_json
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn history(&self, observation_id: i64) -> rusqlite::Result<Vec<ObservationAuditEntry>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, observation_id, timestamp, user, comment, data FROM observation_history WHERE observation_id=?1 ORDER BY id",
+        )?;
+        let rows = stmt.query_map(params![observation_id], |row| {
+            let data_str: String = row.get(5)?;
+            Ok(ObservationAuditEntry {
+                id: row.get(0)?,
+                observation_id: row.get(1)?,
+                timestamp: DateTime::parse_from_rfc3339(&row.get::<_, String>(2)?).unwrap().with_timezone(&Utc),
+                user: row.get(3)?,
+                comment: row.get(4)?,
+                data: serde_json::from_str(&data_str).unwrap(),
+            })
+        })?;
+        let mut res = Vec::new();
+        for r in rows {
+            res.push(r?);
+        }
+        Ok(res)
     }
 
     pub fn query(&self, filter: &QueryFilter) -> rusqlite::Result<Vec<ObservationRecord>> {
@@ -179,10 +280,17 @@ mod tests {
                 elevation: 50.0,
             },
         };
-        db.insert(&rec).unwrap();
-        let filter = QueryFilter { instrument: Some("GNSS1".into()), ..Default::default() };
+        let id = db.insert_with_audit(&rec, "tester", Some("initial")).unwrap();
+        let mut rec2 = rec.clone();
+        rec2.id = Some(id);
+        rec2.instrument = Some("GNSS2".into());
+        db.update(&rec2, "tester", Some("update instrument")).unwrap();
+        let hist = db.history(id).unwrap();
+        assert_eq!(hist.len(), 2);
+        assert_eq!(hist[0].user, "tester");
+        let filter = QueryFilter { instrument: Some("GNSS2".into()), ..Default::default() };
         let res = db.query(&filter).unwrap();
         assert_eq!(res.len(), 1);
-        assert_eq!(res[0].instrument.as_deref(), Some("GNSS1"));
+        assert_eq!(res[0].instrument.as_deref(), Some("GNSS2"));
     }
 }


### PR DESCRIPTION
## Summary
- implement audit log for observations with new history table
- add audit tracking for in-memory point database
- create helper methods for updating records with user comments
- add unit tests for new audit functionality

## Testing
- `cargo test --workspace --quiet` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6844d9a8c97883288628cad0ec39771a