### PR TITLE
Fix clippy warnings

### DIFF
--- a/survey_cad/src/io/e57.rs
+++ b/survey_cad/src/io/e57.rs
@@ -1,12 +1,12 @@
 use crate::geometry::Point3;
 use e57::{E57Reader, E57Writer, Record, RecordValue};
-use uuid::Uuid;
 use std::io;
+use uuid::Uuid;
 
 /// Reads an E57 file and returns all point coordinates found in the file.
 pub fn read_points_e57(path: &str) -> io::Result<Vec<Point3>> {
-    let mut reader = E57Reader::from_file(path)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let mut reader =
+        E57Reader::from_file(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     let mut pts = Vec::new();
     for pc in reader.pointclouds() {
         let mut iter = reader
@@ -25,8 +25,7 @@ pub fn read_points_e57(path: &str) -> io::Result<Vec<Point3>> {
 /// Writes a list of 3D points to an E57 file.
 pub fn write_points_e57(path: &str, points: &[Point3]) -> io::Result<()> {
     let guid = Uuid::new_v4().to_string();
-    let mut writer = E57Writer::from_file(path, &guid)
-        .map_err(|e| io::Error::other(e))?;
+    let mut writer = E57Writer::from_file(path, &guid).map_err(io::Error::other)?;
     let prototype = vec![
         Record::CARTESIAN_X_F64,
         Record::CARTESIAN_Y_F64,
@@ -34,18 +33,15 @@ pub fn write_points_e57(path: &str, points: &[Point3]) -> io::Result<()> {
     ];
     let mut pc_writer = writer
         .add_pointcloud(&guid, prototype)
-        .map_err(|e| io::Error::other(e))?;
+        .map_err(io::Error::other)?;
     for p in points {
         let values = vec![
             RecordValue::Double(p.x),
             RecordValue::Double(p.y),
             RecordValue::Double(p.z),
         ];
-        pc_writer.add_point(values)
-            .map_err(|e| io::Error::other(e))?;
+        pc_writer.add_point(values).map_err(io::Error::other)?;
     }
-    pc_writer.finalize()
-        .map_err(|e| io::Error::other(e))?;
-    writer.finalize()
-        .map_err(|e| io::Error::other(e))
+    pc_writer.finalize().map_err(io::Error::other)?;
+    writer.finalize().map_err(io::Error::other)
 }

--- a/survey_cad/src/io/fgdb.rs
+++ b/survey_cad/src/io/fgdb.rs
@@ -7,10 +7,8 @@ use gdal::Dataset;
 
 /// Reads Point features from an ESRI File Geodatabase layer.
 pub fn read_points_fgdb(path: &str, layer_name: &str) -> io::Result<Vec<Point>> {
-    let ds = Dataset::open(path).map_err(|e| io::Error::other(e))?;
-    let mut layer = ds
-        .layer_by_name(layer_name)
-        .map_err(|e| io::Error::other(e))?;
+    let ds = Dataset::open(path).map_err(io::Error::other)?;
+    let mut layer = ds.layer_by_name(layer_name).map_err(io::Error::other)?;
     let mut pts = Vec::new();
     for feature in layer.features() {
         if let Some(geom) = feature.geometry() {

--- a/survey_cad/src/io/kml.rs
+++ b/survey_cad/src/io/kml.rs
@@ -1,9 +1,9 @@
 use crate::geometry::Point;
 use std::io;
 
+use geo_types::{Geometry, GeometryCollection};
 use kml::types::{Geometry as KmlGeometry, Placemark, Point as KmlPoint};
 use kml::{Kml, KmlReader, KmlWriter};
-use geo_types::{Geometry, GeometryCollection};
 
 /// Reads Point geometries from a KML or KMZ file.
 pub fn read_points_kml(path: &str) -> io::Result<Vec<Point>> {
@@ -48,7 +48,5 @@ pub fn write_points_kml(path: &str, points: &[Point]) -> io::Result<()> {
         attrs: Default::default(),
         elements: placemarks,
     };
-    writer
-        .write(&doc)
-        .map_err(|e| io::Error::other(e))
+    writer.write(&doc).map_err(io::Error::other)
 }

--- a/survey_cad/src/io/las.rs
+++ b/survey_cad/src/io/las.rs
@@ -1,5 +1,5 @@
 use crate::geometry::Point3;
-use las::{point::Point as LasPoint, Reader, Writer, point::Format, Builder, Version};
+use las::{point::Format, point::Point as LasPoint, Builder, Reader, Version, Writer};
 use std::io;
 
 /// Reads a LAS file and returns the contained points.
@@ -20,16 +20,16 @@ pub fn write_points_las(path: &str, points: &[Point3]) -> io::Result<()> {
     let mut builder = Builder::default();
     builder.point_format = Format::new(0).unwrap();
     builder.version = Version::new(1, 2);
-    let header = builder
-        .into_header()
-        .map_err(|e| io::Error::other(e))?;
-    let mut writer = Writer::from_path(path, header)
-        .map_err(|e| io::Error::other(e))?;
+    let header = builder.into_header().map_err(io::Error::other)?;
+    let mut writer = Writer::from_path(path, header).map_err(io::Error::other)?;
     for p in points {
-        let lp = LasPoint { x: p.x, y: p.y, z: p.z, ..Default::default() };
-        writer
-            .write_point(lp)
-            .map_err(|e| io::Error::other(e))?;
+        let lp = LasPoint {
+            x: p.x,
+            y: p.y,
+            z: p.z,
+            ..Default::default()
+        };
+        writer.write_point(lp).map_err(io::Error::other)?;
     }
-    writer.close().map_err(|e| io::Error::other(e))
+    writer.close().map_err(io::Error::other)
 }

--- a/survey_cad/src/io/shp.rs
+++ b/survey_cad/src/io/shp.rs
@@ -1,13 +1,13 @@
 use crate::geometry::{Point, Point3};
-use std::collections::BTreeMap;
+use crate::gis::Feature;
+use shapefile::dbase::TableWriterBuilder;
+use shapefile::dbase::{FieldName, FieldValue, Record};
 use shapefile::{
     Point as ShpPoint, PointZ as ShpPointZ, Polygon as ShpPolygon, PolygonRing, PolygonZ,
-    Polyline as ShpPolyline, PolylineZ, Shape, ShapeReader, ShapeWriter, Reader, Writer, NO_DATA,
+    Polyline as ShpPolyline, PolylineZ, Reader, Shape, ShapeReader, ShapeWriter, Writer, NO_DATA,
 };
-use shapefile::dbase::{FieldName, FieldValue, Record};
-use shapefile::dbase::TableWriterBuilder;
+use std::collections::BTreeMap;
 use std::io;
-use crate::gis::Feature;
 
 /// Record type for a point geometry and its attributes.
 #[derive(Debug, Clone, PartialEq)]
@@ -43,10 +43,12 @@ fn build_table_builder(attrs: &BTreeMap<String, FieldValue>) -> TableWriterBuild
     use std::convert::TryFrom;
     let mut builder = TableWriterBuilder::new();
     for (name, value) in attrs {
-        let field_name = FieldName::try_from(name.as_str()).unwrap_or_else(|_| FieldName::try_from("FIELD").unwrap());
+        let field_name = FieldName::try_from(name.as_str())
+            .unwrap_or_else(|_| FieldName::try_from("FIELD").unwrap());
         builder = match value {
-            FieldValue::Character(_) | FieldValue::Memo(_) =>
-                builder.add_character_field(field_name, 64),
+            FieldValue::Character(_) | FieldValue::Memo(_) => {
+                builder.add_character_field(field_name, 64)
+            }
             FieldValue::Numeric(_) => builder.add_numeric_field(field_name, 18, 5),
             FieldValue::Logical(_) => builder.add_logical_field(field_name),
             FieldValue::Integer(_) => builder.add_integer_field(field_name),
@@ -94,16 +96,27 @@ pub fn point_record_to_feature(rec: PointRecord, class: Option<String>) -> Featu
         .iter()
         .map(|(k, v)| (k.clone(), field_value_to_string(v)))
         .collect();
-    Feature { class, attributes: attrs, geometry: rec.geom }
+    Feature {
+        class,
+        attributes: attrs,
+        geometry: rec.geom,
+    }
 }
 
-pub fn polyline_record_to_feature(rec: PolylineRecord, class: Option<String>) -> Feature<crate::geometry::Polyline> {
+pub fn polyline_record_to_feature(
+    rec: PolylineRecord,
+    class: Option<String>,
+) -> Feature<crate::geometry::Polyline> {
     let attrs = rec
         .attrs
         .iter()
         .map(|(k, v)| (k.clone(), field_value_to_string(v)))
         .collect();
-    Feature { class, attributes: attrs, geometry: rec.geom }
+    Feature {
+        class,
+        attributes: attrs,
+        geometry: rec.geom,
+    }
 }
 
 pub fn polygon_record_to_feature(rec: PolygonRecord, class: Option<String>) -> Feature<Vec<Point>> {
@@ -112,7 +125,11 @@ pub fn polygon_record_to_feature(rec: PolygonRecord, class: Option<String>) -> F
         .iter()
         .map(|(k, v)| (k.clone(), field_value_to_string(v)))
         .collect();
-    Feature { class, attributes: attrs, geometry: rec.geom }
+    Feature {
+        class,
+        attributes: attrs,
+        geometry: rec.geom,
+    }
 }
 
 /// Reads a shapefile containing Point geometries and returns them as [`Point`] values.
@@ -145,31 +162,28 @@ pub fn read_points_shp(path: &str) -> io::Result<(Vec<Point>, Option<Vec<Point3>
 }
 
 /// Writes a list of [`Point`]s to a shapefile.
-pub fn write_points_shp(path: &str, points: &[Point], points_z: Option<&[Point3]>) -> io::Result<()> {
-    let mut writer =
-        ShapeWriter::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+pub fn write_points_shp(
+    path: &str,
+    points: &[Point],
+    points_z: Option<&[Point3]>,
+) -> io::Result<()> {
+    let mut writer = ShapeWriter::from_path(path).map_err(io::Error::other)?;
     if let Some(zpts) = points_z {
         for p in zpts {
             let shp = ShpPointZ::new(p.x, p.y, p.z, NO_DATA);
-            writer
-                .write_shape(&shp)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            writer.write_shape(&shp).map_err(io::Error::other)?;
         }
     } else {
         for p in points {
             let shp = ShpPoint { x: p.x, y: p.y };
-            writer
-                .write_shape(&shp)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            writer.write_shape(&shp).map_err(io::Error::other)?;
         }
     }
-    writer.finalize().map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    writer.finalize().map_err(io::Error::other)
 }
 
 /// Reads a shapefile containing PolyLine geometries and returns them as [`Polyline`] values.
-pub fn read_polylines_shp(
-    path: &str,
-) -> io::Result<PolylineOutput> {
+pub fn read_polylines_shp(path: &str) -> io::Result<PolylineOutput> {
     let mut reader =
         ShapeReader::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     let mut lines = Vec::new();
@@ -189,9 +203,14 @@ pub fn read_polylines_shp(
                 for part in pl.parts() {
                     let verts: Vec<Point> = part.iter().map(|p| Point::new(p.x, p.y)).collect();
                     match lines3 {
-                        Some(ref mut v3) => v3.push(part.iter().map(|p| Point3::new(p.x, p.y, p.z)).collect()),
+                        Some(ref mut v3) => {
+                            v3.push(part.iter().map(|p| Point3::new(p.x, p.y, p.z)).collect())
+                        }
                         None => {
-                            lines3 = Some(vec![part.iter().map(|p| Point3::new(p.x, p.y, p.z)).collect()]);
+                            lines3 = Some(vec![part
+                                .iter()
+                                .map(|p| Point3::new(p.x, p.y, p.z))
+                                .collect()]);
                         }
                     }
                     lines.push(crate::geometry::Polyline::new(verts));
@@ -209,8 +228,7 @@ pub fn write_polylines_shp(
     polylines: &[crate::geometry::Polyline],
     polylines_z: Option<&[Vec<Point3>]>,
 ) -> io::Result<()> {
-    let mut writer =
-        ShapeWriter::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let mut writer = ShapeWriter::from_path(path).map_err(io::Error::other)?;
     if let Some(pl3s) = polylines_z {
         for pl in pl3s {
             if pl.len() < 2 {
@@ -221,9 +239,7 @@ pub fn write_polylines_shp(
                 .map(|p| ShpPointZ::new(p.x, p.y, p.z, NO_DATA))
                 .collect();
             let shp_pl = PolylineZ::new(shp_pts);
-            writer
-                .write_shape(&shp_pl)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            writer.write_shape(&shp_pl).map_err(io::Error::other)?;
         }
     } else {
         for pl in polylines {
@@ -236,12 +252,10 @@ pub fn write_polylines_shp(
                 .map(|p| ShpPoint { x: p.x, y: p.y })
                 .collect();
             let shp_pl = ShpPolyline::new(shp_pts);
-            writer
-                .write_shape(&shp_pl)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            writer.write_shape(&shp_pl).map_err(io::Error::other)?;
         }
     }
-    writer.finalize().map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    writer.finalize().map_err(io::Error::other)
 }
 
 /// Reads a shapefile containing Polygon geometries and returns them as vectors of [`Point`].
@@ -254,11 +268,8 @@ pub fn read_polygons_shp(path: &str) -> io::Result<PolygonOutput> {
         match record.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))? {
             Shape::Polygon(pg) => {
                 for ring in pg.rings() {
-                    let verts: Vec<Point> = ring
-                        .points()
-                        .iter()
-                        .map(|p| Point::new(p.x, p.y))
-                        .collect();
+                    let verts: Vec<Point> =
+                        ring.points().iter().map(|p| Point::new(p.x, p.y)).collect();
                     if let Some(ref mut v3) = polys3 {
                         v3.push(
                             ring.points()
@@ -272,11 +283,8 @@ pub fn read_polygons_shp(path: &str) -> io::Result<PolygonOutput> {
             }
             Shape::PolygonZ(pg) => {
                 for ring in pg.rings() {
-                    let verts: Vec<Point> = ring
-                        .points()
-                        .iter()
-                        .map(|p| Point::new(p.x, p.y))
-                        .collect();
+                    let verts: Vec<Point> =
+                        ring.points().iter().map(|p| Point::new(p.x, p.y)).collect();
                     match polys3 {
                         Some(ref mut v3) => v3.push(
                             ring.points()
@@ -285,12 +293,11 @@ pub fn read_polygons_shp(path: &str) -> io::Result<PolygonOutput> {
                                 .collect(),
                         ),
                         None => {
-                            polys3 = Some(vec![
-                                ring.points()
-                                    .iter()
-                                    .map(|p| Point3::new(p.x, p.y, p.z))
-                                    .collect(),
-                            ]);
+                            polys3 = Some(vec![ring
+                                .points()
+                                .iter()
+                                .map(|p| Point3::new(p.x, p.y, p.z))
+                                .collect()]);
                         }
                     }
                     polys.push(verts);
@@ -308,20 +315,19 @@ pub fn write_polygons_shp(
     polygons: &[Vec<Point>],
     polygons_z: Option<&[Vec<Point3>]>,
 ) -> io::Result<()> {
-    let mut writer =
-        ShapeWriter::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let mut writer = ShapeWriter::from_path(path).map_err(io::Error::other)?;
     if let Some(polys3) = polygons_z {
         for poly in polys3 {
             if poly.len() < 3 {
                 continue;
             }
-            let shp_pts: Vec<ShpPointZ> =
-                poly.iter().map(|p| ShpPointZ::new(p.x, p.y, p.z, NO_DATA)).collect();
+            let shp_pts: Vec<ShpPointZ> = poly
+                .iter()
+                .map(|p| ShpPointZ::new(p.x, p.y, p.z, NO_DATA))
+                .collect();
             let ring = PolygonRing::Outer(shp_pts);
             let shp_poly = PolygonZ::new(ring);
-            writer
-                .write_shape(&shp_poly)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            writer.write_shape(&shp_poly).map_err(io::Error::other)?;
         }
     } else {
         for poly in polygons {
@@ -331,25 +337,31 @@ pub fn write_polygons_shp(
             let shp_pts: Vec<ShpPoint> = poly.iter().map(|p| ShpPoint { x: p.x, y: p.y }).collect();
             let ring = PolygonRing::Outer(shp_pts);
             let shp_poly = ShpPolygon::new(ring);
-            writer
-                .write_shape(&shp_poly)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            writer.write_shape(&shp_poly).map_err(io::Error::other)?;
         }
     }
-    writer.finalize().map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    writer.finalize().map_err(io::Error::other)
 }
 
 /// Reads Point records with attributes from a shapefile.
 pub fn read_point_records_shp(path: &str) -> io::Result<Vec<PointRecord>> {
-    let mut reader = Reader::from_path(path)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let mut reader =
+        Reader::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     let mut out = Vec::new();
     for res in reader.iter_shapes_and_records() {
         let (shape, record) = res.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let attrs: BTreeMap<_, _> = record.into_iter().collect();
         match shape {
-            Shape::Point(p) => out.push(PointRecord { geom: Point::new(p.x, p.y), geom_z: None, attrs }),
-            Shape::PointZ(p) => out.push(PointRecord { geom: Point::new(p.x, p.y), geom_z: Some(Point3::new(p.x, p.y, p.z)), attrs }),
+            Shape::Point(p) => out.push(PointRecord {
+                geom: Point::new(p.x, p.y),
+                geom_z: None,
+                attrs,
+            }),
+            Shape::PointZ(p) => out.push(PointRecord {
+                geom: Point::new(p.x, p.y),
+                geom_z: Some(Point3::new(p.x, p.y, p.z)),
+                attrs,
+            }),
             _ => {}
         }
     }
@@ -362,8 +374,7 @@ pub fn write_point_records_shp(path: &str, records: &[PointRecord]) -> io::Resul
         return Ok(());
     }
     let builder = build_table_builder(&records[0].attrs);
-    let mut writer = Writer::from_path(path, builder)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let mut writer = Writer::from_path(path, builder).map_err(io::Error::other)?;
     for rec in records {
         let mut r = Record::default();
         for (k, v) in &rec.attrs {
@@ -371,10 +382,17 @@ pub fn write_point_records_shp(path: &str, records: &[PointRecord]) -> io::Resul
         }
         if let Some(z) = &rec.geom_z {
             let shp = ShpPointZ::new(z.x, z.y, z.z, NO_DATA);
-            writer.write_shape_and_record(&shp, &r).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            writer
+                .write_shape_and_record(&shp, &r)
+                .map_err(io::Error::other)?;
         } else {
-            let shp = ShpPoint { x: rec.geom.x, y: rec.geom.y };
-            writer.write_shape_and_record(&shp, &r).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            let shp = ShpPoint {
+                x: rec.geom.x,
+                y: rec.geom.y,
+            };
+            writer
+                .write_shape_and_record(&shp, &r)
+                .map_err(io::Error::other)?;
         }
     }
     Ok(())
@@ -382,8 +400,8 @@ pub fn write_point_records_shp(path: &str, records: &[PointRecord]) -> io::Resul
 
 /// Reads Polyline records with attributes from a shapefile.
 pub fn read_polyline_records_shp(path: &str) -> io::Result<Vec<PolylineRecord>> {
-    let mut reader = Reader::from_path(path)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let mut reader =
+        Reader::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     let mut out = Vec::new();
     for res in reader.iter_shapes_and_records() {
         let (shape, record) = res.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -392,14 +410,23 @@ pub fn read_polyline_records_shp(path: &str) -> io::Result<Vec<PolylineRecord>> 
             Shape::Polyline(pl) => {
                 for part in pl.parts() {
                     let verts: Vec<Point> = part.iter().map(|p| Point::new(p.x, p.y)).collect();
-                    out.push(PolylineRecord { geom: crate::geometry::Polyline::new(verts), geom_z: None, attrs: attrs.clone() });
+                    out.push(PolylineRecord {
+                        geom: crate::geometry::Polyline::new(verts),
+                        geom_z: None,
+                        attrs: attrs.clone(),
+                    });
                 }
             }
             Shape::PolylineZ(pl) => {
                 for part in pl.parts() {
                     let verts2: Vec<Point> = part.iter().map(|p| Point::new(p.x, p.y)).collect();
-                    let verts3: Vec<Point3> = part.iter().map(|p| Point3::new(p.x, p.y, p.z)).collect();
-                    out.push(PolylineRecord { geom: crate::geometry::Polyline::new(verts2), geom_z: Some(verts3), attrs: attrs.clone() });
+                    let verts3: Vec<Point3> =
+                        part.iter().map(|p| Point3::new(p.x, p.y, p.z)).collect();
+                    out.push(PolylineRecord {
+                        geom: crate::geometry::Polyline::new(verts2),
+                        geom_z: Some(verts3),
+                        attrs: attrs.clone(),
+                    });
                 }
             }
             _ => {}
@@ -414,23 +441,38 @@ pub fn write_polyline_records_shp(path: &str, records: &[PolylineRecord]) -> io:
         return Ok(());
     }
     let builder = build_table_builder(&records[0].attrs);
-    let mut writer = Writer::from_path(path, builder)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let mut writer = Writer::from_path(path, builder).map_err(io::Error::other)?;
     for rec in records {
         let mut r = Record::default();
         for (k, v) in &rec.attrs {
             r.insert(k.clone(), v.clone());
         }
         if let Some(ref zs) = rec.geom_z {
-            if zs.len() < 2 { continue; }
-            let shp_pts: Vec<ShpPointZ> = zs.iter().map(|p| ShpPointZ::new(p.x, p.y, p.z, NO_DATA)).collect();
+            if zs.len() < 2 {
+                continue;
+            }
+            let shp_pts: Vec<ShpPointZ> = zs
+                .iter()
+                .map(|p| ShpPointZ::new(p.x, p.y, p.z, NO_DATA))
+                .collect();
             let shp_pl = PolylineZ::new(shp_pts);
-            writer.write_shape_and_record(&shp_pl, &r).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            writer
+                .write_shape_and_record(&shp_pl, &r)
+                .map_err(io::Error::other)?;
         } else {
-            if rec.geom.vertices.len() < 2 { continue; }
-            let shp_pts: Vec<ShpPoint> = rec.geom.vertices.iter().map(|p| ShpPoint { x: p.x, y: p.y }).collect();
+            if rec.geom.vertices.len() < 2 {
+                continue;
+            }
+            let shp_pts: Vec<ShpPoint> = rec
+                .geom
+                .vertices
+                .iter()
+                .map(|p| ShpPoint { x: p.x, y: p.y })
+                .collect();
             let shp_pl = ShpPolyline::new(shp_pts);
-            writer.write_shape_and_record(&shp_pl, &r).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            writer
+                .write_shape_and_record(&shp_pl, &r)
+                .map_err(io::Error::other)?;
         }
     }
     Ok(())
@@ -438,8 +480,8 @@ pub fn write_polyline_records_shp(path: &str, records: &[PolylineRecord]) -> io:
 
 /// Reads Polygon records with attributes from a shapefile.
 pub fn read_polygon_records_shp(path: &str) -> io::Result<Vec<PolygonRecord>> {
-    let mut reader = Reader::from_path(path)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let mut reader =
+        Reader::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     let mut out = Vec::new();
     for res in reader.iter_shapes_and_records() {
         let (shape, record) = res.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -447,15 +489,29 @@ pub fn read_polygon_records_shp(path: &str) -> io::Result<Vec<PolygonRecord>> {
         match shape {
             Shape::Polygon(pg) => {
                 for ring in pg.rings() {
-                    let verts: Vec<Point> = ring.points().iter().map(|p| Point::new(p.x, p.y)).collect();
-                    out.push(PolygonRecord { geom: verts, geom_z: None, attrs: attrs.clone() });
+                    let verts: Vec<Point> =
+                        ring.points().iter().map(|p| Point::new(p.x, p.y)).collect();
+                    out.push(PolygonRecord {
+                        geom: verts,
+                        geom_z: None,
+                        attrs: attrs.clone(),
+                    });
                 }
             }
             Shape::PolygonZ(pg) => {
                 for ring in pg.rings() {
-                    let verts2: Vec<Point> = ring.points().iter().map(|p| Point::new(p.x, p.y)).collect();
-                    let verts3: Vec<Point3> = ring.points().iter().map(|p| Point3::new(p.x, p.y, p.z)).collect();
-                    out.push(PolygonRecord { geom: verts2, geom_z: Some(verts3), attrs: attrs.clone() });
+                    let verts2: Vec<Point> =
+                        ring.points().iter().map(|p| Point::new(p.x, p.y)).collect();
+                    let verts3: Vec<Point3> = ring
+                        .points()
+                        .iter()
+                        .map(|p| Point3::new(p.x, p.y, p.z))
+                        .collect();
+                    out.push(PolygonRecord {
+                        geom: verts2,
+                        geom_z: Some(verts3),
+                        attrs: attrs.clone(),
+                    });
                 }
             }
             _ => {}
@@ -470,25 +526,39 @@ pub fn write_polygon_records_shp(path: &str, records: &[PolygonRecord]) -> io::R
         return Ok(());
     }
     let builder = build_table_builder(&records[0].attrs);
-    let mut writer = Writer::from_path(path, builder)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let mut writer = Writer::from_path(path, builder).map_err(io::Error::other)?;
     for rec in records {
         let mut r = Record::default();
         for (k, v) in &rec.attrs {
             r.insert(k.clone(), v.clone());
         }
         if let Some(ref zs) = rec.geom_z {
-            if zs.len() < 3 { continue; }
-            let shp_pts: Vec<ShpPointZ> = zs.iter().map(|p| ShpPointZ::new(p.x, p.y, p.z, NO_DATA)).collect();
+            if zs.len() < 3 {
+                continue;
+            }
+            let shp_pts: Vec<ShpPointZ> = zs
+                .iter()
+                .map(|p| ShpPointZ::new(p.x, p.y, p.z, NO_DATA))
+                .collect();
             let ring = PolygonRing::Outer(shp_pts);
             let shp_poly = PolygonZ::new(ring);
-            writer.write_shape_and_record(&shp_poly, &r).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            writer
+                .write_shape_and_record(&shp_poly, &r)
+                .map_err(io::Error::other)?;
         } else {
-            if rec.geom.len() < 3 { continue; }
-            let shp_pts: Vec<ShpPoint> = rec.geom.iter().map(|p| ShpPoint { x: p.x, y: p.y }).collect();
+            if rec.geom.len() < 3 {
+                continue;
+            }
+            let shp_pts: Vec<ShpPoint> = rec
+                .geom
+                .iter()
+                .map(|p| ShpPoint { x: p.x, y: p.y })
+                .collect();
             let ring = PolygonRing::Outer(shp_pts);
             let shp_poly = ShpPolygon::new(ring);
-            writer.write_shape_and_record(&shp_poly, &r).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            writer
+                .write_shape_and_record(&shp_poly, &r)
+                .map_err(io::Error::other)?;
         }
     }
     Ok(())

--- a/survey_cad/src/layers.rs
+++ b/survey_cad/src/layers.rs
@@ -67,7 +67,7 @@ impl LayerManager {
     }
 
     /// Returns all layers matching `predicate`.
-    pub fn filter<'a, F>(&'a self, predicate: F) -> Vec<&'a Layer>
+    pub fn filter<F>(&self, predicate: F) -> Vec<&Layer>
     where
         F: Fn(&Layer) -> bool,
     {

--- a/survey_cad/src/local_grid.rs
+++ b/survey_cad/src/local_grid.rs
@@ -58,9 +58,8 @@ impl LocalGrid {
     /// Loads a grid definition from a JSON file.
     pub fn load(path: &str) -> std::io::Result<Self> {
         let data = std::fs::read_to_string(path)?;
-        let grid: LocalGrid = serde_json::from_str(&data).map_err(|e| {
-            std::io::Error::new(std::io::ErrorKind::InvalidData, e)
-        })?;
+        let grid: LocalGrid = serde_json::from_str(&data)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         Ok(grid)
     }
 }
@@ -71,7 +70,7 @@ mod tests {
 
     #[test]
     fn round_trip() {
-        let grid = LocalGrid::new(Point::new(100.0, 200.0), 0.78539816339, 2.0);
+        let grid = LocalGrid::new(Point::new(100.0, 200.0), std::f64::consts::FRAC_PI_4, 2.0);
         let global = Point::new(110.0, 210.0);
         let local = grid.to_local(global);
         let back = grid.from_local(local);
@@ -79,4 +78,3 @@ mod tests {
         assert!((back.y - global.y).abs() < 1e-6);
     }
 }
-

--- a/survey_cad/src/reporting.rs
+++ b/survey_cad/src/reporting.rs
@@ -1,19 +1,20 @@
+use crate::geometry::Point;
 #[cfg(feature = "reporting")]
 use genpdf::{elements::Paragraph, Alignment, Document};
 #[cfg(feature = "reporting")]
-use umya_spreadsheet::{self, Spreadsheet, writer::xlsx};
-use crate::geometry::Point;
+use umya_spreadsheet::{self, writer::xlsx, Spreadsheet};
 
 #[cfg(feature = "reporting")]
 fn write_pdf(path: &str, title: &str, rows: &[String]) -> std::io::Result<()> {
     let font_family = genpdf::fonts::from_files("/usr/share/fonts", "LiberationSans", None)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
     let mut doc = Document::new(font_family);
     doc.set_title(title);
     for r in rows {
         doc.push(Paragraph::new(r).aligned(Alignment::Left));
     }
-    doc.render_to_file(path).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+    doc.render_to_file(path)
+        .map_err(|e| std::io::Error::other(e.to_string()))
 }
 
 #[cfg(feature = "reporting")]
@@ -26,7 +27,7 @@ fn write_excel(path: &str, rows: &[Vec<String>]) -> std::io::Result<()> {
                 .set_value(val);
         }
     }
-    xlsx::write(&wb, path).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+    xlsx::write(&wb, path).map_err(|e| std::io::Error::other(e.to_string()))
 }
 
 #[cfg(feature = "reporting")]

--- a/survey_cad/src/sheet.rs
+++ b/survey_cad/src/sheet.rs
@@ -12,6 +12,14 @@ use crate::alignment::{Alignment, HorizontalAlignment, VerticalAlignment};
 use crate::corridor::CrossSection;
 use crate::geometry::Point;
 
+/// Scale factors used for plan/profile sheets.
+#[derive(Debug, Clone, Copy)]
+pub struct PlanProfileScales {
+    pub plan: f64,
+    pub profile_h: f64,
+    pub profile_v: f64,
+}
+
 fn sample_horizontal(halign: &HorizontalAlignment, step: f64) -> Vec<Point> {
     let len = halign.length();
     let mut pts = Vec::new();
@@ -204,9 +212,7 @@ pub fn write_plan_profile_scaled_svg(
     halign: &HorizontalAlignment,
     valign: &VerticalAlignment,
     step: f64,
-    plan_scale: f64,
-    profile_hscale: f64,
-    profile_vscale: f64,
+    scales: PlanProfileScales,
     grid: f64,
 ) -> io::Result<()> {
     let plan = sample_horizontal(halign, step);
@@ -224,12 +230,12 @@ pub fn write_plan_profile_scaled_svg(
     }
 
     let plan_bbox = bbox(&plan).unwrap_or((0.0, 0.0, 0.0, 0.0));
-    let plan_width = (plan_bbox.2 - plan_bbox.0) / plan_scale;
-    let plan_height = (plan_bbox.3 - plan_bbox.1) / plan_scale;
+    let plan_width = (plan_bbox.2 - plan_bbox.0) / scales.plan;
+    let plan_height = (plan_bbox.3 - plan_bbox.1) / scales.plan;
 
     let prof_bbox = bbox(&profile).unwrap_or((0.0, 0.0, 0.0, 0.0));
-    let prof_width = (prof_bbox.2 - prof_bbox.0) / profile_hscale;
-    let prof_height = (prof_bbox.3 - prof_bbox.1) / profile_vscale;
+    let prof_width = (prof_bbox.2 - prof_bbox.0) / scales.profile_h;
+    let prof_height = (prof_bbox.3 - prof_bbox.1) / scales.profile_v;
 
     let width = plan_width.max(prof_width) + 40.0;
     let height = plan_height + prof_height + 60.0;
@@ -252,8 +258,8 @@ pub fn write_plan_profile_scaled_svg(
         .iter()
         .map(|p| {
             Point::new(
-                (p.x - plan_bbox.0) / plan_scale,
-                plan_height - (p.y - plan_bbox.1) / plan_scale,
+                (p.x - plan_bbox.0) / scales.plan,
+                plan_height - (p.y - plan_bbox.1) / scales.plan,
             )
         })
         .collect();
@@ -276,8 +282,8 @@ pub fn write_plan_profile_scaled_svg(
         .iter()
         .map(|p| {
             Point::new(
-                (p.x - prof_bbox.0) / profile_hscale,
-                prof_height - (p.y - prof_bbox.1) / profile_vscale,
+                (p.x - prof_bbox.0) / scales.profile_h,
+                prof_height - (p.y - prof_bbox.1) / scales.profile_v,
             )
         })
         .collect();

--- a/survey_cad/src/surveying/adjustment.rs
+++ b/survey_cad/src/surveying/adjustment.rs
@@ -1,7 +1,7 @@
 // Least squares network adjustment utilities
 
-use crate::geometry::Point;
 use super::cogo::bearing;
+use crate::geometry::Point;
 use nalgebra::{DMatrix, DVector};
 use std::collections::{HashMap, HashSet};
 
@@ -9,9 +9,20 @@ use std::collections::{HashMap, HashSet};
 #[derive(Debug, Clone)]
 pub enum Observation {
     /// Distance between two points identified by their indices.
-    Distance { from: usize, to: usize, value: f64, weight: f64 },
+    Distance {
+        from: usize,
+        to: usize,
+        value: f64,
+        weight: f64,
+    },
     /// Angle at `at` from the line to `from` to the line to `to` (radians).
-    Angle { at: usize, from: usize, to: usize, value: f64, weight: f64 },
+    Angle {
+        at: usize,
+        from: usize,
+        to: usize,
+        value: f64,
+        weight: f64,
+    },
 }
 
 /// Result of a network adjustment.
@@ -55,17 +66,15 @@ fn bearing_derivatives(p: Point, q: Point) -> (f64, f64, f64, f64) {
     (d_theta_dx_p, d_theta_dy_p, d_theta_dx_q, d_theta_dy_q)
 }
 
-fn angle_partials(points: &[Point], at: usize, from: usize, to: usize) -> (f64, f64, f64, f64, f64, f64) {
+fn angle_partials(
+    points: &[Point],
+    at: usize,
+    from: usize,
+    to: usize,
+) -> (f64, f64, f64, f64, f64, f64) {
     let (dx1_a, dy1_a, dx1_f, dy1_f) = bearing_derivatives(points[at], points[from]);
     let (dx2_a, dy2_a, dx2_t, dy2_t) = bearing_derivatives(points[at], points[to]);
-    (
-        dx2_a - dx1_a,
-        dy2_a - dy1_a,
-        -dx1_f,
-        -dy1_f,
-        dx2_t,
-        dy2_t,
-    )
+    (dx2_a - dx1_a, dy2_a - dy1_a, -dx1_f, -dy1_f, dx2_t, dy2_t)
 }
 
 fn build_matrices(
@@ -81,7 +90,12 @@ fn build_matrices(
 
     for (row, obs) in observations.iter().enumerate() {
         match *obs {
-            Observation::Distance { from, to, value, weight } => {
+            Observation::Distance {
+                from,
+                to,
+                value,
+                weight,
+            } => {
                 let p = points[from];
                 let q = points[to];
                 let dx = q.x - p.x;
@@ -99,7 +113,13 @@ fn build_matrices(
                     a[(row, idx + 1)] = dy / dist;
                 }
             }
-            Observation::Angle { at, from, to, value, weight } => {
+            Observation::Angle {
+                at,
+                from,
+                to,
+                value,
+                weight,
+            } => {
                 let b1 = bearing(points[at], points[from]);
                 let b2 = bearing(points[at], points[to]);
                 let mut angle = b2 - b1;
@@ -140,7 +160,11 @@ fn build_matrices(
 }
 
 /// Adjusts a 2D network returning updated coordinates and observation residuals.
-pub fn adjust_network(points: &[Point], fixed: &[usize], observations: &[Observation]) -> AdjustResult {
+pub fn adjust_network(
+    points: &[Point],
+    fixed: &[usize],
+    observations: &[Observation],
+) -> AdjustResult {
     let fixed_set: HashSet<usize> = fixed.iter().cloned().collect();
     let mut index_map = HashMap::new();
     let mut count = 0usize;
@@ -158,7 +182,12 @@ pub fn adjust_network(points: &[Point], fixed: &[usize], observations: &[Observa
     let u = &at * &w * &l;
     let delta = match n.clone().lu().solve(&u) {
         Some(d) => d,
-        None => return AdjustResult { points: points.to_vec(), residuals: vec![] },
+        None => {
+            return AdjustResult {
+                points: points.to_vec(),
+                residuals: vec![],
+            }
+        }
     };
     let v = &a * &delta - &l;
 
@@ -195,8 +224,6 @@ pub fn adjust_network_report(
     let mut current = points.to_vec();
     let mut iterations = Vec::new();
     let mut converged = false;
-    let final_n;
-    let final_res;
 
     for _ in 0..max_iter {
         let (a, l, w) = build_matrices(&current, observations, &index_map, count);
@@ -234,8 +261,8 @@ pub fn adjust_network_report(
         None => DVector::<f64>::zeros(count),
     };
     let v = &a * &delta - &l;
-    final_n = n;
-    final_res = v.clone();
+    let final_n = n;
+    let final_res = v.clone();
     iterations.push(IterationRecord {
         delta: delta.clone(),
         residuals: v.clone(),
@@ -269,12 +296,26 @@ mod tests {
 
     #[test]
     fn simple_distance_network() {
-        let pts = vec![Point::new(0.0,0.0), Point::new(100.0,0.0), Point::new(40.0,40.0)];
-        let obs = vec![
-            Observation::Distance { from:0, to:2, value:(50.0f64.powi(2)+40.0f64.powi(2)).sqrt(), weight:1.0 },
-            Observation::Distance { from:1, to:2, value:(50.0f64.powi(2)+40.0f64.powi(2)).sqrt(), weight:1.0 },
+        let pts = vec![
+            Point::new(0.0, 0.0),
+            Point::new(100.0, 0.0),
+            Point::new(40.0, 40.0),
         ];
-        let res = adjust_network(&pts, &[0,1], &obs);
+        let obs = vec![
+            Observation::Distance {
+                from: 0,
+                to: 2,
+                value: (50.0f64.powi(2) + 40.0f64.powi(2)).sqrt(),
+                weight: 1.0,
+            },
+            Observation::Distance {
+                from: 1,
+                to: 2,
+                value: (50.0f64.powi(2) + 40.0f64.powi(2)).sqrt(),
+                weight: 1.0,
+            },
+        ];
+        let res = adjust_network(&pts, &[0, 1], &obs);
         let c = res.points[2];
         assert!((c.x - 50.0).abs() < 1e-2);
         assert!((c.y - 40.0).abs() < 1e-2);

--- a/survey_cad/src/surveying/point_db.rs
+++ b/survey_cad/src/surveying/point_db.rs
@@ -61,7 +61,10 @@ pub struct PointDatabase {
 impl PointDatabase {
     /// Creates a new empty database.
     pub fn new() -> Self {
-        Self { points: Vec::new(), history: Vec::new() }
+        Self {
+            points: Vec::new(),
+            history: Vec::new(),
+        }
     }
 
     /// Adds a survey point to the database.
@@ -81,7 +84,13 @@ impl PointDatabase {
         self.points.push(point);
     }
 
-    pub fn update_point(&mut self, index: usize, point: SurveyPoint, user: &str, comment: Option<&str>) {
+    pub fn update_point(
+        &mut self,
+        index: usize,
+        point: SurveyPoint,
+        user: &str,
+        comment: Option<&str>,
+    ) {
         if let Some(old) = self.points.get_mut(index) {
             let old_clone = old.clone();
             *old = point.clone();
@@ -90,7 +99,10 @@ impl PointDatabase {
                 user: user.to_string(),
                 timestamp: Utc::now(),
                 comment: comment.map(|s| s.to_string()),
-                change: PointChange::Modified { old: old_clone, new: point },
+                change: PointChange::Modified {
+                    old: old_clone,
+                    new: point,
+                },
             });
         }
     }
@@ -171,7 +183,7 @@ impl PointDatabase {
                     .push(Point::new(p.point.x, p.point.y));
             }
         }
-        map.into_iter().map(|(_, pts)| Polyline::new(pts)).collect()
+        map.into_values().map(Polyline::new).collect()
     }
 
     /// Generates linework by interpreting field codes using begin/continue/end
@@ -192,14 +204,14 @@ impl PointDatabase {
                                 result.push(Polyline::new(pts));
                             }
                         }
-                        active.insert(fc.code, vec![pt.clone()]);
+                        active.insert(fc.code, vec![pt]);
                     }
                     CodeAction::Continue => {
-                        active.entry(fc.code).or_default().push(pt.clone());
+                        active.entry(fc.code).or_default().push(pt);
                     }
                     CodeAction::End => {
                         if let Some(mut pts) = active.remove(&fc.code) {
-                            pts.push(pt.clone());
+                            pts.push(pt);
                             if pts.len() >= 2 {
                                 result.push(Polyline::new(pts));
                             }
@@ -239,13 +251,13 @@ impl PointDatabase {
                 if let Some(entry) = library.get(code) {
                     if let Some(name) = &entry.block {
                         blocks.push(BlockRef {
-                            location: p.point.clone(),
+                            location: p.point,
                             name: name.clone(),
                             attributes: entry.attributes.clone(),
                         });
                     }
                     if entry.linework {
-                        active.entry(code.clone()).or_default().push(pt2d.clone());
+                        active.entry(code.clone()).or_default().push(pt2d);
                     }
                 }
             }
@@ -262,14 +274,14 @@ impl PointDatabase {
                                 lines.push(Polyline::new(pts));
                             }
                         }
-                        active.insert(fc.code, vec![pt2d.clone()]);
+                        active.insert(fc.code, vec![pt2d]);
                     }
                     CodeAction::Continue => {
-                        active.entry(fc.code).or_default().push(pt2d.clone());
+                        active.entry(fc.code).or_default().push(pt2d);
                     }
                     CodeAction::End => {
                         if let Some(mut pts) = active.remove(&fc.code) {
-                            pts.push(pt2d.clone());
+                            pts.push(pt2d);
                             if pts.len() >= 2 {
                                 lines.push(Polyline::new(pts));
                             }


### PR DESCRIPTION
## Summary
- fix redundant closures using `io::Error::other`
- clean up needless lifetimes
- fix local grid constant usage
- refactor scaled sheet writer args
- simplify network adjustment finalization
- various cleanup to point database

## Testing
- `cargo test -p survey_cad -- --test-threads=1` *(fails: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6846c7e10b8c8328b441ebfefe53b020