### PR TITLE
Add TIN tools and multi-surface management

### DIFF
--- a/cad_import/src/lib.rs
+++ b/cad_import/src/lib.rs
@@ -299,11 +299,11 @@ mod tests {
         use std::fs::write;
 
         let content = "1,100.0,200.0,50.0,TEST";
-        let brands = [
-            ("leica.raw", instrument::read_leica_raw as fn(&str) -> _),
-            ("trimble.raw", instrument::read_trimble_raw as fn(&str) -> _),
-            ("topcon.raw", instrument::read_topcon_raw as fn(&str) -> _),
-            ("sokkia.raw", instrument::read_sokkia_raw as fn(&str) -> _),
+        let brands: [(&str, fn(&str) -> io::Result<Vec<SurveyPoint>>); 4] = [
+            ("leica.raw", instrument::read_leica_raw),
+            ("trimble.raw", instrument::read_trimble_raw),
+            ("topcon.raw", instrument::read_topcon_raw),
+            ("sokkia.raw", instrument::read_sokkia_raw),
         ];
         for (name, func) in brands {
             let path = temp_dir().join(name);


### PR DESCRIPTION
## Summary
- support reading raw brand files in cad_import tests by giving the array a concrete type
- add `merge_with` for merging surfaces with tolerance
- allow breakline insertion on `DynamicTin`
- provide a `TinManager` container for managing multiple TINs
- track multiple surfaces in the GUI

## Testing
- `cargo test -p cad_import --no-run` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6845a06b4af08328b778a2fbd82bc3ad