### PR TITLE
Add traverse closure computations

### DIFF
--- a/survey_cad/src/surveying/mod.rs
+++ b/survey_cad/src/surveying/mod.rs
@@ -75,6 +75,62 @@ impl Traverse {
     pub fn area(&self) -> f64 {
         geometry::polygon_area(&self.points)
     }
+
+    /// Returns the latitude (northing change) and departure (easting change)
+    /// for each leg of the traverse. The traverse is not automatically closed,
+    /// so the number of legs returned is `points.len() - 1`.
+    pub fn lat_departures(&self) -> Vec<(f64, f64)> {
+        if self.points.len() < 2 {
+            return Vec::new();
+        }
+        self.points
+            .windows(2)
+            .map(|pair| {
+                let lat = pair[1].y - pair[0].y;
+                let dep = pair[1].x - pair[0].x;
+                (lat, dep)
+            })
+            .collect()
+    }
+
+    /// Total length of the traverse computed as the sum of the leg lengths
+    /// between consecutive points.
+    pub fn length(&self) -> f64 {
+        if self.points.len() < 2 {
+            return 0.0;
+        }
+        self.points
+            .windows(2)
+            .map(|pair| geometry::distance(pair[0], pair[1]))
+            .sum()
+    }
+
+    /// Computes the misclosure vector `(delta_x, delta_y)` and the misclosure
+    /// distance. The misclosure is the difference between the starting point and
+    /// the final point of the traverse.
+    pub fn misclosure(&self) -> (f64, f64, f64) {
+        if self.points.len() < 2 {
+            return (0.0, 0.0, 0.0);
+        }
+        let first = self.points.first().unwrap();
+        let last = self.points.last().unwrap();
+        let dx = first.x - last.x;
+        let dy = first.y - last.y;
+        let mis = (dx * dx + dy * dy).sqrt();
+        (dx, dy, mis)
+    }
+
+    /// Computes the closure precision of the traverse expressed as the ratio of
+    /// total traverse length to the misclosure distance. A perfectly closed
+    /// traverse will return `f64::INFINITY`.
+    pub fn closure_precision(&self) -> f64 {
+        let (_, _, mis) = self.misclosure();
+        if mis.abs() < f64::EPSILON {
+            f64::INFINITY
+        } else {
+            self.length() / mis
+        }
+    }
 }
 
 #[cfg(test)]
@@ -113,5 +169,41 @@ mod tests {
     fn level_elevation_works() {
         let new_elev = level_elevation(100.0, 1.2, 0.8);
         assert!((new_elev - 100.4).abs() < 1e-6);
+    }
+
+    #[test]
+    fn lat_departures_and_misclosure() {
+        let pts = vec![
+            Point::new(0.0, 0.0),
+            Point::new(1.0, 0.0),
+            Point::new(1.0, 1.0),
+            Point::new(0.0, 1.0),
+            Point::new(0.0, 0.0),
+        ];
+        let t = Traverse::new(pts);
+        let ld = t.lat_departures();
+        assert_eq!(ld.len(), 4);
+        assert!((ld[0].0 - 0.0).abs() < 1e-6 && (ld[0].1 - 1.0).abs() < 1e-6);
+        assert!((ld[1].0 - 1.0).abs() < 1e-6 && ld[1].1.abs() < 1e-6);
+        assert!((ld[2].0 - 0.0).abs() < 1e-6 && (ld[2].1 + 1.0).abs() < 1e-6);
+        assert!((ld[3].0 + 1.0).abs() < 1e-6 && ld[3].1.abs() < 1e-6);
+        let (_, _, mis) = t.misclosure();
+        assert!(mis.abs() < 1e-6);
+    }
+
+    #[test]
+    fn closure_precision_works() {
+        let pts = vec![
+            Point::new(0.0, 0.0),
+            Point::new(1.0, 0.0),
+            Point::new(1.0, 1.0),
+            Point::new(0.0, 0.9),
+        ];
+        let t = Traverse::new(pts);
+        let (_, _, mis) = t.misclosure();
+        assert!((mis - 0.9).abs() < 1e-6);
+        let prec = t.closure_precision();
+        let expected = t.length() / mis;
+        assert!((prec - expected).abs() < 1e-6);
     }
 }


### PR DESCRIPTION
## Summary
- implement latitude/departure calculations and misclosure analysis for `Traverse`
- expose closure precision and length helper
- add unit tests for traverse computations

## Testing
- `cargo test -p survey_cad --lib` *(failed: could not complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6844e4f23a688328beec3dcbec4082d8