### PR TITLE
Add Windows release workflow

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,0 +1,34 @@
+name: Release Windows Build
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - name: Build CLI
+        run: cargo build -p survey_cad_cli --release
+      - name: Package Binary
+        shell: bash
+        run: |
+          mkdir dist
+          cp target/release/survey_cad_cli.exe dist/
+          cd dist
+          zip survey_cad_cli-windows.zip survey_cad_cli.exe
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/survey_cad_cli-windows.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ GitHub Actions automatically runs `cargo clippy` and `cargo test` for every push
 and pull request. The workflow fails if clippy reports warnings or any tests
 fail.
 
+Tagged commits start an additional workflow that builds `survey_cad_cli` on
+Windows and attaches the zipped executable to the corresponding GitHub release.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- build CLI for Windows on tag push
- upload zipped binary to GitHub releases
- document the new workflow in README

## Testing
- `cargo test -p survey_cad_cli -- --help` *(fails: build takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_68485b3c4ee48328808d564a9f78962d