### PR TITLE
Add Python README and mention bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ returning an error if they are missing.
 
 ## Architecture Overview
 
-The workspace contains two crates:
+The workspace contains multiple crates:
 
 - `survey_cad` &mdash; core library with modules for geometry, surveying, file I/O and simple rendering utilities.
 - `survey_cad_cli` &mdash; small command line tool that demonstrates the library capabilities.
+- `survey_cad_python` &mdash; Python bindings built with [PyO3](https://pyo3.rs/).
 
 Each module in the library is focused on a specific set of tasks and can be used
 independently within other Rust projects. Heavy rendering dependencies are
@@ -126,6 +127,26 @@ automatically scales the interface based on monitor DPI.
 
 ```bash
 $ cargo run -p survey_cad_gui -- --theme light
+```
+
+## Python Bindings
+
+The workspace also exposes a small [Python module](survey_cad_python) built with
+`maturin`. Build the extension and use it from Python:
+
+```bash
+$ cd survey_cad_python
+$ maturin develop
+```
+
+Example:
+
+```python
+from survey_cad_python import Point, station_distance
+
+a = Point(0.0, 0.0)
+b = Point(3.0, 4.0)
+print(station_distance(a, b))
 ```
 
 ## Continuous Integration

--- a/survey_cad_python/README.md
+++ b/survey_cad_python/README.md
@@ -1,0 +1,24 @@
+# survey_cad_python
+
+Python bindings for the Survey CAD library built with [PyO3](https://pyo3.rs/).
+
+## Building
+
+Install [maturin](https://github.com/PyO3/maturin) and build the module in-place:
+
+```bash
+$ cd survey_cad_python
+$ maturin develop
+```
+
+This compiles the `survey_cad_python` extension so it can be imported from Python.
+
+## Example
+
+```python
+from survey_cad_python import Point, station_distance
+
+a = Point(0.0, 0.0)
+b = Point(3.0, 4.0)
+print(station_distance(a, b))
+```


### PR DESCRIPTION
## Summary
- document Python bindings usage and build steps
- link to Python crate and example in the main README

## Testing
- `apt-get update`
- `apt-get install -y rustc cargo`
- `cargo test` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*

------
https://chatgpt.com/codex/tasks/task_e_684833bc1d508328b34ce21dad34f8e8