### PR TITLE
Implement redundancy diagnostics

### DIFF
--- a/survey_cad/src/surveying/least_squares.rs
+++ b/survey_cad/src/surveying/least_squares.rs
@@ -10,6 +10,19 @@ pub struct LSResult {
     pub residuals: DVector<f64>,
 }
 
+/// Diagnostic information for a least squares solution.
+#[derive(Debug)]
+pub struct LSAnalysis {
+    /// Posterior variance factor of the adjustment.
+    pub variance_factor: f64,
+    /// Variance-covariance matrix of the estimated parameters.
+    pub param_covariance: DMatrix<f64>,
+    /// Redundancy numbers for each observation.
+    pub redundancy_numbers: DVector<f64>,
+    /// Studentized residuals for each observation.
+    pub studentized_residuals: DVector<f64>,
+}
+
 fn pseudoinverse(m: &DMatrix<f64>, tol: f64) -> DMatrix<f64> {
     let svd = SVD::new(m.clone(), true, true);
     let mut s_inv = svd.singular_values.clone();
@@ -57,14 +70,20 @@ pub fn parametric_ls(
         })?;
         let x = sol.rows(0, m).into_owned();
         let v = a * &x - l;
-        Some(LSResult { parameters: x, residuals: v })
+        Some(LSResult {
+            parameters: x,
+            residuals: v,
+        })
     } else {
         let sol = n.clone().lu().solve(&u).or_else(|| {
             let pinv = pseudoinverse(&n, 1e-12);
             Some(pinv * u)
         })?;
         let v = a * &sol - l;
-        Some(LSResult { parameters: sol, residuals: v })
+        Some(LSResult {
+            parameters: sol,
+            residuals: v,
+        })
     }
 }
 
@@ -89,24 +108,66 @@ pub fn conditional_ls(
 }
 
 /// Adjusts a free network applying simple centroid constraints for datum stabilization.
