### PR TITLE
Fix clippy lint warnings

### DIFF
--- a/cad_import/src/lib.rs
+++ b/cad_import/src/lib.rs
@@ -270,6 +270,9 @@ mod tests {
     use super::*;
     use survey_cad::io::write_points_dxf;
 
+    type SurveyPointResult = io::Result<Vec<SurveyPoint>>;
+    type SurveyPointReaderFn = fn(&str) -> SurveyPointResult;
+
     #[test]
     fn read_written_dxf_points() {
         let path = std::env::temp_dir().join("import_pts.dxf");
@@ -299,7 +302,7 @@ mod tests {
         use std::fs::write;
 
         let content = "1,100.0,200.0,50.0,TEST";
-        let brands: [(&str, fn(&str) -> io::Result<Vec<SurveyPoint>>); 4] = [
+        let brands: [(&str, SurveyPointReaderFn); 4] = [
             ("leica.raw", instrument::read_leica_raw),
             ("trimble.raw", instrument::read_trimble_raw),
             ("topcon.raw", instrument::read_topcon_raw),

--- a/survey_cad_cli/src/main.rs
+++ b/survey_cad_cli/src/main.rs
@@ -1,9 +1,9 @@
 use cad_import::{read_point_file, PointFileFormat};
 use clap::{Parser, Subcommand};
-#[cfg(feature = "e57")]
-use survey_cad::io::e57::{read_points_e57, write_points_e57};
 use std::io::BufRead;
 use std::str::FromStr;
+#[cfg(feature = "e57")]
+use survey_cad::io::e57::{read_points_e57, write_points_e57};
 #[cfg(feature = "fgdb")]
 use survey_cad::io::fgdb::read_points_fgdb;
 #[cfg(feature = "kml")]
@@ -1026,7 +1026,7 @@ fn main() {
                         names.push(parts[0].trim().to_string());
                         let x: f64 = parts[1].trim().parse().unwrap_or(0.0);
                         let y: f64 = parts[2].trim().parse().unwrap_or(0.0);
-                        if parts.get(3).map_or(false, |v| v.trim() == "1") {
+                        if parts.get(3).is_some_and(|v| v.trim() == "1") {
                             fixed.push(idx);
                         }
                         pts.push(Point::new(x, y));


### PR DESCRIPTION
## Summary
- simplify complex test type in `cad_import`
- use `is_some_and` in CLI point parser

## Testing
- `cargo check -p cad_import`
- `cargo clippy -p cad_import --tests -- -D warnings`
- `cargo check -p survey_cad_cli --bin survey_cad_cli`

------
https://chatgpt.com/codex/tasks/task_e_6846de0be1388328b9cfffb03614d285