### PR TITLE
Fix orientation cube query conflict

### DIFF
--- a/survey_cad_slint_gui/src/workspace3d.rs
+++ b/survey_cad_slint_gui/src/workspace3d.rs
@@ -156,7 +156,7 @@ fn send_camera_data(
 }
 
 fn sync_orientation_cube(
-    main_cam: Query<&Transform, (With<Camera3d>, With<MainCamera>)>,
+    main_cam: Query<&Transform, (With<Camera3d>, With<MainCamera>, Without<OrientationCube>)>,
     mut cube: Query<&mut Transform, With<OrientationCube>>,
 ) {
     if let (Ok(cam), Ok(mut cube_tf)) = (main_cam.single(), cube.single_mut()) {


### PR DESCRIPTION
## Summary
- ensure orientation cube sync query is disjoint from the main camera query

## Testing
- `cargo check --package survey_cad_slint_gui` *(fails: took too long, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68515a6363748328867278ee16218445