### PR TITLE
Fix panic plugin duplication

### DIFF
--- a/survey_cad_slint_gui/src/workspace3d.rs
+++ b/survey_cad_slint_gui/src/workspace3d.rs
@@ -26,6 +26,8 @@ pub fn setup_scene(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut
 }
 
 pub fn bevy_app(app: &mut App) {
-    app.add_plugins((DefaultPlugins, InfiniteGridPlugin))
+    // `run_bevy_app_with_slint` already registers `DefaultPlugins`.
+    // Only additional plugins specific to this workspace should be added here.
+    app.add_plugins(InfiniteGridPlugin)
         .add_systems(Startup, setup_scene);
 }


### PR DESCRIPTION
## Summary
- avoid re-adding `DefaultPlugins` in the 3D workspace helper

## Testing
- `cargo check -p survey_cad_slint_gui`

------
https://chatgpt.com/codex/tasks/task_e_684c42d0830083288903fab510afe899