### PR TITLE
Use static regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5509,6 +5509,7 @@ dependencies = [
  "las",
  "log",
  "nalgebra",
+ "once_cell",
  "predicates 2.1.5",
  "proj",
  "proj-sys",

--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = "1.0"
 rusqlite = { version = "0.31", features = ["bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
+once_cell = "1"
 geojson = "0.24"
 bevy = { version = "0.15", default-features = false, features = ["bevy_winit", "bevy_sprite", "x11"], optional = true }
 bevy_editor_cam = { version = "0.5", optional = true }

--- a/survey_cad/src/qa.rs
+++ b/survey_cad/src/qa.rs
@@ -1,13 +1,15 @@
+use once_cell::sync::Lazy;
 use regex::Regex;
 use crate::geometry::Point;
 use crate::layers::{LayerManager};
 use crate::geometry;
 
 /// Returns layer names that do not conform to `^[A-Z0-9_]+$`.
+static LAYER_NAME_RE: Lazy<Regex> = Lazy::new(|| Regex::new("^[A-Z0-9_]+$").unwrap());
+
 pub fn check_layer_naming(mgr: &LayerManager) -> Vec<String> {
-    let re = Regex::new("^[A-Z0-9_]+$").unwrap();
     mgr.names()
-        .filter(|name| !re.is_match(name))
+        .filter(|name| !LAYER_NAME_RE.is_match(name))
         .map(|s| s.to_string())
         .collect()
 }


### PR DESCRIPTION
## Summary
- reuse compiled regex in `check_layer_naming`
- expose `once_cell` dependency

## Testing
- `cargo check -p survey_cad --no-default-features` *(fails: couldn't complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68483c64cf1083289f9383d52ac39b58