### PR TITLE
Fix nested event loop error in dialogs

### DIFF
--- a/survey_cad_slint_gui/src/main.rs
+++ b/survey_cad_slint_gui/src/main.rs
@@ -1212,7 +1212,7 @@ fn main() -> Result<(), slint::PlatformError> {
                             }
                         });
                     }
-                    key_dlg.run().unwrap();
+                    key_dlg.show().unwrap();
                 });
             }
             {
@@ -1227,7 +1227,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     }
                 });
             }
-            dlg.run().unwrap();
+            dlg.show().unwrap();
         });
     }
 
@@ -1324,10 +1324,10 @@ fn main() -> Result<(), slint::PlatformError> {
                             }
                         });
                     }
-                    kd.run().unwrap();
+                    kd.show().unwrap();
                 });
             }
-            dlg.run().unwrap();
+            dlg.show().unwrap();
         });
     }
 
@@ -1438,10 +1438,10 @@ fn main() -> Result<(), slint::PlatformError> {
                             }
                         });
                     }
-                    pd.run().unwrap();
+                    pd.show().unwrap();
                 });
             }
-            dlg.run().unwrap();
+            dlg.show().unwrap();
         });
     }
 
@@ -1549,10 +1549,10 @@ fn main() -> Result<(), slint::PlatformError> {
                             }
                         });
                     }
-                    pd.run().unwrap();
+                    pd.show().unwrap();
                 });
             }
-            dlg.run().unwrap();
+            dlg.show().unwrap();
         });
     }
 
@@ -1647,10 +1647,10 @@ fn main() -> Result<(), slint::PlatformError> {
                             }
                         });
                     }
-                    ad.run().unwrap();
+                    ad.show().unwrap();
                 });
             }
-            dlg.run().unwrap();
+            dlg.show().unwrap();
         });
     }
 
@@ -1799,7 +1799,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let _ = d.hide();
                 }
             });
-            dlg.run().unwrap();
+            dlg.show().unwrap();
         });
     }
 
@@ -1855,7 +1855,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let _ = d.hide();
                 }
             });
-            dlg.run().unwrap();
+            dlg.show().unwrap();
         });
     }
 


### PR DESCRIPTION
## Summary
- avoid starting nested event loops when opening dialogs

## Testing
- `cargo check`
- `cargo test` *(fails: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*


------
https://chatgpt.com/codex/tasks/task_e_684b0a0661588328ab52a209271c8269