### PR TITLE
Fix compile error with umya-spreadsheet

### DIFF
--- a/survey_cad/src/reporting.rs
+++ b/survey_cad/src/reporting.rs
@@ -22,7 +22,7 @@ fn write_excel(path: &str, rows: &[Vec<String>]) -> std::io::Result<()> {
     let ws = wb.get_sheet_mut(&0).unwrap();
     for (r_idx, row) in rows.iter().enumerate() {
         for (c_idx, val) in row.iter().enumerate() {
-            ws.get_cell_by_column_and_row_mut((c_idx + 1) as u32, (r_idx + 1) as u32)
+            ws.get_cell_mut((c_idx + 1, r_idx + 1))
                 .set_value(val);
         }
     }


### PR DESCRIPTION
## Summary
- adapt to updated umya-spreadsheet API

## Testing
- `cargo check -p survey_cad --features reporting --lib` *(fails: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68463fdfd2b08328badd7764ecf22b3a