### PR TITLE
Add QA utilities and reporting skeleton

### DIFF
--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -10,6 +10,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 rusqlite = { version = "0.31", features = ["bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
+regex = "1"
 geojson = "0.24"
 bevy = { version = "0.15", default-features = false, features = ["bevy_winit", "bevy_sprite", "x11"], optional = true }
 bevy_editor_cam = { version = "0.5", optional = true }
@@ -32,6 +33,8 @@ nalgebra = { version = "0.32", default-features = false, features = ["std"] }
 tempfile = "3.10"
 fresnel = "0.1"
 uuid = { version = "1", optional = true }
+genpdf = { version = "0.2", optional = true }
+umya-spreadsheet = { version = "1.1", optional = true }
 
 [dev-dependencies]
 assert_fs = "1"
@@ -45,3 +48,4 @@ las = ["dep:las"]
 kml = ["dep:kml"]
 fgdb = ["dep:gdal"]
 e57 = ["dep:e57", "dep:uuid"]
+reporting = ["dep:genpdf", "dep:umya-spreadsheet"]

--- a/survey_cad/src/layers.rs
+++ b/survey_cad/src/layers.rs
@@ -73,4 +73,14 @@ impl LayerManager {
     {
         self.layers.values().filter(|l| predicate(l)).collect()
     }
+
+    /// Iterator over all layer names.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.layers.keys().map(|k| k.as_str())
+    }
+
+    /// Iterator over all layers.
+    pub fn iter(&self) -> impl Iterator<Item = &Layer> {
+        self.layers.values()
+    }
 }

--- a/survey_cad/src/lib.rs
+++ b/survey_cad/src/lib.rs
@@ -23,6 +23,9 @@ pub mod styles;
 pub mod subassembly;
 pub mod superelevation;
 pub mod surveying;
+pub mod qa;
+#[cfg(feature = "reporting")]
+pub mod reporting;
 pub mod truck_integration;
 pub mod variable_offset;
 pub mod workspace;

--- a/survey_cad/src/qa.rs
+++ b/survey_cad/src/qa.rs
@@ -1,0 +1,64 @@
+use regex::Regex;
+use crate::geometry::Point;
+use crate::layers::{LayerManager};
+use crate::geometry;
+
+/// Returns layer names that do not conform to `^[A-Z0-9_]+$`.
+pub fn check_layer_naming(mgr: &LayerManager) -> Vec<String> {
+    let re = Regex::new("^[A-Z0-9_]+$").unwrap();
+    mgr.names()
+        .filter(|name| !re.is_match(name))
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Returns names of used layers that are missing from the manager.
+pub fn check_layer_usage(mgr: &LayerManager, used: &[String]) -> Vec<String> {
+    used.iter()
+        .filter(|name| mgr.layer(name.as_str()).is_none())
+        .cloned()
+        .collect()
+}
+
+/// Finds point indices that are farther than `threshold` from any control point.
+pub fn coordinate_outliers(points: &[Point], control: &[Point], threshold: f64) -> Vec<(usize, f64)> {
+    points
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, p)| {
+            let min_dist = control
+                .iter()
+                .map(|c| geometry::distance(*p, *c))
+                .fold(f64::INFINITY, f64::min);
+            if min_dist > threshold {
+                Some((idx, min_dist))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layers::Layer;
+
+    #[test]
+    fn test_check_layer_naming() {
+        let mut mgr = LayerManager::new();
+        mgr.add_layer(Layer::new("GOOD_LAYER"));
+        mgr.add_layer(Layer::new("badLayer"));
+        let bad = check_layer_naming(&mgr);
+        assert_eq!(bad, vec!["badLayer".to_string()]);
+    }
+
+    #[test]
+    fn test_coordinate_outliers() {
+        let pts = vec![Point::new(0.0,0.0), Point::new(10.0,10.0)];
+        let ctl = vec![Point::new(0.1,0.1)];
+        let res = coordinate_outliers(&pts, &ctl, 1.0);
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].0, 1);
+    }
+}


### PR DESCRIPTION
## Summary
- implement basic QA module with layer name and coordinate checks
- add optional PDF/Excel reporting utilities
- expose new modules in library
- extend `LayerManager` with iterator helpers
- add dependencies for regex and reporting features

## Testing
- `cargo test -p survey_cad --quiet` *(fails: failed to compile due to environment or dependency issues)*

------
https://chatgpt.com/codex/tasks/task_e_68461a7975a88328a9ce2bc7289e6e80