### PR TITLE
Implement stakeout utilities

### DIFF
--- a/survey_cad/src/surveying/mod.rs
+++ b/survey_cad/src/surveying/mod.rs
@@ -7,12 +7,7 @@ pub use cogo::{bearing, forward, line_intersection};
 
 pub mod adjustment;
 pub use adjustment::{
-    adjust_network,
-    adjust_network_report,
-    AdjustResult,
-    AdjustReport,
-    IterationRecord,
-    Observation,
+    adjust_network, adjust_network_report, AdjustReport, AdjustResult, IterationRecord, Observation,
 };
 
 pub mod least_squares;
@@ -35,7 +30,7 @@ pub use observation_db::{
 };
 
 pub mod stakeout;
-pub use stakeout::stakeout_position;
+pub use stakeout::{grid_stakeout_points, optimal_stationing, stakeout_position};
 
 /// Representation of a simple survey station.
 #[derive(Debug)]

--- a/survey_cad/tests/stakeout.rs
+++ b/survey_cad/tests/stakeout.rs
@@ -1,6 +1,6 @@
 use survey_cad::alignment::{HorizontalAlignment, HorizontalElement};
 use survey_cad::geometry::{Arc, Point};
-use survey_cad::surveying::stakeout_position;
+use survey_cad::surveying::{grid_stakeout_points, optimal_stationing, stakeout_position};
 
 #[test]
 fn tangent_offset() {
@@ -19,4 +19,18 @@ fn curve_radial() {
     let ang = std::f64::consts::FRAC_PI_4; // half sweep
     assert!((p.x - 6.0 * ang.cos()).abs() < 1e-6);
     assert!((p.y - 6.0 * ang.sin()).abs() < 1e-6);
+}
+
+#[test]
+fn optimal_stationing_alignment() {
+    let halign = HorizontalAlignment::new(vec![Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+    let stas = optimal_stationing(&halign, 3.0);
+    assert_eq!(stas, vec![0.0, 3.0, 6.0, 9.0, 10.0]);
+}
+
+#[test]
+fn grid_points_simple() {
+    let pts = grid_stakeout_points(Point::new(0.0, 0.0), Point::new(2.0, 2.0), 1.0);
+    assert_eq!(pts.len(), 9);
+    assert!(pts.contains(&Point::new(1.0, 1.0)));
 }


### PR DESCRIPTION
## Summary
- add optimal stationing and grid stakeout functions
- support writing GNSS CSV and RAW formats
- expose new functions via surveying module
- add stakeout subcommand to CLI
- test stakeout utilities and exporters

## Testing
- `cargo test --all` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*

------
https://chatgpt.com/codex/tasks/task_e_6845c4d776f08328af7e7cbe23474716