### PR TITLE
Add import/export menus to Slint GUI

### DIFF
--- a/survey_cad_slint_gui/Cargo.toml
+++ b/survey_cad_slint_gui/Cargo.toml
@@ -8,3 +8,11 @@ slint = { git = "https://github.com/slint-ui/slint", rev = "939d605e0688b7ea4cb6
 survey_cad = { path = "../survey_cad" }
 rfd = "0.15"
 tiny-skia = "0.11"
+
+[features]
+default = []
+shapefile = ["survey_cad/shapefile"]
+las = ["survey_cad/las"]
+kml = ["survey_cad/kml"]
+fgdb = ["survey_cad/fgdb"]
+e57 = ["survey_cad/e57"]


### PR DESCRIPTION
## Summary
- extend `MainWindow` with callbacks for import/export actions
- add Import and Export submenus under the File menu
- call the appropriate `survey_cad::io` functions for the chosen format
- expose optional features in `survey_cad_slint_gui`

## Testing
- `cargo check --workspace`

------
https://chatgpt.com/codex/tasks/task_e_684b06e8a37483289a9903877d2f7354