### PR TITLE
Fix unused Arc import in snap module

### DIFF
--- a/survey_cad/src/snap.rs
+++ b/survey_cad/src/snap.rs
@@ -1,4 +1,6 @@
-use crate::geometry::{distance, Arc, Line, Point};
+use crate::geometry::{distance, Line, Point};
+#[cfg(test)]
+use crate::geometry::Arc;
 use crate::io::DxfEntity;
 use crate::surveying::line_intersection;
 


### PR DESCRIPTION
## Summary
- import Arc conditionally only for test builds

## Testing
- `cargo check -p survey_cad --quiet`
- `cargo test -p survey_cad --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684c0ca67ea48328bbef36421a2e12e1