### PR TITLE
Implement breakline extraction & mesh reconstruction

### DIFF
--- a/survey_cad/src/lib.rs
+++ b/survey_cad/src/lib.rs
@@ -26,5 +26,7 @@ pub mod truck_integration;
 pub mod variable_offset;
 pub mod workspace;
 
-pub use lidar::{classify_points, filter_noise, Classification};
+#[cfg(feature = "render")]
+pub use lidar::point_cloud_to_mesh;
+pub use lidar::{classify_points, extract_breaklines, filter_noise, Classification};
 pub use local_grid::LocalGrid;


### PR DESCRIPTION
## Summary
- expand lidar utilities with breakline detection
- generate textured meshes from point clouds
- re-export new APIs in `survey_cad`

## Testing
- `cargo check -p survey_cad --no-default-features`


------
https://chatgpt.com/codex/tasks/task_e_6845cd735cac8328a6a0272428f1ae4d