-pub fn free_network_ls(
-    a: &DMatrix<f64>,
-    l: &DVector<f64>,
-    w: &DMatrix<f64>,
-) -> Option<LSResult> {
+pub fn free_network_ls(a: &DMatrix<f64>, l: &DVector<f64>, w: &DMatrix<f64>) -> Option<LSResult> {
     let m = a.ncols();
     if m < 2 {
         return parametric_ls(a, l, w, None);
     }
     // constraints: sum dx = 0, sum dy = 0 for translation, and rotation about centroid
     let mut c = DMatrix::<f64>::zeros(3, m);
-    for i in 0..(m/2) {
-        c[(0, 2*i)] = 1.0;
-        c[(1, 2*i + 1)] = 1.0;
+    for i in 0..(m / 2) {
+        c[(0, 2 * i)] = 1.0;
+        c[(1, 2 * i + 1)] = 1.0;
         let x = i as f64;
-        c[(2, 2*i)] = -x;
-        c[(2, 2*i + 1)] = 0.0;
+        c[(2, 2 * i)] = -x;
+        c[(2, 2 * i + 1)] = 0.0;
     }
     let d = DVector::<f64>::zeros(3);
     parametric_ls(a, l, w, Some((&c, &d)))
+}
+
+/// Computes redundancy numbers, parameter covariance and studentized residuals
+/// for a least squares adjustment.
+pub fn redundancy_analysis(
+    a: &DMatrix<f64>,
+    residuals: &DVector<f64>,
+    w: &DMatrix<f64>,
+) -> Option<LSAnalysis> {
+    let m = a.nrows();
+    let n = a.ncols();
+    if m <= n {
+        return None;
+    }
+    let at = a.transpose();
+    let nmat = &at * w * a;
+    let q_xx = pseudoinverse(&nmat, 1e-12);
+
+    let w_inv = pseudoinverse(w, 1e-12);
+    let q_vv = &w_inv - a * &q_xx * at;
+
+    // posterior variance factor
+    let vtpv = residuals.transpose() * w * residuals;
+    let sigma2 = vtpv[(0, 0)] / (m - n) as f64;
+
+    let param_cov = &q_xx * sigma2;
+
+    let mut rnums = DVector::<f64>::zeros(m);
+    let mut stud = DVector::<f64>::zeros(m);
+    for i in 0..m {
+        let qvv = q_vv[(i, i)];
+        rnums[i] = w[(i, i)] * qvv;
+        let sd = (sigma2 * qvv).sqrt();
+        stud[i] = if sd.abs() < 1e-12 {
+            0.0
+        } else {
+            residuals[i] / sd
+        };
+    }
+
+    Some(LSAnalysis {
+        variance_factor: sigma2,
+        param_covariance: param_cov,
+        redundancy_numbers: rnums,
+        studentized_residuals: stud,
+    })
 }

--- a/survey_cad/src/surveying/mod.rs
+++ b/survey_cad/src/surveying/mod.rs
@@ -10,7 +10,7 @@ pub use adjustment::{adjust_network, AdjustResult, Observation};
 
 pub mod least_squares;
 pub use least_squares::{
-    LSResult, conditional_ls, free_network_ls, parametric_ls,
+    conditional_ls, free_network_ls, parametric_ls, redundancy_analysis, LSAnalysis, LSResult,
 };
 
 pub mod field_code;
@@ -24,8 +24,7 @@ pub use point_db::{PointDatabase, SurveyPoint};
 
 pub mod observation_db;
 pub use observation_db::{
-    ObservationDB, ObservationRecord, ObsType, ObservationData, QueryFilter,
-    TraverseLeg,
+    ObsType, ObservationDB, ObservationData, ObservationRecord, QueryFilter, TraverseLeg,
 };
 
 pub mod stakeout;

--- a/survey_cad/tests/lsq.rs
+++ b/survey_cad/tests/lsq.rs
@@ -1,5 +1,5 @@
-use survey_cad::surveying::least_squares::{parametric_ls, conditional_ls};
 use nalgebra::{DMatrix, DVector};
+use survey_cad::surveying::least_squares::{conditional_ls, parametric_ls, redundancy_analysis};
 
 #[test]
 fn parametric_basic() {
@@ -22,4 +22,19 @@ fn conditional_basic() {
     // Corrections should move to x1=-0.5, x2=-0.5 => v1=-1.5, v2=1.5
     assert!((v[0] + 1.5).abs() < 1e-6);
     assert!((v[1] - 1.5).abs() < 1e-6);
+}
+
+#[test]
+fn redundancy_analysis_basic() {
+    // Simple system with one redundant observation
+    let a = DMatrix::from_row_slice(3, 2, &[1.0, 0.0, 0.0, 1.0, 1.0, 1.0]);
+    let l = DVector::from_vec(vec![2.0, 3.0, 5.1]);
+    let w = DMatrix::identity(3, 3);
+    let res = parametric_ls(&a, &l, &w, None).unwrap();
+    let stats = redundancy_analysis(&a, &res.residuals, &w).unwrap();
+    let r_sum: f64 = stats.redundancy_numbers.iter().sum();
+    assert!((r_sum - 1.0).abs() < 1e-6);
+    assert!(stats.studentized_residuals[0] > 0.9);
+    assert!(stats.studentized_residuals[2] < -0.9);
+    assert!(stats.param_covariance[(0, 0)] > 0.0);
 }


### PR DESCRIPTION
## Summary
- add `LSAnalysis` to hold diagnostics for least squares solutions
- compute redundancy numbers, parameter covariance and studentized residuals in new `redundancy_analysis` function
- export the new utilities via `surveying` module
- test redundancy analysis

## Testing
- `cargo test -p survey_cad --no-default-features` *(fails: couldn't compile all crates within the time limit)*

------
https://chatgpt.com/codex/tasks/task_e_6844fdc9f6308328a64227ca705d34a9