### PR TITLE
Add basic Python bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,7 +1677,7 @@ version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -2206,7 +2206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2719,6 +2719,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -2953,6 +2959,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,7 +2972,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3100,7 +3112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4083,6 +4095,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "parking_lot",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4434,7 +4509,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4447,7 +4522,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4762,6 +4837,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 name = "survey_cad"
 version = "0.1.0"
 dependencies = [
+ "assert_fs",
  "bevy",
  "bevy_editor_cam",
  "bevy_picking",
@@ -4813,6 +4889,14 @@ dependencies = [
  "bevy_editor_cam",
  "clap",
  "rfd",
+ "survey_cad",
+]
+
+[[package]]
+name = "survey_cad_python"
+version = "0.1.0"
+dependencies = [
+ "pyo3",
  "survey_cad",
 ]
 
@@ -4899,6 +4983,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4908,7 +4998,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5327,6 +5417,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5707,7 +5803,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "bevy_pmetra",
     "survey_cad_gui",
     "cad_import", "pipe_network",
+    "survey_cad_python",
 ]
 resolver = "2"
 

--- a/survey_cad_python/Cargo.toml
+++ b/survey_cad_python/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "survey_cad_python"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "survey_cad_python"
+crate-type = ["cdylib"]
+
+[dependencies]
+survey_cad = { path = "../survey_cad", default-features = false }
+pyo3 = { version = "0.21", features = ["extension-module"] }

--- a/survey_cad_python/src/lib.rs
+++ b/survey_cad_python/src/lib.rs
@@ -1,0 +1,51 @@
+use pyo3::prelude::*;
+use survey_cad::geometry::Point as CadPoint;
+use survey_cad::surveying::{station_distance as cad_station_distance, Station};
+
+#[pyclass]
+#[derive(Clone)]
+struct Point {
+    inner: CadPoint,
+}
+
+#[pymethods]
+impl Point {
+    #[new]
+    fn new(x: f64, y: f64) -> Self {
+        Self { inner: CadPoint::new(x, y) }
+    }
+
+    #[getter]
+    fn x(&self) -> f64 {
+        self.inner.x
+    }
+
+    #[setter]
+    fn set_x(&mut self, value: f64) {
+        self.inner.x = value;
+    }
+
+    #[getter]
+    fn y(&self) -> f64 {
+        self.inner.y
+    }
+
+    #[setter]
+    fn set_y(&mut self, value: f64) {
+        self.inner.y = value;
+    }
+}
+
+#[pyfunction]
+fn station_distance(a: &Point, b: &Point) -> f64 {
+    let sa = Station::new("a", a.inner);
+    let sb = Station::new("b", b.inner);
+    cad_station_distance(&sa, &sb)
+}
+
+#[pymodule]
+fn survey_cad_python(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_class::<Point>()?;
+    m.add_function(wrap_pyfunction!(station_distance, m)?)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add new crate `survey_cad_python` providing Python bindings via `pyo3`
- update workspace to include the new crate
- refresh lockfile with new dependencies

## Testing
- `cargo check -p survey_cad_python --release` *(fails: build aborted due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_6845ddcd2ce083288cf263fb8f0908cc