### PR TITLE
Fix borrow usage in dtm refinement

### DIFF
--- a/survey_cad/src/dtm.rs
+++ b/survey_cad/src/dtm.rs
@@ -78,9 +78,9 @@ fn refine_edges_for_points(points: &[Point3], edges: &[(usize, usize)]) -> Vec<(
         }
         mids.sort_by(|x, y| x.1.partial_cmp(&y.1).unwrap());
         let mut last = a;
-        for (idx, _) in mids {
-            refined.push((last, idx));
-            last = idx;
+        for (idx, _) in &mids {
+            refined.push((last, *idx));
+            last = *idx;
         }
         refined.push((last, b));
         if !mids.is_empty() {


### PR DESCRIPTION
## Summary
- prevent moving `mids` when iterating in `refine_edges_for_points`

## Testing
- `cargo check --lib` in `survey_cad`

------
https://chatgpt.com/codex/tasks/task_e_6847074fc87883288f6b247684c4c398