### PR TITLE
Add corridor station volume reporting

### DIFF
--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -33,6 +33,9 @@ tempfile = "3.10"
 fresnel = "0.1"
 uuid = { version = "1", optional = true }
 
+[dev-dependencies]
+assert_fs = "1"
+
 [features]
 default = []
 render = ["dep:bevy", "dep:bevy_editor_cam", "dep:bevy_picking"]

--- a/survey_cad/src/geometry/mod.rs
+++ b/survey_cad/src/geometry/mod.rs
@@ -261,6 +261,26 @@ impl Polyline {
         }
     }
 
+    /// Returns the closest point on the polyline to `p`.
+    pub fn nearest_point(&self, p: Point) -> Point {
+        if self.vertices.len() == 1 {
+            return self.vertices[0];
+        }
+
+        let mut nearest = self.vertices[0];
+        let mut best_dist = f64::MAX;
+        for pair in self.vertices.windows(2) {
+            let line = Line::new(pair[0], pair[1]);
+            let pt = line.nearest_point(p);
+            let d = distance(p, pt);
+            if d < best_dist {
+                best_dist = d;
+                nearest = pt;
+            }
+        }
+        nearest
+    }
+
     /// Returns a smoothed version of the polyline using Chaikin's algorithm.
     /// The number of `iterations` controls how many times the refinement is
     /// applied. Values less than 1 return the original polyline.
@@ -356,6 +376,15 @@ mod tests {
         assert!((p.x - 5.0).abs() < 1e-6 && p.y.abs() < 1e-6);
         let dir = pl.direction_at(5.0).unwrap();
         assert!((dir.0 - 1.0).abs() < 1e-6 && dir.1.abs() < 1e-6);
+    }
+
+    #[test]
+    fn polyline_nearest_point() {
+        let pts = vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)];
+        let pl = Polyline::new(pts);
+        let q = Point::new(5.0, 3.0);
+        let n = pl.nearest_point(q);
+        assert!((n.x - 5.0).abs() < 1e-6 && n.y.abs() < 1e-6);
     }
 
     #[test]

--- a/survey_cad/tests/corridor_station_volumes.rs
+++ b/survey_cad/tests/corridor_station_volumes.rs
@@ -1,0 +1,30 @@
+use survey_cad::{
+    alignment::{Alignment, HorizontalAlignment, VerticalAlignment},
+    corridor::{corridor_station_volumes},
+    dtm::Tin,
+    geometry::{Point, Point3},
+};
+
+#[test]
+fn station_volumes_prism() {
+    let design = Tin::from_points(vec![
+        Point3::new(0.0, -1.0, 1.0),
+        Point3::new(0.0, 1.0, 1.0),
+        Point3::new(10.0, -1.0, 1.0),
+        Point3::new(10.0, 1.0, 1.0),
+    ]);
+    let ground = Tin::from_points(vec![
+        Point3::new(0.0, -1.0, 0.0),
+        Point3::new(0.0, 1.0, 0.0),
+        Point3::new(10.0, -1.0, 0.0),
+        Point3::new(10.0, 1.0, 0.0),
+    ]);
+    let hal = HorizontalAlignment::new(vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+    let val = VerticalAlignment::new(vec![(0.0, 0.0), (10.0, 0.0)]);
+    let align = Alignment::new(hal, val);
+    let vols = corridor_station_volumes(&design, &ground, &align, 1.0, 10.0, 1.0);
+    assert_eq!(vols.len(), 2);
+    let last = vols.last().unwrap();
+    assert!((last.cumulative - 20.0).abs() < 1e-6);
+    assert!(last.haul > 0.0);
+}

--- a/survey_cad/tests/cross_section_sheet.rs
+++ b/survey_cad/tests/cross_section_sheet.rs
@@ -1,0 +1,31 @@
+use survey_cad::{
+    alignment::{Alignment, HorizontalAlignment, VerticalAlignment},
+    corridor::{Subassembly, extract_design_cross_sections},
+    sheet::write_cross_section_sheet_svg,
+    geometry::Point,
+};
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+
+#[test]
+fn write_sheet_svg() {
+    let hal = HorizontalAlignment::new(vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+    let val = VerticalAlignment::new(vec![(0.0, 0.0), (10.0, 0.0)]);
+    let align = Alignment::new(hal, val);
+    let subs = vec![Subassembly::new(vec![(-1.0, 0.0), (1.0, 0.0)])];
+    let sections = extract_design_cross_sections(&align, &subs, None, 10.0);
+    let dir = assert_fs::TempDir::new().unwrap();
+    let file = dir.child("sheet.svg");
+    write_cross_section_sheet_svg(
+        file.path().to_str().unwrap(),
+        &align,
+        &sections,
+        40.0,
+        10.0,
+        10.0,
+        5.0,
+    )
+    .unwrap();
+    file.assert(predicate::path::exists());
+    dir.close().unwrap();
+}


### PR DESCRIPTION
## Summary
- add Polyline::nearest_point utility
- implement per-station earthwork volume calculations and haul distance
- output cross-section sheets with match lines
- tests for new volume reporting and sheet output

## Testing
- `cargo test` *(fails: `cargo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845c1a8551483288a130d3222976114