### PR TITLE
Fix Windows build by disabling proj network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,7 +4595,6 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58e0c01de214d7ea50ee6519969be9efdc6f0dc5ce6c64fbd4f054ea26d43ca4"
 dependencies = [
- "geo-types",
  "http",
  "libc",
  "num-traits",

--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -23,7 +23,7 @@ truck-geometry = "0.5"
 delaunator = "1"
 cdt = "0.1"
 roxmltree = "0.20"
-proj = { version = "0.30", features = ["network"] }
+proj = { version = "0.30", default-features = false }
 proj-sys = "0.26"
 shapefile = { version = "0.7", optional = true }
 las = { version = "0.9", optional = true }
@@ -52,3 +52,4 @@ kml = ["dep:kml"]
 fgdb = ["dep:gdal"]
 e57 = ["dep:e57", "dep:uuid"]
 reporting = ["dep:genpdf", "dep:umya-spreadsheet"]
+network = ["proj/network"]


### PR DESCRIPTION
## Summary
- disable `proj` network support by default
- expose optional `network` feature

This avoids needing TIFF during Windows release builds, which was failing.

## Testing
- `cargo check -p survey_cad --no-default-features` *(fails: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684867fbfdb88328801370e498b5c7b4