### PR TITLE
Add workspace profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ Generate a mass haul diagram:
 $ cargo run -p survey_cad_cli -- mass-haul design.csv ground.csv halign.csv valign.csv 10.0 --interval 10.0 --offset-step 1.0
 ```
 
+## GUI Workspace Profiles
+
+The `survey_cad_gui` binary now accepts a `--profile` option to tailor the
+interface for different roles. Available profiles are `surveyor`, `engineer` and
+`gis`. The default profile is `surveyor`.
+
+```bash
+$ cargo run -p survey_cad_gui -- --profile engineer
+```
+
 ## Continuous Integration
 
 GitHub Actions automatically runs `cargo clippy` and `cargo test` for every push


### PR DESCRIPTION
## Summary
- add `WorkspaceProfile` enum and CLI option in GUI
- spawn toolbar and edit panel based on selected profile
- document new `--profile` flag

## Testing
- `cargo check -p survey_cad_gui` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68461d47cbfc8328930f92ccc5f63ca3