### PR TITLE
Add cut/fill and mass haul tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Compute cut/fill volume along an alignment:
 $ cargo run -p survey_cad_cli -- corridor-volume design.csv ground.csv halign.csv valign.csv 10.0 --interval 10.0 --offset-step 1.0
 ```
 
+Generate a mass haul diagram:
+
+```bash
+$ cargo run -p survey_cad_cli -- mass-haul design.csv ground.csv halign.csv valign.csv 10.0 --interval 10.0 --offset-step 1.0
+```
+
 ## Continuous Integration
 
 GitHub Actions automatically runs `cargo clippy` and `cargo test` for every push

--- a/survey_cad/tests/corridor_cut_fill.rs
+++ b/survey_cad/tests/corridor_cut_fill.rs
@@ -1,0 +1,32 @@
+use survey_cad::{
+    alignment::{Alignment, HorizontalAlignment, VerticalAlignment},
+    corridor::{corridor_cut_fill, corridor_mass_haul},
+    dtm::Tin,
+    geometry::{Point, Point3},
+};
+
+#[test]
+fn cut_fill_prism_fill_only() {
+    let design = Tin::from_points(vec![
+        Point3::new(0.0, -1.0, 1.0),
+        Point3::new(0.0, 1.0, 1.0),
+        Point3::new(10.0, -1.0, 1.0),
+        Point3::new(10.0, 1.0, 1.0),
+    ]);
+    let ground = Tin::from_points(vec![
+        Point3::new(0.0, -1.0, 0.0),
+        Point3::new(0.0, 1.0, 0.0),
+        Point3::new(10.0, -1.0, 0.0),
+        Point3::new(10.0, 1.0, 0.0),
+    ]);
+    let hal = HorizontalAlignment::new(vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+    let val = VerticalAlignment::new(vec![(0.0, 0.0), (10.0, 0.0)]);
+    let align = Alignment::new(hal, val);
+    let (cut, fill) = corridor_cut_fill(&design, &ground, &align, 1.0, 10.0, 1.0);
+    assert!(cut.abs() < 1e-6);
+    assert!((fill - 20.0).abs() < 1e-6);
+
+    let haul = corridor_mass_haul(&design, &ground, &align, 1.0, 10.0, 1.0);
+    assert_eq!(haul.len(), 2);
+    assert!((haul.last().unwrap().1 - 20.0).abs() < 1e-6);
+}


### PR DESCRIPTION
## Summary
- support symmetric cut/fill computation between TIN surfaces
- add corridor cut/fill and mass haul utilities
- expose mass haul command in CLI
- document mass haul usage
- test new volume functions

## Testing
- `cargo test` *(fails: couldn't finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6845ad1debd48328876d3f0bc12959c2