### PR TITLE
Add Slint Bevy integration example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "survey_cad_cli",
     "bevy_pmetra",
     "survey_cad_gui",
+    "slint_bevy_example",
     "cad_import", "pipe_network",
     "survey_cad_python",
 ]

--- a/slint_bevy_example/Cargo.toml
+++ b/slint_bevy_example/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "slint_bevy_example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+slint = { git = "https://github.com/slint-ui/slint", rev = "939d605e0688b7ea4cb6e3a5b3f40d918a60a5db", features = ["unstable-wgpu-24"] }
+spin_on = "0.1"
+bevy = { version = "0.16", default-features = false, features = ["bevy_core_pipeline", "bevy_pbr", "bevy_window", "bevy_scene", "bevy_gltf", "bevy_log", "jpeg", "png", "tonemapping_luts", "multi_threaded"] }
+smol = "2.0"
+async-compat = "0.2.4"
+reqwest = { version = "0.12", features = ["stream"] }

--- a/slint_bevy_example/src/main.rs
+++ b/slint_bevy_example/src/main.rs
@@ -1,0 +1,304 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+#![allow(clippy::type_complexity)]
+use bevy::prelude::*;
+use slint::{Model, SharedString};
+
+mod slint_bevy_adapter;
+mod web_asset;
+
+slint::slint! {
+import { Palette, Button, ComboBox, GroupBox, GridBox, Slider, HorizontalBox, VerticalBox, ProgressIndicator } from "std-widgets.slint";
+
+export component AppWindow inherits Window {
+    in property <image> texture <=> i.source;
+    out property <length> requested-texture-width: i.width;
+    out property <length> requested-texture-height: i.height;
+
+    in property <bool> show-loading-screen: false;
+    in property <string> download-url;
+    in property <percent> download-progress;
+
+    in property <[string]> available-models;
+    callback load-model(index: int);
+
+    title: @tr("Slint & Bevy");
+    preferred-width: 500px;
+    preferred-height: 600px;
+
+    VerticalBox {
+        alignment: start;
+        Rectangle {
+            background: Palette.alternate-background;
+
+            VerticalBox {
+                Text {
+                    text: "This text is rendered using Slint. The animation below is rendered using Bevy code.";
+                    wrap: word-wrap;
+                }
+
+                HorizontalBox {
+                    Text {
+                        text: "Select Model:";
+                        vertical-alignment: center;
+                    }
+                    ComboBox {
+                        model: root.available-models;
+                        selected(current-value) => { root.load-model(self.current-index) }
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            width: 100%;
+            height: 100%;
+            if !show-loading-screen: Text {
+                y: 80px;
+                width: 450px;
+                font-size: 14px;
+                text: "This text is also rendered using Slint. It can be seen because Bevy is rendering with a transparent background.";
+                wrap: word-wrap;
+            }
+            i := Image {
+                image-fit: fill;
+                width: 100%;
+                height: 100%;
+                preferred-width: self.source.width * 1px;
+                preferred-height: self.source.height * 1px;
+
+                if show-loading-screen: Rectangle {
+                    VerticalBox {
+                        alignment: start;
+                        Text {
+                            horizontal-alignment: center;
+                            text: "Downloading Assets";
+                        }
+                        Text {
+                            text: download-url;
+                            overflow: elide;
+                        }
+                        ProgressIndicator {
+                            indeterminate: download-url.is-empty;
+                            progress: root.download-progress;
+                        }
+                    }
+                }
+            }
+
+        }
+    }
+}
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (model_selector_sender, model_selector_receiver) = smol::channel::bounded::<GLTFModel>(1);
+
+    let (download_progress_sender, download_progress_receiver) =
+        smol::channel::bounded::<(SharedString, f32)>(5);
+
+    let (new_texture_receiver, control_message_sender) =
+        spin_on::spin_on(slint_bevy_adapter::run_bevy_app_with_slint(
+            |app| {
+                app.add_plugins(web_asset::WebAssetReaderPlugin(download_progress_sender));
+            },
+            |mut app| {
+                app.insert_resource(CameraPos(Vec3::new(3., 4.0, 4.0)))
+                    //                    .insert_resource(ModelBasePath("".into()))
+                    .insert_resource(ModelBasePath(
+                        "https://github.com/KhronosGroup/glTF-Sample-Assets/raw/refs/heads/main/"
+                            .into(),
+                    ))
+                    .add_systems(Startup, setup)
+                    .add_systems(Update, reload_model_from_channel(model_selector_receiver))
+                    .add_systems(Update, animate_camera)
+                    .insert_resource(ClearColor(Color::NONE))
+                    .run();
+            },
+        ))?;
+
+    let app_window = AppWindow::new().unwrap();
+    let app2 = app_window.as_weak();
+
+    app_window
+        .window()
+        .set_rendering_notifier(move |state, _| {
+            let slint::RenderingState::BeforeRendering = state else {
+                return;
+            };
+            let Some(app) = app2.upgrade() else { return };
+            app.window().request_redraw();
+            let Ok(new_texture) = new_texture_receiver.try_recv() else {
+                return;
+            };
+            if let Some(old_texture) = app.get_texture().to_wgpu_24_texture() {
+                let control_message_sender = control_message_sender.clone();
+                slint::spawn_local(async move {
+                    control_message_sender
+                        .send(
+                            slint_bevy_adapter::ControlMessage::ReleaseFrontBufferTexture {
+                                texture: old_texture,
+                            },
+                        )
+                        .await
+                        .unwrap();
+                })
+                .unwrap();
+            }
+
+            let requested_width = app.get_requested_texture_width().round() as u32;
+            let requested_height = app.get_requested_texture_height().round() as u32;
+            if requested_width > 0 && requested_height > 0 {
+                let control_message_sender = control_message_sender.clone();
+                slint::spawn_local(async move {
+                    control_message_sender
+                        .send(slint_bevy_adapter::ControlMessage::ResizeBuffers {
+                            width: requested_width,
+                            height: requested_height,
+                        })
+                        .await
+                        .unwrap();
+                })
+                .unwrap();
+            }
+
+            if let Ok(image) = new_texture.try_into() {
+                app.set_texture(image);
+            }
+        })?;
+
+    let app_weak = app_window.as_weak();
+
+    slint::spawn_local(async move {
+        loop {
+            let Ok((url, progress)) = download_progress_receiver.recv().await else {
+                break;
+            };
+            let Some(app) = app_weak.upgrade() else {
+                return;
+            };
+            app.set_download_url(url);
+            app.set_download_progress(progress * 100.);
+            app.set_show_loading_screen(progress < 1.0);
+        }
+    })
+    .unwrap();
+
+    let models = slint::VecModel::from_slice(&[
+        GLTFModel {
+            name: "Damaged Helmet".into(),
+            path: "Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb".into(),
+            center: Vec3::new(3.0, 4.0, 4.0),
+        },
+        GLTFModel {
+            name: "Fish".into(),
+            path: "Models/BarramundiFish/glTF-Binary/BarramundiFish.glb".into(),
+            center: Vec3::new(3.0, 2.0, 1.0),
+        },
+        GLTFModel {
+            name: "Box".into(),
+            path: "Models/Box/glTF-Binary/Box.glb".into(),
+            center: Vec3::new(3.0, 4.0, 4.0),
+        },
+    ]);
+
+    app_window.set_available_models(slint::ModelRc::new(
+        models.clone().map(|model| model.name.clone()),
+    ));
+
+    model_selector_sender
+        .send_blocking(models.row_data(0).unwrap())
+        .unwrap();
+
+    app_window.on_load_model(move |index| {
+        let model = models.row_data(index as usize).unwrap();
+        let model_selector_sender = model_selector_sender.clone();
+        slint::spawn_local(async move {
+            model_selector_sender.send(model).await.ok();
+        })
+        .unwrap();
+    });
+
+    app_window.run()?;
+
+    Ok(())
+}
+
+#[derive(Clone)]
+struct GLTFModel {
+    name: SharedString,
+    path: SharedString,
+    center: Vec3,
+}
+
+#[derive(Resource)]
+struct CameraPos(Vec3);
+
+#[derive(Resource)]
+struct ModelBasePath(String);
+
+fn setup(mut commands: Commands, camera: Res<CameraPos>) {
+    commands.spawn(DirectionalLight {
+        illuminance: 100_000.0,
+        ..default()
+    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(camera.0).looking_at(Vec3::new(0.0, -0.5, 0.0), Vec3::Y),
+        PointLight {
+            color: Color::linear_rgb(0.5, 0., 0.),
+            ..default()
+        },
+    ));
+
+    /*
+    commands.spawn(SceneRoot(
+        //asset_server.load(GltfAssetLabel::Scene(0).from_asset("DamagedHelmet.glb")),
+        asset_server.load(
+            GltfAssetLabel::Scene(0)
+                .from_asset("Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb"), //  GltfAssetLabel::Scene(0)
+                                                                                   //      .from_asset("https://github.com/KhronosGroup/glTF-Sample-Assets/raw/refs/heads/main/Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb"),
+        ),
+    ));
+    */
+}
+
+fn reload_model_from_channel(
+    receiver: smol::channel::Receiver<GLTFModel>,
+) -> impl FnMut(
+    Commands,
+    Res<AssetServer>,
+    Query<Entity, With<SceneRoot>>,
+    ResMut<CameraPos>,
+    Res<ModelBasePath>,
+) {
+    move |mut commands, asset_server, loaded_bundles, mut camera, base_path| {
+        let Ok(new_model) = receiver.try_recv() else {
+            return;
+        };
+        for loaded_bundle in loaded_bundles.iter() {
+            commands.entity(loaded_bundle).despawn();
+        }
+        commands.spawn(SceneRoot(
+            //asset_server.load(GltfAssetLabel::Scene(0).from_asset("DamagedHelmet.glb")),
+            asset_server.load(
+                GltfAssetLabel::Scene(0).from_asset(format!("{}{}", base_path.0, new_model.path)),
+            ),
+        ));
+        camera.0 = new_model.center;
+    }
+}
+
+fn animate_camera(
+    mut cameras: Query<&mut Transform, With<Camera3d>>,
+    time: Res<Time>,
+    camera: Res<CameraPos>,
+) {
+    let now = time.elapsed_secs();
+    for mut transform in cameras.iter_mut() {
+        // transform.translation = vec3(ops::cos(now), 0.0, ops::sin(now)) * vec3(3.0, 4.0, 4.0);
+        transform.translation = vec3(ops::cos(now), 0.0, ops::sin(now)) * camera.0;
+        transform.look_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y);
+    }
+}

--- a/slint_bevy_example/src/slint_bevy_adapter.rs
+++ b/slint_bevy_example/src/slint_bevy_adapter.rs
@@ -1,0 +1,274 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+//! This module provides function(s) to integrate a bevy App into a Slint application.
+//!
+//! The integration's entry point is [`run_bevy_app_with_slint()`], which will launch the
+//! bevy [`App`] in a thread separate from the main thread and supply textures of the rendered
+//! scenes via channels.
+
+use std::sync::Arc;
+
+use slint::wgpu_24::wgpu;
+
+use bevy::{
+    prelude::*,
+    render::{
+        extract_resource::{ExtractResource, ExtractResourcePlugin},
+        render_graph::{self, NodeRunError, RenderGraph, RenderGraphContext, RenderLabel},
+        renderer::RenderContext,
+        settings::RenderCreation,
+        RenderApp, RenderPlugin,
+    },
+};
+
+/// This enum describes the two kinds of message the Slint application send to the bevy integration thread.
+pub enum ControlMessage {
+    /// Send this message when you don't need a previously received texture anymore.
+    ReleaseFrontBufferTexture { texture: wgpu::Texture },
+    /// Send this message to adjust the size of the scene textures.
+    ResizeBuffers { width: u32, height: u32 },
+}
+
+/// Initializes Bevy and Slint, spawns a bevy [`App`], and supplies textures of the rendered scenes via channels.
+///
+/// Use the `bevy_app_pre_default_plugins_callback` callback to add any plugins to the app before the default plugins.
+/// Use the `bevy_main` callback to add systems, plugins, etc. to your app and call [`App::run()`].
+///
+/// If successful, this function returns two channels:
+/// - Use the receiver channel to obtain textures for use in the Slint UI. These textures have the scene of your default
+///   camera rendered into.
+/// - Use the [`ControlMessage`] sender channel to return textures that you don't need anymore, as well as to inform the
+///   renderer to resize the texture if needed.
+///
+/// *Note*: At the moment only one single camera is supported.
+pub async fn run_bevy_app_with_slint(
+    bevy_app_pre_default_plugins_callback: impl FnOnce(&mut App) + Send + 'static,
+    bevy_main: impl FnOnce(App) + Send + 'static,
+) -> Result<
+    (
+        smol::channel::Receiver<wgpu::Texture>,
+        smol::channel::Sender<ControlMessage>,
+    ),
+    slint::PlatformError,
+> {
+    let backends = wgpu::Backends::from_env().unwrap_or_default();
+    let dx12_shader_compiler = wgpu::Dx12Compiler::from_env().unwrap_or_default();
+    let gles_minor_version = wgpu::Gles3MinorVersion::from_env().unwrap_or_default();
+
+    let instance = wgpu::util::new_instance_with_webgpu_detection(&wgpu::InstanceDescriptor {
+        backends,
+        flags: wgpu::InstanceFlags::from_build_config().with_env(),
+        backend_options: wgpu::BackendOptions {
+            dx12: wgpu::Dx12BackendOptions {
+                shader_compiler: dx12_shader_compiler,
+            },
+            gl: wgpu::GlBackendOptions { gles_minor_version },
+        },
+    })
+    .await;
+
+    let (render_device, render_queue, adapter_info, adapter) =
+        bevy::render::renderer::initialize_renderer(
+            &instance,
+            &bevy::render::settings::WgpuSettings::default(),
+            &wgpu::RequestAdapterOptions::default(),
+        )
+        .await;
+
+    let selector =
+        slint::BackendSelector::new().require_wgpu_24(slint::wgpu_24::WGPUConfiguration::Manual {
+            instance: instance.clone(),
+            adapter: (**adapter.0).clone(),
+            device: render_device.wgpu_device().clone(),
+            queue: (**render_queue.0).clone(),
+        });
+    selector.select()?;
+
+    let (control_message_sender, control_message_receiver) =
+        smol::channel::bounded::<ControlMessage>(2);
+    let (bevy_front_buffer_sender, bevy_front_buffer_receiver) =
+        smol::channel::bounded::<wgpu::Texture>(2);
+
+    let wgpu_device = render_device.wgpu_device().clone();
+
+    let create_texture = move |label, width, height| {
+        wgpu_device.create_texture(&wgpu::TextureDescriptor {
+            label: Some(label),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb, // Can only render to SRGB texture - https://github.com/bevyengine/bevy/issues/15201
+            usage: wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        })
+    };
+
+    let front_buffer = create_texture("Front Buffer", 640, 480);
+    let back_buffer = create_texture("Back Buffer", 640, 480);
+    let inflight_buffer = create_texture("Back Buffer", 640, 480);
+
+    let mut buffer_width = 640;
+    let mut buffer_height = 480;
+
+    let _bevy_thread = std::thread::spawn(move || {
+        let runner = move |mut app: bevy::app::App| {
+            app.finish();
+            app.cleanup();
+
+            let mut next_texture_view_id: u32 = 0;
+
+            loop {
+                let mut next_back_buffer = match control_message_receiver.recv_blocking() {
+                    Ok(ControlMessage::ReleaseFrontBufferTexture { texture }) => texture,
+                    Ok(ControlMessage::ResizeBuffers { width, height }) => {
+                        buffer_width = width;
+                        buffer_height = height;
+                        continue;
+                    }
+                    Err(_) => break,
+                };
+
+                if next_back_buffer.width() != buffer_width
+                    || next_back_buffer.height() != buffer_height
+                {
+                    next_back_buffer = create_texture("back buffer", buffer_width, buffer_height);
+                }
+
+                let texture_view = next_back_buffer.create_view(&wgpu::TextureViewDescriptor {
+                    label: Some("bevy back buffer texture view"),
+                    format: None,
+                    dimension: None,
+                    ..Default::default()
+                });
+                let texture_view_handle =
+                    bevy::render::camera::ManualTextureViewHandle(next_texture_view_id);
+                next_texture_view_id += 1;
+                {
+                    let world = app.world_mut();
+
+                    let mut back_buffer = world.get_resource_mut::<BackBuffer>().unwrap();
+                    back_buffer.0 = Some(next_back_buffer.clone());
+
+                    let mut manual_texture_views = world
+                        .get_resource_mut::<bevy::render::camera::ManualTextureViews>()
+                        .unwrap();
+                    manual_texture_views.clear();
+                    manual_texture_views.insert(
+                        texture_view_handle,
+                        bevy::render::camera::ManualTextureView {
+                            texture_view: texture_view.into(),
+                            size: (next_back_buffer.width(), next_back_buffer.height()).into(),
+                            format: bevy::render::render_resource::TextureFormat::Rgba8UnormSrgb,
+                        },
+                    );
+                    let mut cameras = world.query::<&mut Camera>();
+                    if let Some(mut c) = cameras.iter_mut(world).next() {
+                        c.target =
+                            bevy::render::camera::RenderTarget::TextureView(texture_view_handle);
+                    }
+                }
+
+                app.update();
+            }
+
+            bevy::app::AppExit::Success
+        };
+
+        let mut app = App::new();
+        app.set_runner(runner);
+        app.insert_resource(BackBuffer(None));
+        bevy_app_pre_default_plugins_callback(&mut app);
+        app.add_plugins(
+            DefaultPlugins
+                .set(ImagePlugin::default_nearest())
+                .set(RenderPlugin {
+                    render_creation: RenderCreation::manual(
+                        render_device,
+                        render_queue,
+                        adapter_info,
+                        adapter,
+                        bevy::render::renderer::RenderInstance(Arc::new(
+                            bevy::render::renderer::WgpuWrapper::new(instance),
+                        )),
+                    ),
+                    ..default()
+                }), //.disable::<bevy::winit::WinitPlugin>(),
+        );
+        app.add_plugins(SlintRenderToTexturePlugin(bevy_front_buffer_sender));
+        app.add_plugins(ExtractResourcePlugin::<BackBuffer>::default());
+
+        bevy_main(app)
+    });
+
+    control_message_sender
+        .send_blocking(ControlMessage::ReleaseFrontBufferTexture {
+            texture: back_buffer,
+        })
+        .unwrap();
+    control_message_sender
+        .send_blocking(ControlMessage::ReleaseFrontBufferTexture {
+            texture: inflight_buffer,
+        })
+        .unwrap();
+    control_message_sender
+        .send_blocking(ControlMessage::ReleaseFrontBufferTexture {
+            texture: front_buffer,
+        })
+        .unwrap();
+
+    Ok((bevy_front_buffer_receiver, control_message_sender))
+}
+
+#[derive(Resource, Deref)]
+struct FrontBufferReturnSender(smol::channel::Sender<wgpu::Texture>);
+/// Plugin for Render world part of work
+struct SlintRenderToTexturePlugin(smol::channel::Sender<wgpu::Texture>);
+impl Plugin for SlintRenderToTexturePlugin {
+    fn build(&self, app: &mut App) {
+        let render_app = app.sub_app_mut(RenderApp);
+
+        let mut graph = render_app.world_mut().resource_mut::<RenderGraph>();
+        graph.add_node(SlintSwapChain, SlintSwapChainDriver);
+        graph.add_node_edge(bevy::render::graph::CameraDriverLabel, SlintSwapChain);
+
+        render_app.insert_resource(FrontBufferReturnSender(self.0.clone()));
+    }
+}
+
+#[derive(Clone, Resource, ExtractResource, Deref, DerefMut)]
+struct BackBuffer(pub Option<wgpu::Texture>);
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, RenderLabel)]
+struct SlintSwapChain;
+
+#[derive(Default)]
+struct SlintSwapChainDriver;
+
+impl render_graph::Node for SlintSwapChainDriver {
+    fn run(
+        &self,
+        _graph: &mut RenderGraphContext,
+        _render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
+        let front_buffer_sender = world.get_resource::<FrontBufferReturnSender>().unwrap();
+        let back_buffer = world.get_resource::<BackBuffer>().unwrap();
+
+        if let Some(bb) = &back_buffer.0 {
+            // silently ignore errors when the sender is closed. Reporting an error would just result in bevy panicing,
+            // while a closed channel is indicating a shutdown condition.
+            front_buffer_sender.0.send_blocking(bb.clone()).ok();
+        }
+
+        Ok(())
+    }
+}

