### PR TITLE
Fix breakline handling and slope elevation

### DIFF
--- a/survey_cad/src/corridor.rs
+++ b/survey_cad/src/corridor.rs
@@ -82,12 +82,13 @@ impl Subassembly {
 impl Tin {
     /// Returns the interpolated elevation at (x,y) if the point lies within the TIN.
     pub fn elevation_at(&self, x: f64, y: f64) -> Option<f64> {
+        const EPS: f64 = 1e-8;
         for tri in &self.triangles {
             let a = self.vertices[tri[0]];
             let b = self.vertices[tri[1]];
             let c = self.vertices[tri[2]];
             if let Some((u, v, w)) = barycentric(Point::new(x, y), a, b, c) {
-                if u >= 0.0 && v >= 0.0 && w >= 0.0 {
+                if u >= -EPS && v >= -EPS && w >= -EPS {
                     return Some(u * a.z + v * b.z + w * c.z);
                 }
             }

--- a/survey_cad/src/dtm.rs
+++ b/survey_cad/src/dtm.rs
@@ -83,7 +83,12 @@ fn refine_edges_for_points(points: &[Point3], edges: &[(usize, usize)]) -> Vec<(
             last = idx;
         }
         refined.push((last, b));
+        if !mids.is_empty() {
+            refined.push((a, b));
+        }
     }
+    refined.sort_unstable();
+    refined.dedup();
     refined
 }
 


### PR DESCRIPTION
## Summary
- relax tolerance when checking barycentric coordinates for elevation
- keep original breakline edges and deduplicate refined edges

## Testing
- `cargo test -p survey_cad --lib dtm::tests::breakline_editing -- --nocapture` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6846fe35144c832890fc352397ffdd3a