### PR TITLE
Implement adjustment report

### DIFF
--- a/survey_cad/src/surveying/mod.rs
+++ b/survey_cad/src/surveying/mod.rs
@@ -6,7 +6,14 @@ pub mod cogo;
 pub use cogo::{bearing, forward, line_intersection};
 
 pub mod adjustment;
-pub use adjustment::{adjust_network, AdjustResult, Observation};
+pub use adjustment::{
+    adjust_network,
+    adjust_network_report,
+    AdjustResult,
+    AdjustReport,
+    IterationRecord,
+    Observation,
+};
 
 pub mod least_squares;
 pub use least_squares::{

--- a/survey_cad_cli/src/main.rs
+++ b/survey_cad_cli/src/main.rs
@@ -659,7 +659,7 @@ fn main() {
             observations,
         } => {
             use std::collections::HashMap;
-            use survey_cad::surveying::{adjust_network, Observation};
+            use survey_cad::surveying::{adjust_network_report, Observation};
             match (read_lines(&points), read_lines(&observations)) {
                 (Ok(p_lines), Ok(o_lines)) => {
                     let mut names = Vec::new();
@@ -734,7 +734,9 @@ fn main() {
                             }
                         }
                     }
-                    let result = adjust_network(&pts, &fixed, &obs);
+                    let (result, report) =
+                        adjust_network_report(&pts, &fixed, &obs, 1e-6, 10);
+                    println!("iterations: {}", report.iterations.len());
                     for (name, p) in names.iter().zip(result.points.iter()) {
                         println!("{}, {:.3}, {:.3}", name, p.x, p.y);
                     }


### PR DESCRIPTION
## Summary
- add new `IterationRecord` and `AdjustReport` structures
- implement `adjust_network_report` for iterative adjustment diagnostics
- export new API through `surveying` module
- extend CLI network adjust command to show iteration count

## Testing
- `cargo check -p survey_cad --lib --no-default-features` *(fails: build timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684501e708a083288cb74167e69e21be