### PR TITLE
Add GUI themes and HiDPI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ interface for different roles. Available profiles are `surveyor`, `engineer` and
 $ cargo run -p survey_cad_gui -- --profile engineer
 ```
 
+The GUI also supports dark and light themes via the `--theme` option and
+automatically scales the interface based on monitor DPI.
+
+```bash
+$ cargo run -p survey_cad_gui -- --theme light
+```
+
 ## Continuous Integration
 
 GitHub Actions automatically runs `cargo clippy` and `cargo test` for every push


### PR DESCRIPTION
## Summary
- introduce light/dark themes for survey_cad_gui
- detect monitor DPI and scale the UI
- document new theme option in README

## Testing
- `cargo check -p survey_cad_gui` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684628ad80c883288d411d72cc972f18