### PR TITLE
Automate tagging for releases

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: windows-latest
@@ -28,10 +31,24 @@ jobs:
           cp target/release/survey_cad_cli.exe dist/
           cd dist
           7z a survey_cad_cli-windows.zip survey_cad_cli.exe
+      - name: Prepare Release Tag
+        id: tag
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            TAG="v$(date +'%Y%m%d%H%M%S')"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          fi
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
           files: dist/survey_cad_cli-windows.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ fail.
 
 Tagged commits start an additional workflow that builds `survey_cad_cli` on
 Windows and attaches the zipped executable to the corresponding GitHub release.
+Manual runs of this workflow automatically create a timestamped tag so
+releases can be generated without manually pushing a new tag.
 
 ## License
 


### PR DESCRIPTION
## Summary
- update Windows release workflow to auto-create a tag when triggered manually
- note that manual runs create a tag in README

## Testing
- `cargo test --all` *(failed: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6848939d9fb88328924b8dc17fb26de2