### PR TITLE
Add infinite grid and snap option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,6 +1523,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_infinite_grid"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e6a879a57fc6e274d83582eeb387e06f7eaa652224ad9dada0ef97b8326568"
+dependencies = [
+ "bevy 0.16.1",
+]
+
+[[package]]
 name = "bevy_input"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9429,6 +9438,7 @@ name = "survey_cad_slint_gui"
 version = "0.1.0"
 dependencies = [
  "bevy 0.16.1",
+ "bevy_infinite_grid",
  "rfd",
  "slint",
  "smol",

--- a/survey_cad_slint_gui/Cargo.toml
+++ b/survey_cad_slint_gui/Cargo.toml
@@ -20,6 +20,7 @@ bevy = { version = "0.16", default-features = false, features = [
     "tonemapping_luts",
     "multi_threaded"
 ] }
+bevy_infinite_grid = "0.15"
 spin_on = "0.1"
 smol = "2.0"
 

--- a/survey_cad_slint_gui/src/main.rs
+++ b/survey_cad_slint_gui/src/main.rs
@@ -53,7 +53,7 @@ component Workspace3D inherits Rectangle {
     }
 }
 
-import { Button, VerticalBox, HorizontalBox, ComboBox, LineEdit, ListView } from "std-widgets.slint";
+import { Button, VerticalBox, HorizontalBox, ComboBox, LineEdit, ListView, CheckBox } from "std-widgets.slint";
 
 export component AddPointDialog inherits Window {
     callback from_file();
@@ -335,6 +335,7 @@ export component MainWindow inherits Window {
     in-out property <image> workspace_image;
     in-out property <image> workspace_texture;
     in-out property <bool> workspace_click_mode;
+    in-out property <bool> snap_to_grid;
 
     callback workspace_clicked(length, length);
 
@@ -456,6 +457,11 @@ export component MainWindow inherits Window {
             current-index <=> root.crs_index;
             selected => { root.crs_changed(root.crs_index); }
         }
+    }
+
+    HorizontalBox {
+        spacing: 6px;
+        CheckBox { text: "Snap Grid"; checked <=> root.snap_to_grid; }
     }
 
     VerticalBox {
@@ -744,6 +750,7 @@ fn main() -> Result<(), slint::PlatformError> {
     ));
     app.set_workspace_click_mode(false);
     app.set_workspace_texture(Image::default());
+    app.set_snap_to_grid(true);
 
     let (bevy_texture_receiver, bevy_control_sender) =
         spin_on(bevy_adapter::run_bevy_app_with_slint(

--- a/survey_cad_slint_gui/src/workspace3d.rs
+++ b/survey_cad_slint_gui/src/workspace3d.rs
@@ -1,7 +1,9 @@
 use bevy::prelude::*;
 use bevy::math::primitives::Cuboid;
+use bevy_infinite_grid::{InfiniteGridBundle, InfiniteGridPlugin};
 
 pub fn setup_scene(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut materials: ResMut<Assets<StandardMaterial>>) {
+    commands.spawn(InfiniteGridBundle::default());
     commands.spawn((
         DirectionalLight {
             illuminance: 10000.0,
@@ -24,6 +26,6 @@ pub fn setup_scene(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut
 }
 
 pub fn bevy_app(app: &mut App) {
-    app.add_plugins(DefaultPlugins)
+    app.add_plugins((DefaultPlugins, InfiniteGridPlugin))
         .add_systems(Startup, setup_scene);
 }


### PR DESCRIPTION
## Summary
- add `bevy_infinite_grid` crate for an infinite grid
- spawn the grid and plugin in the 3d workspace
- expose a `snap_to_grid` checkbox in the Slint UI

## Testing
- `cargo check -p survey_cad_slint_gui`

------
https://chatgpt.com/codex/tasks/task_e_684be9f014a48328b239cc0bcb0ef96c