### PR TITLE
Add file logging option to GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,6 +5547,8 @@ dependencies = [
  "bevy",
  "bevy_editor_cam",
  "clap",
+ "env_logger",
+ "log",
  "rfd",
  "survey_cad",
 ]

--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ C:\> survey_cad_gui.exe
 
 PowerShell users can set the variable with `$env:RUST_LOG="info"` before running the binary.
 
+You can also direct log output to a file by setting `SURVEY_CAD_LOG` before
+launching the GUI:
+
+```bash
+$ export SURVEY_CAD_LOG=gui.log
+$ cargo run -p survey_cad_gui
+```
 
 ## Python Bindings
 

--- a/survey_cad_gui/Cargo.toml
+++ b/survey_cad_gui/Cargo.toml
@@ -9,6 +9,8 @@ survey_cad = { path = "../survey_cad" }
 rfd = "0.15"
 clap = { version = "4", features = ["derive"] }
 bevy_editor_cam = "0.5"
+log = "0.4"
+env_logger = "0.10"
 
 
 [features]

--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -5,6 +5,7 @@ use bevy::log::warn;
 use bevy_editor_cam::prelude::*;
 use clap::{Parser, ValueEnum};
 use std::collections::HashMap;
+use std::fs::File;
 use survey_cad::geometry::{Point, Point3, Polyline};
 use survey_cad::{crs::Crs, geometry::distance};
 
@@ -283,6 +284,22 @@ impl Default for CorridorParams {
 }
 
 fn main() {
+    if let Ok(path) = std::env::var("SURVEY_CAD_LOG") {
+        match File::create(&path) {
+            Ok(file) => {
+                env_logger::Builder::from_default_env()
+                    .target(env_logger::Target::Pipe(Box::new(file)))
+                    .init();
+            }
+            Err(e) => {
+                eprintln!("Failed to create log file {}: {}", path, e);
+                env_logger::Builder::from_default_env().init();
+            }
+        }
+    } else {
+        env_logger::Builder::from_default_env().init();
+    }
+
     let args = Args::parse();
     println!("Using EPSG {}", args.epsg);
     App::new()


### PR DESCRIPTION
## Summary
- add `log` and `env_logger` deps for GUI
- initialize `env_logger` with a file target when `SURVEY_CAD_LOG` is set
- document `SURVEY_CAD_LOG` in README

## Testing
- `cargo test -p survey_cad_gui --quiet` *(fails: process interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_6848c906751c832894fd2309df57124f