### PR TITLE
Fix workspace box fill in slint GUI

### DIFF
--- a/survey_cad_slint_gui/src/main.rs
+++ b/survey_cad_slint_gui/src/main.rs
@@ -482,12 +482,15 @@ export component MainWindow inherits Window {
     }
 
     VerticalBox {
+        height: 100%;
         if root.workspace_mode == 0 : Workspace2D {
+            vertical-stretch: 1;
             image <=> root.workspace_image;
             click_mode <=> root.workspace_click_mode;
             clicked(x, y) => { root.workspace_clicked(x, y); }
         }
         if root.workspace_mode == 1 : Workspace3D {
+            vertical-stretch: 1;
             texture <=> root.workspace_texture;
             mouse_moved(x, y) => { root.workspace_mouse_moved(x, y); }
             mouse_exited() => { root.workspace_mouse_exited(); }


### PR DESCRIPTION
## Summary
- ensure the main window's workspace box fills available height
- allow 2D and 3D workspaces to expand vertically

## Testing
- `cargo check -p survey_cad_slint_gui`
- `cargo run -p survey_cad_slint_gui -- --help` *(fails: Unable to find a GPU)*

------
https://chatgpt.com/codex/tasks/task_e_685027e1706c8328902234b9473ac11a