### PR TITLE
Add GUI binary to Windows release workflow

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -24,13 +24,17 @@ jobs:
         run: choco install -y sqlite
       - name: Build CLI
         run: cargo build -p survey_cad_cli --release
-      - name: Package Binary
+      - name: Build GUI
+        run: cargo build -p survey_cad_gui --release
+      - name: Package Binaries
         shell: bash
         run: |
           mkdir dist
           cp target/release/survey_cad_cli.exe dist/
+          cp target/release/survey_cad_gui.exe dist/
           cd dist
           7z a survey_cad_cli-windows.zip survey_cad_cli.exe
+          7z a survey_cad_gui-windows.zip survey_cad_gui.exe
       - name: Prepare Release Tag
         id: tag
         shell: bash
@@ -49,6 +53,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
-          files: dist/survey_cad_cli-windows.zip
+          files: |
+            dist/survey_cad_cli-windows.zip
+            dist/survey_cad_gui-windows.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -155,10 +155,11 @@ GitHub Actions automatically runs `cargo clippy` and `cargo test` for every push
 and pull request. The workflow fails if clippy reports warnings or any tests
 fail.
 
-Tagged commits start an additional workflow that builds `survey_cad_cli` on
-Windows and attaches the zipped executable to the corresponding GitHub release.
-Manual runs of this workflow automatically create a timestamped tag so
-releases can be generated without manually pushing a new tag.
+Tagged commits start an additional workflow that builds both `survey_cad_cli`
+and `survey_cad_gui` on Windows. The zipped executables are attached to the
+corresponding GitHub release. Manual runs of this workflow automatically create
+a timestamped tag so releases can be generated without manually pushing a new
+tag.
 
 ## License
 


### PR DESCRIPTION
## Summary
- compile `survey_cad_gui` in Windows release workflow
- package the GUI executable alongside the CLI
- note new release contents in the README

## Testing
- `cargo test --all` *(fails: build cancelled due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6848af938fcc8328b8be248070f25dce