### PR TITLE
Add cleanup step before CI checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install GDAL
         run: sudo apt-get update && sudo apt-get install -y libgdal-dev
+      - name: Free disk space
+        run: |
+          sudo apt-get clean
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android $AGENT_TOOLSDIRECTORY
+          df -h
       - name: Build survey_cad_cli
         run: cargo build -p survey_cad_cli --release
       - name: Upload binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install GDAL
         run: sudo apt-get update && sudo apt-get install -y libgdal-dev
+      - name: Free disk space
+        run: |
+          sudo apt-get clean
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android $AGENT_TOOLSDIRECTORY
+          df -h
       - name: Run cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Run cargo test


### PR DESCRIPTION
## Summary
- free disk space in CI before running clippy and tests
- free disk space in build workflow before building CLI

## Testing
- `cargo test --workspace --no-run --quiet` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684b56a331648328848ad560a05a5c0e