### PR TITLE
Add offset/radial stakeout

### DIFF
--- a/survey_cad/src/surveying/mod.rs
+++ b/survey_cad/src/surveying/mod.rs
@@ -23,6 +23,9 @@ pub use observation_db::{
     TraverseLeg,
 };
 
+pub mod stakeout;
+pub use stakeout::stakeout_position;
+
 /// Representation of a simple survey station.
 #[derive(Debug)]
 pub struct Station {

--- a/survey_cad/src/surveying/stakeout.rs
+++ b/survey_cad/src/surveying/stakeout.rs
@@ -1,0 +1,60 @@
+use crate::alignment::{HorizontalAlignment, HorizontalElement};
+use crate::geometry::{Point, Arc};
+
+/// Computes the stakeout position at a given station and offset along a
+/// horizontal alignment. Tangent segments use a perpendicular offset while
+/// curves apply a radial offset.
+pub fn stakeout_position(alignment: &HorizontalAlignment, station: f64, offset: f64) -> Option<Point> {
+    if station < 0.0 || station > alignment.length() {
+        return None;
+    }
+    let mut remaining = station;
+    for elem in &alignment.elements {
+        let len = elem.length();
+        if remaining <= len {
+            return Some(match elem {
+                HorizontalElement::Tangent { start, end } => {
+                    tangent_point(*start, *end, remaining, offset)
+                }
+                HorizontalElement::Curve { arc } => curve_point(arc, remaining, offset),
+                HorizontalElement::Spiral { spiral } => {
+                    let base = spiral.point_at(remaining);
+                    let dir = spiral.direction_at(remaining);
+                    let norm = (-dir.1, dir.0);
+                    let nlen = (norm.0 * norm.0 + norm.1 * norm.1).sqrt();
+                    if nlen.abs() < f64::EPSILON {
+                        base
+                    } else {
+                        Point::new(base.x + offset * norm.0 / nlen, base.y + offset * norm.1 / nlen)
+                    }
+                }
+            });
+        }
+        remaining -= len;
+    }
+    None
+}
+
+/// Computes a stakeout point on a tangent segment.
+fn tangent_point(start: Point, end: Point, distance: f64, offset: f64) -> Point {
+    let dx = end.x - start.x;
+    let dy = end.y - start.y;
+    let len = (dx * dx + dy * dy).sqrt();
+    if len.abs() < f64::EPSILON {
+        return start;
+    }
+    let t = distance / len;
+    let x = start.x + t * dx;
+    let y = start.y + t * dy;
+    let nx = -dy / len;
+    let ny = dx / len;
+    Point::new(x + offset * nx, y + offset * ny)
+}
+
+/// Computes a stakeout point on a circular curve using a radial offset.
+fn curve_point(arc: &Arc, distance: f64, offset: f64) -> Point {
+    let dir = if arc.end_angle >= arc.start_angle { 1.0 } else { -1.0 };
+    let ang = arc.start_angle + distance / arc.radius * dir;
+    let r = arc.radius + offset;
+    Point::new(arc.center.x + r * ang.cos(), arc.center.y + r * ang.sin())
+}

--- a/survey_cad/tests/stakeout.rs
+++ b/survey_cad/tests/stakeout.rs
@@ -1,0 +1,22 @@
+use survey_cad::alignment::{HorizontalAlignment, HorizontalElement};
+use survey_cad::geometry::{Arc, Point};
+use survey_cad::surveying::stakeout_position;
+
+#[test]
+fn tangent_offset() {
+    let halign = HorizontalAlignment::new(vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+    let p = stakeout_position(&halign, 5.0, 1.0).unwrap();
+    assert!((p.x - 5.0).abs() < 1e-6);
+    assert!((p.y - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn curve_radial() {
+    let arc = Arc::new(Point::new(0.0, 0.0), 5.0, 0.0, std::f64::consts::FRAC_PI_2);
+    let halign = HorizontalAlignment { elements: vec![HorizontalElement::Curve { arc }] };
+    let len = arc.length();
+    let p = stakeout_position(&halign, len / 2.0, 1.0).unwrap();
+    let ang = std::f64::consts::FRAC_PI_4; // half sweep
+    assert!((p.x - 6.0 * ang.cos()).abs() < 1e-6);
+    assert!((p.y - 6.0 * ang.sin()).abs() < 1e-6);
+}


### PR DESCRIPTION
## Summary
- add new `stakeout` module with alignment offset/radial computations
- expose `stakeout_position` from surveying utilities
- test stakeout against tangents and curves

## Testing
- `cargo test -p survey_cad stakeout_position -q` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6844e89116a08328a58c8d8f7db24b4d