### PR TITLE
Fix clippy default constructed unit struct warnings

### DIFF
--- a/survey_cad/src/render/mod.rs
+++ b/survey_cad/src/render/mod.rs
@@ -25,7 +25,7 @@ pub fn render_point(p: Point) {
             }),
             MeshPickingPlugin,
             DefaultEditorCamPlugins,
-            bevy_gizmos::GizmoPlugin::default(),
+            bevy_gizmos::GizmoPlugin,
         ))
         .add_systems(Startup, move |mut commands: Commands| {
             commands.spawn((Camera3d::default(), EditorCam::default()));
@@ -51,7 +51,7 @@ pub fn render_points(points: &[Point]) {
             }),
             MeshPickingPlugin,
             DefaultEditorCamPlugins,
-            bevy_gizmos::GizmoPlugin::default(),
+            bevy_gizmos::GizmoPlugin,
         ))
         .add_systems(Startup, move |mut commands: Commands| {
             commands.spawn((Camera3d::default(), EditorCam::default()));

--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::type_complexity, clippy::too_many_arguments)]
 use bevy::input::mouse::{MouseMotion, MouseWheel};
-use bevy::prelude::*;
 use bevy::log::warn;
+use bevy::prelude::*;
 use bevy_editor_cam::prelude::*;
 use clap::{Parser, ValueEnum};
 use std::collections::HashMap;
@@ -316,7 +316,7 @@ fn main() {
                 ..default()
             }),
             DefaultEditorCamPlugins,
-            bevy_gizmos::GizmoPlugin::default(),
+            bevy_gizmos::GizmoPlugin,
         ))
         .insert_resource(SelectedPoints::default())
         .insert_resource(Dragging::default())
@@ -2149,7 +2149,10 @@ mod tests {
         let mut input = ButtonInput::<KeyCode>::default();
         input.press(KeyCode::KeyL);
         app.insert_resource(input);
-        app.insert_resource(SelectedPoints(vec![Entity::from_raw(1), Entity::from_raw(2)]));
+        app.insert_resource(SelectedPoints(vec![
+            Entity::from_raw(1),
+            Entity::from_raw(2),
+        ]));
 
         app.update();
 
@@ -2162,7 +2165,10 @@ mod tests {
     fn update_line_missing_points() {
         let mut world = World::new();
         world.spawn((
-            CadLine { start: Entity::from_raw(1), end: Entity::from_raw(2) },
+            CadLine {
+                start: Entity::from_raw(1),
+                end: Entity::from_raw(2),
+            },
             Transform::default(),
             Sprite::default(),
         ));


### PR DESCRIPTION
## Summary
- fix clippy warnings by removing unnecessary `::default()` calls

## Testing
- `cargo check -p survey_cad_gui`

------
https://chatgpt.com/codex/tasks/task_e_68497f46094c8328b58d03cc2c48f2f1