### PR TITLE
Fix Windows release workflow

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -17,6 +17,8 @@ jobs:
           profile: minimal
           override: true
       - uses: Swatinem/rust-cache@v2
+      - name: Install SQLite3
+        run: choco install -y sqlite
       - name: Build CLI
         run: cargo build -p survey_cad_cli --release
       - name: Package Binary


### PR DESCRIPTION
## Summary
- install SQLite3 binary on Windows CI before building

## Testing
- `cargo test --all` *(failed: build took too long)*

------
https://chatgpt.com/codex/tasks/task_e_684873629c9483289d3bbadd04b21ca4