### PR TITLE
Fix winit event loop init error

### DIFF
--- a/survey_cad_slint_gui/src/bevy_adapter.rs
+++ b/survey_cad_slint_gui/src/bevy_adapter.rs
@@ -194,7 +194,8 @@ pub async fn run_bevy_app_with_slint(
                         )),
                     ),
                     ..default()
-                }), //.disable::<bevy::winit::WinitPlugin>(),
+                })
+                .disable::<bevy::winit::WinitPlugin>(),
         );
         app.add_plugins(SlintRenderToTexturePlugin(bevy_front_buffer_sender));
         app.add_plugins(ExtractResourcePlugin::<BackBuffer>::default());


### PR DESCRIPTION
## Summary
- disable Bevy's WinitPlugin when launching `survey_cad_slint_gui`

## Testing
- `rustfmt --edition 2021 survey_cad_slint_gui/src/bevy_adapter.rs`


------
https://chatgpt.com/codex/tasks/task_e_684b365b6050832894fbcf09016b3069