### PR TITLE
Add Slint GUI example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "slint_bevy_example",
     "cad_import", "pipe_network",
     "survey_cad_python",
+    "survey_cad_slint_gui",
 ]
 resolver = "2"
 

--- a/survey_cad_slint_gui/Cargo.toml
+++ b/survey_cad_slint_gui/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "survey_cad_slint_gui"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+slint = { git = "https://github.com/slint-ui/slint", rev = "939d605e0688b7ea4cb6e3a5b3f40d918a60a5db" }
+survey_cad = { path = "../survey_cad" }

--- a/survey_cad_slint_gui/src/main.rs
+++ b/survey_cad_slint_gui/src/main.rs
@@ -1,0 +1,45 @@
+slint::slint! {
+import { Button, VerticalBox, HorizontalBox, LineEdit } from "std-widgets.slint";
+export component DistanceApp inherits Window {
+    width: 300px;
+    height: 200px;
+    in-out property <string> x1;
+    in-out property <string> y1;
+    in-out property <string> x2;
+    in-out property <string> y2;
+    in-out property <string> result;
+    callback compute();
+
+    VerticalBox {
+        HorizontalBox {
+            Text { text: "Point A:"; }
+            LineEdit { text <=> root.x1; placeholder-text: "x"; }
+            LineEdit { text <=> root.y1; placeholder-text: "y"; }
+        }
+        HorizontalBox {
+            Text { text: "Point B:"; }
+            LineEdit { text <=> root.x2; placeholder-text: "x"; }
+            LineEdit { text <=> root.y2; placeholder-text: "y"; }
+        }
+        Button { text: "Compute Distance"; clicked => { root.compute(); } }
+        Text { text: root.result; }
+    }
+}
+}
+
+fn main() -> Result<(), slint::PlatformError> {
+    let app = DistanceApp::new()?;
+    let weak = app.as_weak();
+    app.on_compute(move || {
+        let app = weak.unwrap();
+        let x1: f64 = app.get_x1().parse().unwrap_or(0.0);
+        let y1: f64 = app.get_y1().parse().unwrap_or(0.0);
+        let x2: f64 = app.get_x2().parse().unwrap_or(0.0);
+        let y2: f64 = app.get_y2().parse().unwrap_or(0.0);
+        let p1 = survey_cad::geometry::Point::new(x1, y1);
+        let p2 = survey_cad::geometry::Point::new(x2, y2);
+        let dist = survey_cad::geometry::distance(p1, p2);
+        app.set_result(format!("Distance: {:.2}", dist).into());
+    });
+    app.run()
+}


### PR DESCRIPTION
## Summary
- add a simple `survey_cad_slint_gui` crate
- include it in the workspace

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6849b617583c832893afb9c0f7dc6406