### PR TITLE
Add 2D workspace rendering and view toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8885,6 +8885,7 @@ dependencies = [
  "rfd",
  "slint",
  "survey_cad",
+ "tiny-skia",
 ]
 
 [[package]]

--- a/survey_cad_slint_gui/Cargo.toml
+++ b/survey_cad_slint_gui/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 slint = { git = "https://github.com/slint-ui/slint", rev = "939d605e0688b7ea4cb6e3a5b3f40d918a60a5db" }
 survey_cad = { path = "../survey_cad" }
 rfd = "0.15"
+tiny-skia = "0.11"


### PR DESCRIPTION
## Summary
- enable 2D/3D workspace selection in Slint GUI
- implement `Workspace2D` component drawing points and lines
- generate workspace image with tiny-skia
- update menus and callbacks to switch modes and refresh view

## Testing
- `cargo check -p survey_cad_slint_gui`


------
https://chatgpt.com/codex/tasks/task_e_684aca7559848328805385d567fe733a