### PR TITLE
Fix Windows release packaging

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -27,7 +27,7 @@ jobs:
           mkdir dist
           cp target/release/survey_cad_cli.exe dist/
           cd dist
-          zip survey_cad_cli-windows.zip survey_cad_cli.exe
+          7z a survey_cad_cli-windows.zip survey_cad_cli.exe
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
## Summary
- adjust windows release action to use 7z for zipping

## Testing
- `cargo test --workspace` *(fails: Blocking waiting for file lock on build directory)*

------
https://chatgpt.com/codex/tasks/task_e_68487bbf2ee88328a8c04a80a5a21056