### PR TITLE
Fix borrow issue in line tests

### DIFF
--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -2133,7 +2133,7 @@ mod tests {
             Sprite::default(),
         ));
 
-        let lines = world.query::<&CadLine>();
+        let mut lines = world.query::<&CadLine>();
         for line in lines.iter(&world) {
             if let (Some(_a), Some(_b)) = (
                 world.get::<Transform>(line.start),


### PR DESCRIPTION
## Summary
- fix missing `mut` when iterating over CadLine query

## Testing
- `cargo check -p survey_cad_gui` *(fails: build did not finish in time)*

------
https://chatgpt.com/codex/tasks/task_e_6847faea97848328abcf28991d25ba69