### PR TITLE
Add 3D workspace skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,7 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b747210d7db09dfacc237707d4fd31c8b43d7744cd5e5829e2c4ca86b9e47baf"
 dependencies = [
+ "arrayvec",
  "bevy_ecs_macros 0.15.3",
  "bevy_ptr 0.15.3",
  "bevy_reflect 0.15.1",
@@ -1317,6 +1318,37 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38b79c0e43c6387699d6a332d12f98ed895bcf69dd70c462d5e49ad76d44d1f"
+dependencies = [
+ "base64 0.22.1",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_color 0.15.2",
+ "bevy_core",
+ "bevy_core_pipeline 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_hierarchy",
+ "bevy_image 0.15.1",
+ "bevy_math 0.15.1",
+ "bevy_pbr 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
+ "bevy_scene 0.15.1",
+ "bevy_tasks 0.15.3",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
+ "derive_more 1.0.0",
+ "gltf",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "smallvec",
+]
+
+[[package]]
+name = "bevy_gltf"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a080237c0b8842ccc15a06d3379302c68580eeea4497b1c7387e470eda1f07"
@@ -1479,6 +1511,7 @@ dependencies = [
  "bevy_diagnostic 0.15.1",
  "bevy_ecs 0.15.1",
  "bevy_gizmos 0.15.1",
+ "bevy_gltf 0.15.1",
  "bevy_hierarchy",
  "bevy_image 0.15.1",
  "bevy_input 0.15.1",
@@ -1516,7 +1549,7 @@ dependencies = [
  "bevy_diagnostic 0.16.1",
  "bevy_ecs 0.16.1",
  "bevy_gizmos 0.16.1",
- "bevy_gltf",
+ "bevy_gltf 0.16.1",
  "bevy_image 0.16.1",
  "bevy_input 0.16.1",
  "bevy_input_focus",
@@ -2121,7 +2154,9 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028630ddc355563bd567df1076db3515858aa26715ddf7467d2086f9b40e5ab1"
 dependencies = [
+ "async-channel",
  "async-executor",
+ "concurrent-queue",
  "futures-channel",
  "futures-lite",
  "pin-project",
@@ -8882,8 +8917,12 @@ dependencies = [
 name = "survey_cad_slint_gui"
 version = "0.1.0"
 dependencies = [
+ "bevy 0.15.1",
+ "bevy_editor_cam",
  "rfd",
  "slint",
+ "smol",
+ "spin_on",
  "survey_cad",
  "tiny-skia",
 ]

--- a/survey_cad_slint_gui/Cargo.toml
+++ b/survey_cad_slint_gui/Cargo.toml
@@ -4,10 +4,24 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-slint = { git = "https://github.com/slint-ui/slint", rev = "939d605e0688b7ea4cb6e3a5b3f40d918a60a5db" }
+slint = { git = "https://github.com/slint-ui/slint", rev = "939d605e0688b7ea4cb6e3a5b3f40d918a60a5db", features = ["unstable-wgpu-24"] }
 survey_cad = { path = "../survey_cad" }
 rfd = "0.15"
 tiny-skia = "0.11"
+bevy = { version = "0.15", default-features = false, features = [
+    "bevy_core_pipeline",
+    "bevy_pbr",
+    "bevy_window",
+    "bevy_scene",
+    "bevy_gltf",
+    "jpeg",
+    "png",
+    "tonemapping_luts",
+    "multi_threaded"
+] }
+bevy_editor_cam = "0.5"
+spin_on = "0.1"
+smol = "2.0"
 
 [features]
 default = []

--- a/survey_cad_slint_gui/src/bevy_adapter.rs
+++ b/survey_cad_slint_gui/src/bevy_adapter.rs
@@ -1,0 +1,274 @@
+// Copyright © SixtyFPS GmbH <info@slint.dev>
+// SPDX-License-Identifier: MIT
+
+//! This module provides function(s) to integrate a bevy App into a Slint application.
+//!
+//! The integration's entry point is [`run_bevy_app_with_slint()`], which will launch the
+//! bevy [`App`] in a thread separate from the main thread and supply textures of the rendered
+//! scenes via channels.
+
+use std::sync::Arc;
+
+use slint::wgpu_24::wgpu;
+
+use bevy::{
+    prelude::*,
+    render::{
+        extract_resource::{ExtractResource, ExtractResourcePlugin},
+        render_graph::{self, NodeRunError, RenderGraph, RenderGraphContext, RenderLabel},
+        renderer::RenderContext,
+        settings::RenderCreation,
+        RenderApp, RenderPlugin,
+    },
+};
+
+/// This enum describes the two kinds of message the Slint application send to the bevy integration thread.
+pub enum ControlMessage {
+    /// Send this message when you don't need a previously received texture anymore.
+    ReleaseFrontBufferTexture { texture: wgpu::Texture },
+    /// Send this message to adjust the size of the scene textures.
+    ResizeBuffers { width: u32, height: u32 },
+}
+
+/// Initializes Bevy and Slint, spawns a bevy [`App`], and supplies textures of the rendered scenes via channels.
+///
+/// Use the `bevy_app_pre_default_plugins_callback` callback to add any plugins to the app before the default plugins.
+/// Use the `bevy_main` callback to add systems, plugins, etc. to your app and call [`App::run()`].
+///
+/// If successful, this function returns two channels:
+/// - Use the receiver channel to obtain textures for use in the Slint UI. These textures have the scene of your default
+///   camera rendered into.
+/// - Use the [`ControlMessage`] sender channel to return textures that you don't need anymore, as well as to inform the
+///   renderer to resize the texture if needed.
+///
+/// *Note*: At the moment only one single camera is supported.
+pub async fn run_bevy_app_with_slint(
+    bevy_app_pre_default_plugins_callback: impl FnOnce(&mut App) + Send + 'static,
+    bevy_main: impl FnOnce(App) + Send + 'static,
+) -> Result<
+    (
+        smol::channel::Receiver<wgpu::Texture>,
+        smol::channel::Sender<ControlMessage>,
+    ),
+    slint::PlatformError,
+> {
+    let backends = wgpu::Backends::from_env().unwrap_or_default();
+    let dx12_shader_compiler = wgpu::Dx12Compiler::from_env().unwrap_or_default();
+    let gles_minor_version = wgpu::Gles3MinorVersion::from_env().unwrap_or_default();
+
+    let instance = wgpu::util::new_instance_with_webgpu_detection(&wgpu::InstanceDescriptor {
+        backends,
+        flags: wgpu::InstanceFlags::from_build_config().with_env(),
+        backend_options: wgpu::BackendOptions {
+            dx12: wgpu::Dx12BackendOptions {
+                shader_compiler: dx12_shader_compiler,
+            },
+            gl: wgpu::GlBackendOptions { gles_minor_version },
+        },
+    })
+    .await;
+
+    let (render_device, render_queue, adapter_info, adapter) =
+        bevy::render::renderer::initialize_renderer(
+            &instance,
+            &bevy::render::settings::WgpuSettings::default(),
+            &wgpu::RequestAdapterOptions::default(),
+        )
+        .await;
+
+    let selector =
+        slint::BackendSelector::new().require_wgpu_24(slint::wgpu_24::WGPUConfiguration::Manual {
+            instance: instance.clone(),
+            adapter: (**adapter.0).clone(),
+            device: render_device.wgpu_device().clone(),
+            queue: (**render_queue.0).clone(),
+        });
+    selector.select()?;
+
+    let (control_message_sender, control_message_receiver) =
+        smol::channel::bounded::<ControlMessage>(2);
+    let (bevy_front_buffer_sender, bevy_front_buffer_receiver) =
+        smol::channel::bounded::<wgpu::Texture>(2);
+
+    let wgpu_device = render_device.wgpu_device().clone();
+
+    let create_texture = move |label, width, height| {
+        wgpu_device.create_texture(&wgpu::TextureDescriptor {
+            label: Some(label),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb, // Can only render to SRGB texture - https://github.com/bevyengine/bevy/issues/15201
+            usage: wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        })
+    };
+
+    let front_buffer = create_texture("Front Buffer", 640, 480);
+    let back_buffer = create_texture("Back Buffer", 640, 480);
+    let inflight_buffer = create_texture("Back Buffer", 640, 480);
+
+    let mut buffer_width = 640;
+    let mut buffer_height = 480;
+
+    let _bevy_thread = std::thread::spawn(move || {
+        let runner = move |mut app: bevy::app::App| {
+            app.finish();
+            app.cleanup();
+
+            let mut next_texture_view_id: u32 = 0;
+
+            loop {
+                let mut next_back_buffer = match control_message_receiver.recv_blocking() {
+                    Ok(ControlMessage::ReleaseFrontBufferTexture { texture }) => texture,
+                    Ok(ControlMessage::ResizeBuffers { width, height }) => {
+                        buffer_width = width;
+                        buffer_height = height;
+                        continue;
+                    }
+                    Err(_) => break,
+                };
+
+                if next_back_buffer.width() != buffer_width
+                    || next_back_buffer.height() != buffer_height
+                {
+                    next_back_buffer = create_texture("back buffer", buffer_width, buffer_height);
+                }
+
+                let texture_view = next_back_buffer.create_view(&wgpu::TextureViewDescriptor {
+                    label: Some("bevy back buffer texture view"),
+                    format: None,
+                    dimension: None,
+                    ..Default::default()
+                });
+                let texture_view_handle =
+                    bevy::render::camera::ManualTextureViewHandle(next_texture_view_id);
+                next_texture_view_id += 1;
+                {
+                    let world = app.world_mut();
+
+                    let mut back_buffer = world.get_resource_mut::<BackBuffer>().unwrap();
+                    back_buffer.0 = Some(next_back_buffer.clone());
+
+                    let mut manual_texture_views = world
+                        .get_resource_mut::<bevy::render::camera::ManualTextureViews>()
+                        .unwrap();
+                    manual_texture_views.clear();
+                    manual_texture_views.insert(
+                        texture_view_handle,
+                        bevy::render::camera::ManualTextureView {
+                            texture_view: texture_view.into(),
+                            size: (next_back_buffer.width(), next_back_buffer.height()).into(),
+                            format: bevy::render::render_resource::TextureFormat::Rgba8UnormSrgb,
+                        },
+                    );
+                    let mut cameras = world.query::<&mut Camera>();
+                    if let Some(mut c) = cameras.iter_mut(world).next() {
+                        c.target =
+                            bevy::render::camera::RenderTarget::TextureView(texture_view_handle);
+                    }
+                }
+
+                app.update();
+            }
+
+            bevy::app::AppExit::Success
+        };
+
+        let mut app = App::new();
+        app.set_runner(runner);
+        app.insert_resource(BackBuffer(None));
+        bevy_app_pre_default_plugins_callback(&mut app);
+        app.add_plugins(
+            DefaultPlugins
+                .set(ImagePlugin::default_nearest())
+                .set(RenderPlugin {
+                    render_creation: RenderCreation::manual(
+                        render_device,
+                        render_queue,
+                        adapter_info,
+                        adapter,
+                        bevy::render::renderer::RenderInstance(Arc::new(
+                            bevy::render::renderer::WgpuWrapper::new(instance),
+                        )),
+                    ),
+                    ..default()
+                }), //.disable::<bevy::winit::WinitPlugin>(),
+        );
+        app.add_plugins(SlintRenderToTexturePlugin(bevy_front_buffer_sender));
+        app.add_plugins(ExtractResourcePlugin::<BackBuffer>::default());
+
+        bevy_main(app)
+    });
+
+    control_message_sender
+        .send_blocking(ControlMessage::ReleaseFrontBufferTexture {
+            texture: back_buffer,
+        })
+        .unwrap();
+    control_message_sender
+        .send_blocking(ControlMessage::ReleaseFrontBufferTexture {
+            texture: inflight_buffer,
+        })
+        .unwrap();
+    control_message_sender
+        .send_blocking(ControlMessage::ReleaseFrontBufferTexture {
+            texture: front_buffer,
+        })
+        .unwrap();
+
+    Ok((bevy_front_buffer_receiver, control_message_sender))
+}
+
+#[derive(Resource, Deref)]
+struct FrontBufferReturnSender(smol::channel::Sender<wgpu::Texture>);
+/// Plugin for Render world part of work
+struct SlintRenderToTexturePlugin(smol::channel::Sender<wgpu::Texture>);
+impl Plugin for SlintRenderToTexturePlugin {
+    fn build(&self, app: &mut App) {
+        let render_app = app.sub_app_mut(RenderApp);
+
+        let mut graph = render_app.world_mut().resource_mut::<RenderGraph>();
+        graph.add_node(SlintSwapChain, SlintSwapChainDriver);
+        graph.add_node_edge(bevy::render::graph::CameraDriverLabel, SlintSwapChain);
+
+        render_app.insert_resource(FrontBufferReturnSender(self.0.clone()));
+    }
+}
+
+#[derive(Clone, Resource, ExtractResource, Deref, DerefMut)]
+struct BackBuffer(pub Option<wgpu::Texture>);
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, RenderLabel)]
+struct SlintSwapChain;
+
+#[derive(Default)]
+struct SlintSwapChainDriver;
+
+impl render_graph::Node for SlintSwapChainDriver {
+    fn run(
+        &self,
+        _graph: &mut RenderGraphContext,
+        _render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
+        let front_buffer_sender = world.get_resource::<FrontBufferReturnSender>().unwrap();
+        let back_buffer = world.get_resource::<BackBuffer>().unwrap();
+
+        if let Some(bb) = &back_buffer.0 {
+            // silently ignore errors when the sender is closed. Reporting an error would just result in bevy panicing,
+            // while a closed channel is indicating a shutdown condition.
+            front_buffer_sender.0.send_blocking(bb.clone()).ok();
+        }
+
+        Ok(())
+    }
+}

--- a/survey_cad_slint_gui/src/workspace3d.rs
+++ b/survey_cad_slint_gui/src/workspace3d.rs
@@ -1,0 +1,27 @@
+use bevy::prelude::*;
+use bevy::render::mesh::shape;
+use bevy_editor_cam::{DefaultEditorCamPlugins, controller::component::EditorCam};
+
+pub fn setup_scene(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut materials: ResMut<Assets<StandardMaterial>>) {
+    commands.spawn(DirectionalLightBundle {
+        directional_light: DirectionalLight {
+            illuminance: 10000.0,
+            ..default()
+        },
+        ..default()
+    });
+
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        ..default()
+    });
+
+    commands.spawn((Camera3d::default(), EditorCam::default()));
+}
+
+pub fn bevy_app(app: &mut App) {
+    app.add_plugins(DefaultPlugins)
+        .add_plugins(DefaultEditorCamPlugins)
+        .add_systems(Startup, setup_scene);
+}


### PR DESCRIPTION
## Summary
- add wgpu-enabled `slint` integration with Bevy
- include Bevy editor camera setup
- start hooking up 3D workspace in the Slint UI

## Testing
- `cargo check -p survey_cad_slint_gui` *(fails: use of undeclared types, wgpu version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684b18c2b3308328a96dd6ad5b3dd140