### PR TITLE
Fix cell coordinate type

### DIFF
--- a/survey_cad/src/reporting.rs
+++ b/survey_cad/src/reporting.rs
@@ -22,7 +22,7 @@ fn write_excel(path: &str, rows: &[Vec<String>]) -> std::io::Result<()> {
     let ws = wb.get_sheet_mut(&0).unwrap();
     for (r_idx, row) in rows.iter().enumerate() {
         for (c_idx, val) in row.iter().enumerate() {
-            ws.get_cell_mut((c_idx + 1, r_idx + 1))
+            ws.get_cell_mut(((c_idx + 1) as u32, (r_idx + 1) as u32))
                 .set_value(val);
         }
     }


### PR DESCRIPTION
## Summary
- cast coordinates to `u32` for umya spreadsheet API

## Testing
- `cargo check -p survey_cad --features reporting --no-default-features` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6846b83232108328b2b4f5972aa8c545