### PR TITLE
Add top menu bar to slint GUI

### DIFF
--- a/survey_cad_slint_gui/src/main.rs
+++ b/survey_cad_slint_gui/src/main.rs
@@ -39,6 +39,28 @@ export component MainWindow inherits Window {
     callback add_arc();
     callback clear_workspace();
 
+    MenuBar {
+        Menu {
+            title: "File";
+            MenuItem { title: "New"; activated => { root.new_project(); } }
+            MenuItem { title: "Open"; activated => { root.open_project(); } }
+            MenuItem { title: "Save"; activated => { root.save_project(); } }
+        }
+        Menu {
+            title: "Edit";
+            MenuItem { title: "Add Point"; activated => { root.add_point(); } }
+            MenuItem { title: "Add Line"; activated => { root.add_line(); } }
+            MenuItem { title: "Add Polygon"; activated => { root.add_polygon(); } }
+            MenuItem { title: "Add Polyline"; activated => { root.add_polyline(); } }
+            MenuItem { title: "Add Arc"; activated => { root.add_arc(); } }
+            MenuItem { title: "Clear"; activated => { root.clear_workspace(); } }
+        }
+        Menu {
+            title: "View";
+            MenuItem { title: "Placeholder"; enabled: false; }
+        }
+    }
+
     HorizontalBox {
         spacing: 6px;
         Button { text: "New"; clicked => { root.new_project(); } }


### PR DESCRIPTION
## Summary
- add a persistent `MenuBar` to the Slint GUI
- include File, Edit, and View dropdown menus with actions hooked up to existing callbacks

## Testing
- `cargo check -p survey_cad_slint_gui`

------
https://chatgpt.com/codex/tasks/task_e_684ac1db91f88328afe0245247834498