### PR TITLE
Bundle PROJ in survey_cad build

### DIFF
--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -24,7 +24,7 @@ delaunator = "1"
 cdt = "0.1"
 roxmltree = "0.20"
 proj = { version = "0.30", default-features = false }
-proj-sys = "0.26"
+proj-sys = { version = "0.26", features = ["bundled_proj"] }
 shapefile = { version = "0.7", optional = true }
 las = { version = "0.9", optional = true }
 kml = { version = "0.9", features = ["zip", "geo-types"], optional = true }


### PR DESCRIPTION
## Summary
- ensure PROJ is bundled when building the Rust crates

## Testing
- `cargo build -p survey_cad_gui --release`

------
https://chatgpt.com/codex/tasks/task_e_6848b7a051ec8328ba3624a81254e851