### PR TITLE
Fix Point3 import in slint GUI

### DIFF
--- a/survey_cad_slint_gui/src/main.rs
+++ b/survey_cad_slint_gui/src/main.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use slint::{Image, Rgba8Pixel, SharedPixelBuffer, SharedString, VecModel};
 use survey_cad::crs::{list_known_crs, Crs};
-use survey_cad::geometry::{Arc, Point, Polyline};
+use survey_cad::geometry::{Arc, Point, Point3, Polyline};
 use survey_cad::surveying::{
     bearing, forward, level_elevation, line_intersection, station_distance, vertical_angle, Station,
 };


### PR DESCRIPTION
## Summary
- include `Point3` in geometry imports for the slint GUI crate

## Testing
- `cargo test --workspace` *(fails to complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684b0d3c97f48328ad5ef1a2aa9eb586