### PR TITLE
Fix bevy tuple limit

### DIFF
--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -467,6 +467,11 @@ fn main() {
                 handle_section_buttons,
                 update_profile_lines,
                 update_plan_labels,
+            ),
+        )
+        .add_systems(
+            Update,
+            (
                 update_section_lines,
                 handle_crs_option_buttons,
             ),


### PR DESCRIPTION
## Summary
- split long `add_systems` tuple in the GUI so bevy compiles

## Testing
- `cargo check -p survey_cad_gui --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684abdee60308328bc3515df5a33eaed