### PR TITLE
Remove unnecessary cast in workspace3d

### DIFF
--- a/survey_cad_slint_gui/src/workspace3d.rs
+++ b/survey_cad_slint_gui/src/workspace3d.rs
@@ -79,7 +79,7 @@ pub fn setup_scene(
         },
         Transform::from_translation(Vec3::new(0.0, 0.0, 3.0)).looking_at(Vec3::ZERO, Vec3::Y),
         OrientationCamera,
-        RenderLayers::layer(ORIENTATION_LAYER as usize),
+        RenderLayers::layer(ORIENTATION_LAYER),
     ));
 
     // Orientation cube
@@ -89,7 +89,7 @@ pub fn setup_scene(
         Transform::default(),
         GlobalTransform::default(),
         OrientationCube,
-        RenderLayers::layer(ORIENTATION_LAYER as usize),
+        RenderLayers::layer(ORIENTATION_LAYER),
     ));
 }
 


### PR DESCRIPTION
## Summary
- fix `RenderLayers` call in workspace3d.rs by removing redundant cast

## Testing
- `cargo test --all --release -- --test-threads=1` *(fails: build halted)*

------
https://chatgpt.com/codex/tasks/task_e_68506fc653648328be2c8ae0fcf3b5aa