### PR TITLE
Add least squares adjustment utilities

### DIFF
--- a/survey_cad/src/surveying/least_squares.rs
+++ b/survey_cad/src/surveying/least_squares.rs
@@ -1,0 +1,112 @@
+// General least squares utilities with support for constraint equations and datum stabilization.
+// Provides parametric, conditional and free-network adjustment options.
+
+use nalgebra::{DMatrix, DVector, SVD};
+
+/// Result of a least squares computation.
+#[derive(Debug)]
+pub struct LSResult {
+    pub parameters: DVector<f64>,
+    pub residuals: DVector<f64>,
+}
+
+fn pseudoinverse(m: &DMatrix<f64>, tol: f64) -> DMatrix<f64> {
+    let svd = SVD::new(m.clone(), true, true);
+    let mut s_inv = svd.singular_values.clone();
+    for val in s_inv.iter_mut() {
+        if *val > tol {
+            *val = 1.0 / *val;
+        } else {
+            *val = 0.0;
+        }
+    }
+    let u = svd.u.unwrap();
+    let vt = svd.v_t.unwrap();
+    vt.transpose() * DMatrix::from_diagonal(&s_inv) * u.transpose()
+}
+
+/// Performs a parametric least squares adjustment.
+///
+/// `a` - design matrix relating parameters to observations
+/// `l` - misclosure vector (observed - computed)
+/// `w` - weight matrix (full support)
+/// `constraint` - optional pair `(c, d)` for constraint equations `c * x = d`
+pub fn parametric_ls(
+    a: &DMatrix<f64>,
+    l: &DVector<f64>,
+    w: &DMatrix<f64>,
+    constraint: Option<(&DMatrix<f64>, &DVector<f64>)>,
+) -> Option<LSResult> {
+    let at = a.transpose();
+    let n = &at * w * a;
+    let u = &at * w * l;
+
+    if let Some((c, d)) = constraint {
+        let m = n.nrows();
+        let k = c.nrows();
+        let mut mtx = DMatrix::<f64>::zeros(m + k, m + k);
+        mtx.slice_mut((0, 0), (m, m)).copy_from(&n);
+        mtx.slice_mut((0, m), (m, k)).copy_from(&c.transpose());
+        mtx.slice_mut((m, 0), (k, m)).copy_from(c);
+        let mut rhs = DVector::<f64>::zeros(m + k);
+        rhs.rows_mut(0, m).copy_from(&u);
+        rhs.rows_mut(m, k).copy_from(d);
+        let sol = mtx.clone().lu().solve(&rhs).or_else(|| {
+            let pinv = pseudoinverse(&mtx, 1e-12);
+            Some(pinv * rhs)
+        })?;
+        let x = sol.rows(0, m).into_owned();
+        let v = a * &x - l;
+        Some(LSResult { parameters: x, residuals: v })
+    } else {
+        let sol = n.clone().lu().solve(&u).or_else(|| {
+            let pinv = pseudoinverse(&n, 1e-12);
+            Some(pinv * u)
+        })?;
+        let v = a * &sol - l;
+        Some(LSResult { parameters: sol, residuals: v })
+    }
+}
+
+/// Performs a conditional least squares adjustment returning the observation corrections.
+///
+/// `b` - coefficient matrix of the condition equations
+/// `w_vec` - right-hand side of the linearized conditions
+/// `p` - weight matrix of the observations
+pub fn conditional_ls(
+    b: &DMatrix<f64>,
+    w_vec: &DVector<f64>,
+    p: &DMatrix<f64>,
+) -> Option<DVector<f64>> {
+    let n = b * p * b.transpose();
+    let rhs = w_vec.clone();
+    let lambda = n.clone().lu().solve(&rhs).or_else(|| {
+        let pinv = pseudoinverse(&n, 1e-12);
+        Some(pinv * rhs)
+    })?;
+    let v = -p * b.transpose() * lambda;
+    Some(v)
+}
+
+/// Adjusts a free network applying simple centroid constraints for datum stabilization.
+pub fn free_network_ls(
+    a: &DMatrix<f64>,
+    l: &DVector<f64>,
+    w: &DMatrix<f64>,
+) -> Option<LSResult> {
+    let m = a.ncols();
+    if m < 2 {
+        return parametric_ls(a, l, w, None);
+    }
+    // constraints: sum dx = 0, sum dy = 0 for translation, and rotation about centroid
+    let mut c = DMatrix::<f64>::zeros(3, m);
+    for i in 0..(m/2) {
+        c[(0, 2*i)] = 1.0;
+        c[(1, 2*i + 1)] = 1.0;
+        let x = i as f64;
+        c[(2, 2*i)] = -x;
+        c[(2, 2*i + 1)] = 0.0;
+    }
+    let d = DVector::<f64>::zeros(3);
+    parametric_ls(a, l, w, Some((&c, &d)))
+}

--- a/survey_cad/src/surveying/mod.rs
+++ b/survey_cad/src/surveying/mod.rs
@@ -8,6 +8,11 @@ pub use cogo::{bearing, forward, line_intersection};
 pub mod adjustment;
 pub use adjustment::{adjust_network, AdjustResult, Observation};
 
+pub mod least_squares;
+pub use least_squares::{
+    LSResult, conditional_ls, free_network_ls, parametric_ls,
+};
+
 pub mod field_code;
 pub use field_code::{CodeAction, FieldCode};
 

--- a/survey_cad/tests/lsq.rs
+++ b/survey_cad/tests/lsq.rs
@@ -1,0 +1,25 @@
+use survey_cad::surveying::least_squares::{parametric_ls, conditional_ls};
+use nalgebra::{DMatrix, DVector};
+
+#[test]
+fn parametric_basic() {
+    // Solve x1 + x2 = 3, x1 - x2 = 1
+    let a = DMatrix::from_row_slice(2, 2, &[1.0, 1.0, 1.0, -1.0]);
+    let l = DVector::from_vec(vec![3.0, 1.0]);
+    let w = DMatrix::identity(2, 2);
+    let res = parametric_ls(&a, &l, &w, None).unwrap();
+    assert!((res.parameters[0] - 2.0).abs() < 1e-6);
+    assert!((res.parameters[1] - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn conditional_basic() {
+    // Condition: x1 + x2 = 0 with observations x1=1, x2=-2
+    let b = DMatrix::from_row_slice(1, 2, &[1.0, 1.0]);
+    let wv = DVector::from_vec(vec![1.0 + -2.0]);
+    let p = DMatrix::identity(2, 2);
+    let v = conditional_ls(&b, &wv, &p).unwrap();
+    // Corrections should move to x1=-0.5, x2=-0.5 => v1=-1.5, v2=1.5
+    assert!((v[0] + 1.5).abs() < 1e-6);
+    assert!((v[1] - 1.5).abs() < 1e-6);
+}


### PR DESCRIPTION
## Summary
- add module `least_squares` implementing general parametric, conditional and free-network solvers
- expose new helpers from surveying module
- provide tests for parametric and conditional adjustments

## Testing
- `cargo test -p survey_cad --quiet` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6844f1fa5c5483288a47bb36657de6cb