### PR TITLE
Add reusable CRS transformer

### DIFF
--- a/survey_cad/tests/crs.rs
+++ b/survey_cad/tests/crs.rs
@@ -1,4 +1,4 @@
-use survey_cad::crs::Crs;
+use survey_cad::crs::{Crs, CrsTransformer};
 
 #[test]
 fn transform_point3d_identity() {
@@ -7,4 +7,16 @@ fn transform_point3d_identity() {
     assert!((x - 1.0).abs() < 1e-6);
     assert!((y - 2.0).abs() < 1e-6);
     assert!((z - 3.0).abs() < 1e-6);
+}
+
+#[test]
+fn transformer_reuse() {
+    let crs = Crs::from_epsg(4979);
+    let t = CrsTransformer::new(&crs, &crs).unwrap();
+    for _ in 0..3 {
+        let (x, y, z) = t.transform(1.0, 2.0, 3.0).unwrap();
+        assert!((x - 1.0).abs() < 1e-6);
+        assert!((y - 2.0).abs() < 1e-6);
+        assert!((z - 3.0).abs() < 1e-6);
+    }
 }


### PR DESCRIPTION
## Summary
- add `CrsTransformer` for caching PROJ contexts
- reuse the cached transformer in `PointDatabase::transform`
- refactor `transform_point3d` to build a transformer internally
- add tests for the new struct

## Testing
- `cargo test -p survey_cad --no-default-features` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_684801c7babc8328baaebb03e3f4b6d1