### PR TITLE
Fix slint gui compile errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,6 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b747210d7db09dfacc237707d4fd31c8b43d7744cd5e5829e2c4ca86b9e47baf"
 dependencies = [
- "arrayvec",
  "bevy_ecs_macros 0.15.3",
  "bevy_ptr 0.15.3",
  "bevy_reflect 0.15.1",
@@ -1318,37 +1317,6 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38b79c0e43c6387699d6a332d12f98ed895bcf69dd70c462d5e49ad76d44d1f"
-dependencies = [
- "base64 0.22.1",
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_color 0.15.2",
- "bevy_core",
- "bevy_core_pipeline 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_hierarchy",
- "bevy_image 0.15.1",
- "bevy_math 0.15.1",
- "bevy_pbr 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
- "bevy_scene 0.15.1",
- "bevy_tasks 0.15.3",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
- "derive_more 1.0.0",
- "gltf",
- "percent-encoding",
- "serde",
- "serde_json",
- "smallvec",
-]
-
-[[package]]
-name = "bevy_gltf"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a080237c0b8842ccc15a06d3379302c68580eeea4497b1c7387e470eda1f07"
@@ -1511,7 +1479,6 @@ dependencies = [
  "bevy_diagnostic 0.15.1",
  "bevy_ecs 0.15.1",
  "bevy_gizmos 0.15.1",
- "bevy_gltf 0.15.1",
  "bevy_hierarchy",
  "bevy_image 0.15.1",
  "bevy_input 0.15.1",
@@ -1549,7 +1516,7 @@ dependencies = [
  "bevy_diagnostic 0.16.1",
  "bevy_ecs 0.16.1",
  "bevy_gizmos 0.16.1",
- "bevy_gltf 0.16.1",
+ "bevy_gltf",
  "bevy_image 0.16.1",
  "bevy_input 0.16.1",
  "bevy_input_focus",
@@ -2154,9 +2121,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028630ddc355563bd567df1076db3515858aa26715ddf7467d2086f9b40e5ab1"
 dependencies = [
- "async-channel",
  "async-executor",
- "concurrent-queue",
  "futures-channel",
  "futures-lite",
  "pin-project",
@@ -8917,8 +8882,7 @@ dependencies = [
 name = "survey_cad_slint_gui"
 version = "0.1.0"
 dependencies = [
- "bevy 0.15.1",
- "bevy_editor_cam",
+ "bevy 0.16.1",
  "rfd",
  "slint",
  "smol",

--- a/survey_cad_slint_gui/Cargo.toml
+++ b/survey_cad_slint_gui/Cargo.toml
@@ -8,7 +8,7 @@ slint = { git = "https://github.com/slint-ui/slint", rev = "939d605e0688b7ea4cb6
 survey_cad = { path = "../survey_cad" }
 rfd = "0.15"
 tiny-skia = "0.11"
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_pbr",
     "bevy_window",
@@ -19,7 +19,6 @@ bevy = { version = "0.15", default-features = false, features = [
     "tonemapping_luts",
     "multi_threaded"
 ] }
-bevy_editor_cam = "0.5"
 spin_on = "0.1"
 smol = "2.0"
 

--- a/survey_cad_slint_gui/src/bevy_adapter.rs
+++ b/survey_cad_slint_gui/src/bevy_adapter.rs
@@ -26,8 +26,6 @@ use bevy::{
 pub enum ControlMessage {
     /// Send this message when you don't need a previously received texture anymore.
     ReleaseFrontBufferTexture { texture: wgpu::Texture },
-    /// Send this message to adjust the size of the scene textures.
-    ResizeBuffers { width: u32, height: u32 },
 }
 
 /// Initializes Bevy and Slint, spawns a bevy [`App`], and supplies textures of the rendered scenes via channels.
@@ -116,8 +114,8 @@ pub async fn run_bevy_app_with_slint(
     let back_buffer = create_texture("Back Buffer", 640, 480);
     let inflight_buffer = create_texture("Back Buffer", 640, 480);
 
-    let mut buffer_width = 640;
-    let mut buffer_height = 480;
+    let buffer_width = 640;
+    let buffer_height = 480;
 
     let _bevy_thread = std::thread::spawn(move || {
         let runner = move |mut app: bevy::app::App| {
@@ -129,11 +127,6 @@ pub async fn run_bevy_app_with_slint(
             loop {
                 let mut next_back_buffer = match control_message_receiver.recv_blocking() {
                     Ok(ControlMessage::ReleaseFrontBufferTexture { texture }) => texture,
-                    Ok(ControlMessage::ResizeBuffers { width, height }) => {
-                        buffer_width = width;
-                        buffer_height = height;
-                        continue;
-                    }
                     Err(_) => break,
                 };
 

--- a/survey_cad_slint_gui/src/workspace3d.rs
+++ b/survey_cad_slint_gui/src/workspace3d.rs
@@ -1,27 +1,29 @@
 use bevy::prelude::*;
-use bevy::render::mesh::shape;
-use bevy_editor_cam::{DefaultEditorCamPlugins, controller::component::EditorCam};
+use bevy::math::primitives::Cuboid;
 
 pub fn setup_scene(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut materials: ResMut<Assets<StandardMaterial>>) {
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
+    commands.spawn((
+        DirectionalLight {
             illuminance: 10000.0,
             ..default()
         },
-        ..default()
-    });
+        Transform::default(),
+    ));
 
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-        ..default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Mesh::from(Cuboid::new(1.0, 1.0, 1.0)))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        Transform::default(),
+        GlobalTransform::default(),
+    ));
 
-    commands.spawn((Camera3d::default(), EditorCam::default()));
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, -5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Z),
+    ));
 }
 
 pub fn bevy_app(app: &mut App) {
     app.add_plugins(DefaultPlugins)
-        .add_plugins(DefaultEditorCamPlugins)
         .add_systems(Startup, setup_scene);
 }


### PR DESCRIPTION
## Summary
- update bevy version in `survey_cad_slint_gui`
- remove editor cam dependency and adjust 3D setup
- fix Slint UI bindings and remove unused texture resize
- clean up clippy warnings

## Testing
- `cargo clippy -p survey_cad_slint_gui -- -D warnings`
- `cargo test` *(failed to run to completion)*

------
https://chatgpt.com/codex/tasks/task_e_684b1eb100e48328a45ac78830ad3682