### PR TITLE
Fix release workflow for manual runs

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -29,6 +29,7 @@ jobs:
           cd dist
           7z a survey_cad_cli-windows.zip survey_cad_cli.exe
       - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           files: dist/survey_cad_cli-windows.zip


### PR DESCRIPTION
## Summary
- skip release step if workflow isn't running on a tag

## Testing
- `cargo test --all` *(fails: compile too slow)*

------
https://chatgpt.com/codex/tasks/task_e_684886afefbc832885f6a28931733fc8