### PR TITLE
Fix send errors in Slint adapter

### DIFF
--- a/slint_bevy_example/src/main.rs
+++ b/slint_bevy_example/src/main.rs
@@ -209,7 +209,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     model_selector_sender
         .send_blocking(models.row_data(0).unwrap())
-        .unwrap();
+        .ok();
 
     app_window.on_load_model(move |index| {
         let model = models.row_data(index as usize).unwrap();

--- a/slint_bevy_example/src/slint_bevy_adapter.rs
+++ b/slint_bevy_example/src/slint_bevy_adapter.rs
@@ -213,17 +213,17 @@ pub async fn run_bevy_app_with_slint(
         .send_blocking(ControlMessage::ReleaseFrontBufferTexture {
             texture: back_buffer,
         })
-        .unwrap();
+        .ok();
     control_message_sender
         .send_blocking(ControlMessage::ReleaseFrontBufferTexture {
             texture: inflight_buffer,
         })
-        .unwrap();
+        .ok();
     control_message_sender
         .send_blocking(ControlMessage::ReleaseFrontBufferTexture {
             texture: front_buffer,
         })
-        .unwrap();
+        .ok();
 
     Ok((bevy_front_buffer_receiver, control_message_sender))
 }

--- a/survey_cad_slint_gui/src/bevy_adapter.rs
+++ b/survey_cad_slint_gui/src/bevy_adapter.rs
@@ -207,17 +207,17 @@ pub async fn run_bevy_app_with_slint(
         .send_blocking(ControlMessage::ReleaseFrontBufferTexture {
             texture: back_buffer,
         })
-        .unwrap();
+        .ok();
     control_message_sender
         .send_blocking(ControlMessage::ReleaseFrontBufferTexture {
             texture: inflight_buffer,
         })
-        .unwrap();
+        .ok();
     control_message_sender
         .send_blocking(ControlMessage::ReleaseFrontBufferTexture {
             texture: front_buffer,
         })
-        .unwrap();
+        .ok();
 
     Ok((bevy_front_buffer_receiver, control_message_sender))
 }


### PR DESCRIPTION
## Summary
- prevent panics in `survey_cad_slint_gui` when releasing textures
- apply the same fix in the Slint Bevy example
- avoid unwrap on initial model send

## Testing
- `cargo check` *(fails: building workspace takes a long time)*
- `cargo test --workspace --no-run` *(fails: building workspace takes a long time)*

------
https://chatgpt.com/codex/tasks/task_e_684c44df0fe083289ad0613b68b48373