### PR TITLE
Handle triangulation errors

### DIFF
--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -1466,6 +1466,7 @@ fn build_tin(data: &SurfaceData) -> survey_cad::dtm::Tin {
         None,
         &data.holes,
     )
+    .unwrap()
 }
 
 fn handle_build_surface(


### PR DESCRIPTION
## Summary
- propagate `cdt` errors when building constrained TINs
- adjust dynamic TIN update helpers for `Result`
- adapt GUI helper and unit tests to new API

## Testing
- `cargo test -p survey_cad dtm::dynamic_tin_updates --quiet` *(fails: took too long)*

------
https://chatgpt.com/codex/tasks/task_e_6847439625848328884633bc5850b053