### PR TITLE
Fix query iteration borrow in tests

### DIFF
--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -2134,7 +2134,7 @@ mod tests {
         ));
 
         let lines = world.query::<&CadLine>();
-        for line in lines.iter(world) {
+        for line in lines.iter(&world) {
             if let (Some(_a), Some(_b)) = (
                 world.get::<Transform>(line.start),
                 world.get::<Transform>(line.end),


### PR DESCRIPTION
## Summary
- fix mismatched type error in `update_line_missing_points` by borrowing `world`

## Testing
- `cargo check` *(fails: build did not finish in time)*

------
https://chatgpt.com/codex/tasks/task_e_68478f049b088328be2f60c436e5c65b