### PR TITLE
Clean up cross-platform features

### DIFF
--- a/survey_cad/tests/shp_records.rs
+++ b/survey_cad/tests/shp_records.rs
@@ -1,22 +1,29 @@
 #[cfg(feature = "shapefile")]
-use survey_cad::io::shp::{
-    PointRecord, PolylineRecord, PolygonRecord,
-    write_point_records_shp, read_point_records_shp,
-    write_polyline_records_shp, read_polyline_records_shp,
-    write_polygon_records_shp, read_polygon_records_shp,
-};
+use shapefile::dbase::FieldValue;
 #[cfg(feature = "shapefile")]
 use survey_cad::geometry::{Point, Point3, Polyline};
-use shapefile::dbase::FieldValue;
+#[cfg(feature = "shapefile")]
+use survey_cad::io::shp::{
+    read_point_records_shp, read_polygon_records_shp, read_polyline_records_shp,
+    write_point_records_shp, write_polygon_records_shp, write_polyline_records_shp, PointRecord,
+    PolygonRecord, PolylineRecord,
+};
 
 #[cfg(feature = "shapefile")]
 #[test]
 fn point_record_roundtrip() {
-    use tempfile::NamedTempFile;
     use std::collections::BTreeMap;
+    use tempfile::NamedTempFile;
     let mut attrs = BTreeMap::new();
-    attrs.insert("Name".to_string(), FieldValue::Character(Some("Pt".to_string())));
-    let rec = PointRecord { geom: Point::new(1.0,2.0), geom_z: None, attrs };
+    attrs.insert(
+        "Name".to_string(),
+        FieldValue::Character(Some("Pt".to_string())),
+    );
+    let rec = PointRecord {
+        geom: Point::new(1.0, 2.0),
+        geom_z: None,
+        attrs,
+    };
     let file = NamedTempFile::new().unwrap();
     write_point_records_shp(file.path().to_str().unwrap(), &[rec.clone()]).unwrap();
     let records = read_point_records_shp(file.path().to_str().unwrap()).unwrap();
@@ -27,12 +34,16 @@ fn point_record_roundtrip() {
 #[cfg(feature = "shapefile")]
 #[test]
 fn polyline_record_roundtrip() {
-    use tempfile::NamedTempFile;
     use std::collections::BTreeMap;
+    use tempfile::NamedTempFile;
     let mut attrs = BTreeMap::new();
     attrs.insert("ID".to_string(), FieldValue::Numeric(Some(1.0)));
-    let pl = Polyline::new(vec![Point::new(0.0,0.0), Point::new(1.0,0.0)]);
-    let rec = PolylineRecord { geom: pl.clone(), geom_z: None, attrs };
+    let pl = Polyline::new(vec![Point::new(0.0, 0.0), Point::new(1.0, 0.0)]);
+    let rec = PolylineRecord {
+        geom: pl.clone(),
+        geom_z: None,
+        attrs,
+    };
     let file = NamedTempFile::new().unwrap();
     write_polyline_records_shp(file.path().to_str().unwrap(), &[rec.clone()]).unwrap();
     let records = read_polyline_records_shp(file.path().to_str().unwrap()).unwrap();
@@ -43,17 +54,21 @@ fn polyline_record_roundtrip() {
 #[cfg(feature = "shapefile")]
 #[test]
 fn polygon_record_roundtrip() {
-    use tempfile::NamedTempFile;
     use std::collections::BTreeMap;
+    use tempfile::NamedTempFile;
     let mut attrs = BTreeMap::new();
     attrs.insert("Val".to_string(), FieldValue::Integer(5));
     let poly = vec![
-        Point::new(0.0,0.0),
-        Point::new(1.0,0.0),
-        Point::new(1.0,1.0),
-        Point::new(0.0,0.0),
+        Point::new(0.0, 0.0),
+        Point::new(1.0, 0.0),
+        Point::new(1.0, 1.0),
+        Point::new(0.0, 0.0),
     ];
-    let rec = PolygonRecord { geom: poly.clone(), geom_z: None, attrs };
+    let rec = PolygonRecord {
+        geom: poly.clone(),
+        geom_z: None,
+        attrs,
+    };
     let file = NamedTempFile::new().unwrap();
     write_polygon_records_shp(file.path().to_str().unwrap(), &[rec.clone()]).unwrap();
     let records = read_polygon_records_shp(file.path().to_str().unwrap()).unwrap();

--- a/survey_cad_cli/src/main.rs
+++ b/survey_cad_cli/src/main.rs
@@ -472,6 +472,7 @@ enum Commands {
     #[cfg(feature = "e57")]
     ExportE57 { input: String, output: String },
     /// Filter noise from a CSV point cloud.
+    #[cfg(feature = "las")]
     FilterNoise {
         input: String,
         output: String,
@@ -481,6 +482,7 @@ enum Commands {
         min_neighbors: usize,
     },
     /// Classify a CSV point cloud into ground, vegetation and buildings.
+    #[cfg(feature = "las")]
     ClassifyCloud {
         input: String,
         output: String,
@@ -897,6 +899,7 @@ fn main() {
             },
             Err(e) => eprintln!("Error reading {}: {}", input, e),
         },
+        #[cfg(feature = "las")]
         Commands::FilterNoise {
             input,
             output,
@@ -913,6 +916,7 @@ fn main() {
             }
             Err(e) => eprintln!("Error reading {}: {}", input, e),
         },
+        #[cfg(feature = "las")]
         Commands::ClassifyCloud {
             input,
             output,


### PR DESCRIPTION
## Summary
- gate CLI commands requiring 3D CSV helpers behind `las` feature
- gate shapefile test imports with `shapefile` feature

## Testing
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test --no-run` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68462f4dcb6883288d42df8376d2a9c4