### PR TITLE
Fix unused function warning

### DIFF
--- a/survey_cad_cli/src/main.rs
+++ b/survey_cad_cli/src/main.rs
@@ -155,6 +155,7 @@ fn read_points_csv_3d(path: &str) -> std::io::Result<Vec<Point3>> {
     Ok(pts)
 }
 
+#[cfg(feature = "las")]
 fn write_points_classified(
     path: &str,
     points: &[Point3],


### PR DESCRIPTION
## Summary
- feature-gate `write_points_classified` to avoid unused warnings when the `las` feature isn't enabled

## Testing
- `cargo check -p survey_cad_cli --quiet` *(fails: operation timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6846eef6f44c8328ac542e65e8957d26