### PR TITLE
Fix clippy warning in workspace mouse move callback

### DIFF
--- a/survey_cad_slint_gui/src/main.rs
+++ b/survey_cad_slint_gui/src/main.rs
@@ -2233,8 +2233,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let sender = ui_tx.clone();
         app.on_workspace_mouse_moved(move |x, y| {
             let _ = sender.send(workspace3d::UiEvent::MouseMove {
-                dx: x as f32,
-                dy: y as f32,
+                dx: x,
+                dy: y,
             });
         });
     }


### PR DESCRIPTION
## Summary
- clean up casting in the mouse move callback

## Testing
- `cargo check -p survey_cad_slint_gui`

------
https://chatgpt.com/codex/tasks/task_e_685008312e0083288b0877435cbed6f8