### PR TITLE
Fix LocalGrid::save error handling

### DIFF
--- a/survey_cad/src/local_grid.rs
+++ b/survey_cad/src/local_grid.rs
@@ -50,9 +50,9 @@ impl LocalGrid {
     }
 
     /// Saves this grid definition to a JSON file.
-    pub fn save(&self, path: &str) -> std::io::Result<()> {
-        let json = serde_json::to_string_pretty(self).unwrap();
-        std::fs::write(path, json)
+    pub fn save(&self, path: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let json = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, json).map_err(|e| e.into())
     }
 
     /// Loads a grid definition from a JSON file.


### PR DESCRIPTION
## Summary
- propagate serde_json errors in `LocalGrid::save`

## Testing
- `cargo test -p survey_cad --no-default-features --lib` *(fails: build takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_68473e9131808328abfa0f49a02b7df8