### PR TITLE
Fix GUI build errors

### DIFF
--- a/survey_cad_slint_gui/src/main.rs
+++ b/survey_cad_slint_gui/src/main.rs
@@ -58,7 +58,11 @@ component Workspace3D inherits Rectangle {
         width: 100%;
         height: 100%;
         moved => { root.mouse_moved(self.mouse-x, self.mouse-y); }
-        exited => { root.mouse_exited(); }
+        pointer-event(event) => {
+            if event.kind == PointerEventKind.cancel {
+                root.mouse_exited();
+            }
+        }
     }
 }
 

--- a/survey_cad_slint_gui/src/workspace3d.rs
+++ b/survey_cad_slint_gui/src/workspace3d.rs
@@ -79,7 +79,7 @@ fn process_ui_events(
                 }
                 UiEvent::UpdatePoints(pts) => {
                     for e in point_entities.0.drain(..) {
-                        commands.entity(e).despawn_recursive();
+                        commands.entity(e).despawn();
                     }
                     for p in pts {
                         let e = commands


### PR DESCRIPTION
## Summary
- update TouchArea to use pointer-event for exit handling
- use despawn instead of deprecated despawn_recursive

## Testing
- `cargo check -p survey_cad_slint_gui`
- `cargo test -p survey_cad_slint_gui --no-run -q`

------
https://chatgpt.com/codex/tasks/task_e_68501c0ea9fc83289943af865e5939b7