### PR TITLE
Fix clippy warning in Slint GUI

### DIFF
--- a/survey_cad_slint_gui/src/main.rs
+++ b/survey_cad_slint_gui/src/main.rs
@@ -139,8 +139,7 @@ fn render_workspace(points: &[Point], lines: &[(Point, Point)]) -> Image {
     let mut paint = Paint::default();
     paint.set_color(Color::from_rgba8(255, 0, 0, 255));
     paint.anti_alias = true;
-    let mut stroke = Stroke::default();
-    stroke.width = 2.0;
+    let stroke = Stroke { width: 2.0, ..Stroke::default() };
 
     for (s, e) in lines {
         let mut pb = PathBuilder::new();


### PR DESCRIPTION
## Summary
- fix `clippy::field-reassign-with-default` warning in `survey_cad_slint_gui`

## Testing
- `cargo clippy --all-targets --all-features --workspace -q` *(fails: `gdal-sys` not found)*
- `cargo test --all-targets --all-features --workspace -q` *(fails: `gdal-sys` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae11fe75c8328af25e65850fa9e36