### PR TITLE
Install GDAL for gdal-sys builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
           profile: minimal
           override: true
       - uses: Swatinem/rust-cache@v2
+      - name: Install GDAL
+        run: sudo apt-get update && sudo apt-get install -y libgdal-dev
       - name: Build survey_cad_cli
         run: cargo build -p survey_cad_cli --release
       - name: Upload binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           override: true
           components: clippy
       - uses: Swatinem/rust-cache@v2
+      - name: Install GDAL
+        run: sudo apt-get update && sudo apt-get install -y libgdal-dev
       - name: Run cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Run cargo test


### PR DESCRIPTION
## Summary
- add libgdal-dev installation step in CI workflows

## Testing
- `cargo check --workspace --locked` *(fails: building dependencies exceeded time)*

------
https://chatgpt.com/codex/tasks/task_e_68463455133c8328bb422bf78a743d0f