### PR TITLE
Fix system registration tuple size

### DIFF
--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -476,6 +476,11 @@ fn main() {
                 handle_section_nav,
                 handle_section_buttons,
                 update_profile_lines,
+            ),
+        )
+        .add_systems(
+            Update,
+            (
                 update_plan_labels,
             ),
         )


### PR DESCRIPTION
## Summary
- avoid using tuple of >20 systems

## Testing
- `cargo check -p survey_cad_gui`

------
https://chatgpt.com/codex/tasks/task_e_684ad1a4a5588328aa0d775627f6798f