### PR TITLE
Fix clippy warnings

### DIFF
--- a/survey_cad/src/dtm.rs
+++ b/survey_cad/src/dtm.rs
@@ -239,14 +239,9 @@ impl Tin {
         let mut verts = self.vertices.clone();
         let mut adj: Vec<Vec<usize>> = vec![Vec::new(); verts.len()];
         for tri in &self.triangles {
-            for i in 0..3 {
-                let a = tri[i];
-                for j in 0..3 {
-                    if i == j {
-                        continue;
-                    }
-                    let b = tri[j];
-                    if !adj[a].contains(&b) {
+            for &a in tri.iter() {
+                for &b in tri.iter() {
+                    if a != b && !adj[a].contains(&b) {
                         adj[a].push(b);
                     }
                 }

--- a/survey_cad/src/intersection.rs
+++ b/survey_cad/src/intersection.rs
@@ -284,9 +284,7 @@ pub fn intersection_alignment(a: &Alignment, b: &Alignment, radius: f64) -> Opti
         _ => return None,
     }
 
-    h_elems.push(HorizontalElement::Curve {
-        arc: curb.arc.clone(),
-    });
+    h_elems.push(HorizontalElement::Curve { arc: curb.arc });
 
     match b.horizontal.elements.first().unwrap() {
         HorizontalElement::Tangent { end, .. } => {

--- a/survey_cad/src/io/e57.rs
+++ b/survey_cad/src/io/e57.rs
@@ -26,7 +26,7 @@ pub fn read_points_e57(path: &str) -> io::Result<Vec<Point3>> {
 pub fn write_points_e57(path: &str, points: &[Point3]) -> io::Result<()> {
     let guid = Uuid::new_v4().to_string();
     let mut writer = E57Writer::from_file(path, &guid)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        .map_err(|e| io::Error::other(e))?;
     let prototype = vec![
         Record::CARTESIAN_X_F64,
         Record::CARTESIAN_Y_F64,
@@ -34,7 +34,7 @@ pub fn write_points_e57(path: &str, points: &[Point3]) -> io::Result<()> {
     ];
     let mut pc_writer = writer
         .add_pointcloud(&guid, prototype)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        .map_err(|e| io::Error::other(e))?;
     for p in points {
         let values = vec![
             RecordValue::Double(p.x),
@@ -42,10 +42,10 @@ pub fn write_points_e57(path: &str, points: &[Point3]) -> io::Result<()> {
             RecordValue::Double(p.z),
         ];
         pc_writer.add_point(values)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(|e| io::Error::other(e))?;
     }
     pc_writer.finalize()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        .map_err(|e| io::Error::other(e))?;
     writer.finalize()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        .map_err(|e| io::Error::other(e))
 }

--- a/survey_cad/src/io/fgdb.rs
+++ b/survey_cad/src/io/fgdb.rs
@@ -7,10 +7,10 @@ use gdal::Dataset;
 
 /// Reads Point features from an ESRI File Geodatabase layer.
 pub fn read_points_fgdb(path: &str, layer_name: &str) -> io::Result<Vec<Point>> {
-    let ds = Dataset::open(path).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let ds = Dataset::open(path).map_err(|e| io::Error::other(e))?;
     let mut layer = ds
         .layer_by_name(layer_name)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        .map_err(|e| io::Error::other(e))?;
     let mut pts = Vec::new();
     for feature in layer.features() {
         if let Some(geom) = feature.geometry() {

--- a/survey_cad/src/io/kml.rs
+++ b/survey_cad/src/io/kml.rs
@@ -50,5 +50,5 @@ pub fn write_points_kml(path: &str, points: &[Point]) -> io::Result<()> {
     };
     writer
         .write(&doc)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        .map_err(|e| io::Error::other(e))
 }

--- a/survey_cad/src/io/las.rs
+++ b/survey_cad/src/io/las.rs
@@ -22,14 +22,14 @@ pub fn write_points_las(path: &str, points: &[Point3]) -> io::Result<()> {
     builder.version = Version::new(1, 2);
     let header = builder
         .into_header()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        .map_err(|e| io::Error::other(e))?;
     let mut writer = Writer::from_path(path, header)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        .map_err(|e| io::Error::other(e))?;
     for p in points {
         let lp = LasPoint { x: p.x, y: p.y, z: p.z, ..Default::default() };
         writer
             .write_point(lp)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(|e| io::Error::other(e))?;
     }
-    writer.close().map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    writer.close().map_err(|e| io::Error::other(e))
 }

--- a/survey_cad/src/io/mod.rs
+++ b/survey_cad/src/io/mod.rs
@@ -557,14 +557,9 @@ pub fn write_dwg(path: &str, entities: &[DxfEntity]) -> io::Result<()> {
         .arg(tmp.path())
         .arg(path)
         .status()
-        .map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("failed to spawn dxf2dwg: {e}"),
-            )
-        })?;
+        .map_err(|e| io::Error::other(format!("failed to spawn dxf2dwg: {e}")))?;
     if !status.success() {
-        return Err(io::Error::new(io::ErrorKind::Other, "dxf2dwg failed"));
+        return Err(io::Error::other("dxf2dwg failed"));
     }
     Ok(())
 }
@@ -582,14 +577,9 @@ pub fn read_dwg(path: &str) -> io::Result<Vec<DxfEntity>> {
         .arg(path)
         .arg(tmp.path())
         .status()
-        .map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("failed to spawn dwg2dxf: {e}"),
-            )
-        })?;
+        .map_err(|e| io::Error::other(format!("failed to spawn dwg2dxf: {e}")))?;
     if !status.success() {
-        return Err(io::Error::new(io::ErrorKind::Other, "dwg2dxf failed"));
+        return Err(io::Error::other("dwg2dxf failed"));
     }
     read_dxf(tmp.path().to_str().unwrap())
 }

--- a/survey_cad/src/io/shp.rs
+++ b/survey_cad/src/io/shp.rs
@@ -33,6 +33,12 @@ pub struct PolygonRecord {
     pub attrs: BTreeMap<String, FieldValue>,
 }
 
+/// Output type for polylines with optional Z coordinates.
+pub type PolylineOutput = (Vec<crate::geometry::Polyline>, Option<Vec<Vec<Point3>>>);
+
+/// Output type for polygons with optional Z coordinates.
+pub type PolygonOutput = (Vec<Vec<Point>>, Option<Vec<Vec<Point3>>>);
+
 fn build_table_builder(attrs: &BTreeMap<String, FieldValue>) -> TableWriterBuilder {
     use std::convert::TryFrom;
     let mut builder = TableWriterBuilder::new();
@@ -163,7 +169,7 @@ pub fn write_points_shp(path: &str, points: &[Point], points_z: Option<&[Point3]
 /// Reads a shapefile containing PolyLine geometries and returns them as [`Polyline`] values.
 pub fn read_polylines_shp(
     path: &str,
-) -> io::Result<(Vec<crate::geometry::Polyline>, Option<Vec<Vec<Point3>>>)> {
+) -> io::Result<PolylineOutput> {
     let mut reader =
         ShapeReader::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     let mut lines = Vec::new();
@@ -239,7 +245,7 @@ pub fn write_polylines_shp(
 }
 
 /// Reads a shapefile containing Polygon geometries and returns them as vectors of [`Point`].
-pub fn read_polygons_shp(path: &str) -> io::Result<(Vec<Vec<Point>>, Option<Vec<Vec<Point3>>>)> {
+pub fn read_polygons_shp(path: &str) -> io::Result<PolygonOutput> {
     let mut reader =
         ShapeReader::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     let mut polys = Vec::new();

--- a/survey_cad/src/lidar.rs
+++ b/survey_cad/src/lidar.rs
@@ -99,10 +99,8 @@ pub fn extract_breaklines(
     slope_threshold: f64,
 ) -> Vec<(usize, usize)> {
     let mut lines = Vec::new();
-    for i in 0..points.len() {
-        let a = points[i];
-        for j in (i + 1)..points.len() {
-            let b = points[j];
+    for (i, &a) in points.iter().enumerate() {
+        for (j, &b) in points.iter().enumerate().skip(i + 1) {
             let dx = a.x - b.x;
             let dy = a.y - b.y;
             let horiz = (dx * dx + dy * dy).sqrt();


### PR DESCRIPTION
## Summary
- fix range-based loops and Arc clone
- use `io::Error::other` across IO helpers
- introduce type aliases to simplify shapefile result types

## Testing
- `cargo check` *(fails: warnings due to dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846be193a448328b99f760017dd5897