--- a/slint_bevy_example/src/web_asset.rs
+++ b/slint_bevy_example/src/web_asset.rs
@@ -1,0 +1,114 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+#![allow(clippy::needless_return)]
+use bevy::asset::io::{AssetReader, AssetSource, AssetSourceId};
+use bevy::prelude::*;
+use slint::SharedString;
+
+fn map_err(err: reqwest::Error) -> bevy::asset::io::AssetReaderError {
+    match err.status().map(|s| s.as_u16()) {
+        Some(404) => bevy::asset::io::AssetReaderError::NotFound(
+            err.url().map(|u| u.path()).unwrap_or_default().into(),
+        ),
+        Some(code) => bevy::asset::io::AssetReaderError::HttpError(code),
+        _ => bevy::asset::io::AssetReaderError::Io(
+            std::io::Error::new(std::io::ErrorKind::Unsupported, "Unknown error").into(),
+        ),
+    }
+}
+
+async fn get(
+    url: impl reqwest::IntoUrl,
+    progress_channel: smol::channel::Sender<(SharedString, f32)>,
+) -> Result<bevy::asset::io::VecReader, bevy::asset::io::AssetReaderError> {
+    use smol::stream::StreamExt;
+
+    let url = url.into_url().unwrap();
+
+    let response = reqwest::get(url.clone()).await.map_err(map_err)?;
+
+    let content_length = response.content_length();
+
+    let mut stream = response.bytes_stream();
+
+    let mut data = Vec::new();
+
+    let progress_url_str = SharedString::from(url.as_str());
+
+    let _ = progress_channel
+        .send((progress_url_str.clone(), 0.))
+        .await
+        .ok();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk_bytes = chunk.map_err(map_err)?;
+        data.extend(chunk_bytes);
+        let progress_percent = content_length
+            .map(|total_length| data.len() as f32 / total_length as f32)
+            .unwrap_or_default();
+        let _ = progress_channel
+            .send((progress_url_str.clone(), progress_percent))
+            .await
+            .ok();
+    }
+
+    Ok(bevy::asset::io::VecReader::new(data))
+}
+
+struct WebAssetLoader(smol::channel::Sender<(SharedString, f32)>);
+
+impl AssetReader for WebAssetLoader {
+    fn read<'a>(
+        &'a self,
+        path: &'a std::path::Path,
+    ) -> impl bevy::asset::io::AssetReaderFuture<Value: bevy::asset::io::Reader + 'a> {
+        let url = reqwest::Url::parse(&format!("https://{}", path.to_string_lossy())).unwrap();
+        async_compat::Compat::new(get(url, self.0.clone()))
+    }
+
+    fn read_meta<'a>(
+        &'a self,
+        path: &'a std::path::Path,
+    ) -> impl bevy::asset::io::AssetReaderFuture<Value: bevy::asset::io::Reader + 'a> {
+        std::future::ready(Result::<bevy::asset::io::VecReader, _>::Err(
+            bevy::asset::io::AssetReaderError::NotFound(path.into()),
+        ))
+    }
+
+    fn read_directory<'a>(
+        &'a self,
+        path: &'a std::path::Path,
+    ) -> impl bevy::tasks::ConditionalSendFuture<
+        Output = std::result::Result<
+            Box<bevy::asset::io::PathStream>,
+            bevy::asset::io::AssetReaderError,
+        >,
+    > {
+        return std::future::ready(Err(bevy::asset::io::AssetReaderError::NotFound(
+            path.into(),
+        )));
+    }
+
+    fn is_directory<'a>(
+        &'a self,
+        _path: &'a std::path::Path,
+    ) -> impl bevy::tasks::ConditionalSendFuture<
+        Output = std::result::Result<bool, bevy::asset::io::AssetReaderError>,
+    > {
+        std::future::ready(Ok(false))
+    }
+}
+
+pub struct WebAssetReaderPlugin(pub smol::channel::Sender<(SharedString, f32)>);
+
+impl Plugin for WebAssetReaderPlugin {
+    fn build(&self, app: &mut App) {
+        let progress_channel = self.0.clone();
+        app.register_asset_source(
+            AssetSourceId::Name("https".into()),
+            AssetSource::build()
+                .with_reader(move || Box::new(WebAssetLoader(progress_channel.clone()))),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- include new `slint_bevy_example` crate demonstrating Slint with Bevy via WGPU
- register the example in the workspace

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` *(failed to complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6849b15c7a648328be0582941ecf54b6