### PR TITLE
Remove deprecated allow and update spawn

### DIFF
--- a/bevy_pmetra/src/lib.rs
+++ b/bevy_pmetra/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use bevy::prelude::*;
 use bevy::prelude::{Cuboid, Mesh3d, MeshMaterial3d};
 
@@ -15,14 +14,15 @@ impl Plugin for ParametricBox {
             move |mut commands: Commands,
                   mut meshes: ResMut<Assets<Mesh>>,
                   mut materials: ResMut<Assets<StandardMaterial>>| {
-                commands.spawn(PbrBundle {
-                    mesh: Mesh3d::from(meshes.add(Mesh::from(Cuboid::new(size.x, size.y, size.z)))),
-                    material: MeshMaterial3d::from(materials.add(StandardMaterial {
+                commands.spawn((
+                    Mesh3d::from(meshes.add(Mesh::from(Cuboid::new(size.x, size.y, size.z)))),
+                    MeshMaterial3d::from(materials.add(StandardMaterial {
                         base_color: Color::srgb(0.8, 0.8, 0.8),
                         ..default()
                     })),
-                    ..default()
-                });
+                    Transform::default(),
+                    Visibility::default(),
+                ));
             },
         );
     }

--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(deprecated, clippy::type_complexity, clippy::too_many_arguments)]
+#![allow(clippy::type_complexity, clippy::too_many_arguments)]
 use bevy::input::mouse::{MouseMotion, MouseWheel};
 use bevy::prelude::*;
 use bevy_editor_cam::prelude::*;


### PR DESCRIPTION
## Summary
- remove `allow(deprecated)` from GUI main
- replace deprecated `PbrBundle` and `SpatialBundle` usage in bevy_pmetra

## Testing
- `cargo check -p bevy_pmetra -p survey_cad_gui --quiet` *(fails: took too long to build in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6847603e2a2c83288956517081b2b745