### PR TITLE
Add Truck-based Slint GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4319,6 +4319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b"
 dependencies = [
  "hashbrown 0.15.4",
+ "rayon",
  "ttf-parser 0.21.1",
 ]
 
@@ -5170,6 +5171,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "rayon",
  "serde",
 ]
 
@@ -5413,7 +5415,7 @@ dependencies = [
  "drm",
  "gbm",
  "glutin",
- "i-slint-common",
+ "i-slint-common 1.12.0 (git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db)",
  "i-slint-core",
  "i-slint-renderer-femtovg",
  "input",
@@ -5431,7 +5433,7 @@ dependencies = [
  "const-field-offset",
  "cpp",
  "cpp_build",
- "i-slint-common",
+ "i-slint-common 1.12.0 (git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db)",
  "i-slint-core",
  "i-slint-core-macros",
  "lyon_path",
@@ -5450,7 +5452,7 @@ dependencies = [
  "i-slint-backend-linuxkms",
  "i-slint-backend-qt",
  "i-slint-backend-winit",
- "i-slint-common",
+ "i-slint-common 1.12.0 (git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db)",
  "i-slint-core",
  "i-slint-core-macros",
  "i-slint-renderer-skia",
@@ -5471,7 +5473,7 @@ dependencies = [
  "futures",
  "glutin",
  "glutin-winit",
- "i-slint-common",
+ "i-slint-common 1.12.0 (git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db)",
  "i-slint-core",
  "i-slint-core-macros",
  "i-slint-renderer-femtovg",
@@ -5496,6 +5498,19 @@ dependencies = [
 [[package]]
 name = "i-slint-common"
 version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "748b5c0e292b2263fbd5b2855df207f4f6e068382668c55526037ac0ff5ba038"
+dependencies = [
+ "cfg-if",
+ "derive_more 2.0.1",
+ "fontdb 0.23.0",
+ "libloading",
+ "ttf-parser 0.25.1",
+]
+
+[[package]]
+name = "i-slint-common"
+version = "1.12.0"
 source = "git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db#939d605e0688b7ea4cb6e3a5b3f40d918a60a5db"
 dependencies = [
  "cfg-if",
@@ -5508,13 +5523,43 @@ dependencies = [
 [[package]]
 name = "i-slint-compiler"
 version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae46edba3b6875f66765d4074ecf4d65b8cbf1e7a0f2b4581e23e72bd8f1157"
+dependencies = [
+ "by_address",
+ "codemap",
+ "codemap-diagnostic",
+ "derive_more 2.0.1",
+ "fontdue",
+ "i-slint-common 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.25.6",
+ "itertools 0.14.0",
+ "linked_hash_set",
+ "lyon_extra",
+ "lyon_path",
+ "num_enum",
+ "polib",
+ "proc-macro2",
+ "quote",
+ "rayon",
+ "resvg",
+ "rowan",
+ "smol_str 0.3.2",
+ "strum 0.27.1",
+ "typed-index-collections",
+ "url",
+]
+
+[[package]]
+name = "i-slint-compiler"
+version = "1.12.0"
 source = "git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db#939d605e0688b7ea4cb6e3a5b3f40d918a60a5db"
 dependencies = [
  "by_address",
  "codemap",
  "codemap-diagnostic",
  "derive_more 2.0.1",
- "i-slint-common",
+ "i-slint-common 1.12.0 (git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db)",
  "itertools 0.14.0",
  "linked_hash_set",
  "lyon_extra",
@@ -5544,7 +5589,7 @@ dependencies = [
  "derive_more 2.0.1",
  "euclid",
  "fontdue",
- "i-slint-common",
+ "i-slint-common 1.12.0 (git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db)",
  "i-slint-core-macros",
  "image 0.25.6",
  "integer-sqrt",
@@ -5600,7 +5645,7 @@ dependencies = [
  "dwrote",
  "femtovg",
  "glow 0.16.0",
- "i-slint-common",
+ "i-slint-common 1.12.0 (git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db)",
  "i-slint-core",
  "i-slint-core-macros",
  "imgref",
@@ -5629,7 +5674,7 @@ dependencies = [
  "derive_more 2.0.1",
  "glow 0.16.0",
  "glutin",
- "i-slint-common",
+ "i-slint-common 1.12.0 (git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db)",
  "i-slint-core",
  "i-slint-core-macros",
  "lyon_path",
@@ -6262,6 +6307,15 @@ checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
 dependencies = [
  "libc",
  "x11",
+]
+
+[[package]]
+name = "linereader"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d921fea6860357575519aca014c6e22470585accdd543b370c404a8a72d0dd1d"
+dependencies = [
+ "memchr 2.7.4",
 ]
 
 [[package]]
@@ -7623,6 +7677,15 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polib"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b393b155cf9be86249cba1b56cc81be0e6212c66d94ac0d76d37a1761f3bb1b"
+dependencies = [
+ "linereader",
 ]
 
 [[package]]
@@ -9016,11 +9079,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "slint-build"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7076e05474941b35df7e2d03c393a3c3b4e4855dd93f0280451002df07e474"
+dependencies = [
+ "derive_more 2.0.1",
+ "i-slint-compiler 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin_on",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
 name = "slint-macros"
 version = "1.12.0"
 source = "git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db#939d605e0688b7ea4cb6e3a5b3f40d918a60a5db"
 dependencies = [
- "i-slint-compiler",
+ "i-slint-compiler 1.12.0 (git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db)",
  "proc-macro2",
  "quote",
  "spin_on",
@@ -9442,10 +9517,23 @@ dependencies = [
  "crossbeam-channel",
  "rfd",
  "slint",
+ "slint-build",
  "smol",
  "spin_on",
  "survey_cad",
  "tiny-skia",
+]
+
+[[package]]
+name = "survey_cad_truck_gui"
+version = "0.1.0"
+dependencies = [
+ "rfd",
+ "slint",
+ "slint-build",
+ "survey_cad",
+ "tiny-skia",
+ "truck_cad_engine",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "survey_cad_python",
     "survey_cad_slint_gui",
     "truck_cad_engine",
+    "survey_cad_truck_gui",
 ]
 resolver = "2"
 

--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "survey_cad_truck_gui"
+version = "0.1.0"
+edition = "2021"
+build = "build.rs"
+
+[dependencies]
+slint = { git = "https://github.com/slint-ui/slint", rev = "939d605e0688b7ea4cb6e3a5b3f40d918a60a5db", features = ["unstable-wgpu-24"] }
+survey_cad = { path = "../survey_cad" }
+rfd = "0.15"
+tiny-skia = "0.11"
+truck_cad_engine = { path = "../truck_cad_engine" }
+
+[build-dependencies]
+slint-build = "1"
+
+[features]
+default = []
+shapefile = ["survey_cad/shapefile"]
+las = ["survey_cad/las"]
+kml = ["survey_cad/kml"]
+fgdb = ["survey_cad/fgdb"]
+e57 = ["survey_cad/e57"]

--- a/survey_cad_truck_gui/README.md
+++ b/survey_cad_truck_gui/README.md
@@ -1,0 +1,21 @@
+# survey_cad_truck_gui
+
+This crate contains an alternative Slint based GUI that uses the Truck CAD
+engine for rendering.
+
+## Editing the UI
+
+The user interface is defined in the files inside [`ui/`](ui/). The main
+entry point is `main.slint` which imports additional modules such as
+`workspace.slint` and `dialogs.slint`.
+
+To modify the UI simply edit these `.slint` files. The Rust bindings generated
+from them are rebuilt automatically when running `cargo build`:
+
+```bash
+# from the workspace root
+cargo build -p survey_cad_truck_gui
+```
+
+Rebuilding ensures that any changes in the `.slint` files are reflected in the
+Rust code via the generated bindings.

--- a/survey_cad_truck_gui/build.rs
+++ b/survey_cad_truck_gui/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    slint_build::compile("ui/main.slint").unwrap();
+}

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -1,0 +1,137 @@
+#![allow(unused_variables)]
+
+use slint::{Image, SharedString, VecModel};
+use std::rc::Rc;
+
+use survey_cad::alignment::HorizontalAlignment;
+use survey_cad::crs::list_known_crs;
+use survey_cad::dtm::Tin;
+use survey_cad::geometry::{Arc, Line, Point, Polyline};
+
+mod truck_backend;
+use truck_backend::TruckBackend;
+
+use tiny_skia::{Color, Paint, PathBuilder, Pixmap, Stroke, Transform};
+
+slint::include_modules!();
+
+struct WorkspaceRenderData<'a> {
+    points: &'a [Point],
+    lines: &'a [(Point, Point)],
+    polygons: &'a [Vec<Point>],
+    polylines: &'a [Polyline],
+    arcs: &'a [Arc],
+    surfaces: &'a [Tin],
+    alignments: &'a [HorizontalAlignment],
+}
+
+fn render_workspace(data: &WorkspaceRenderData, zoom: f32) -> Image {
+    const WIDTH: u32 = 600;
+    const HEIGHT: u32 = 400;
+    let mut pixmap = Pixmap::new(WIDTH, HEIGHT).unwrap();
+    pixmap.fill(Color::from_rgba8(32, 32, 32, 255));
+    let mut paint = Paint::default();
+    paint.set_color(Color::from_rgba8(60, 60, 60, 255));
+    paint.anti_alias = true;
+    let grid_stroke = Stroke {
+        width: 1.0,
+        ..Stroke::default()
+    };
+    let origin_x = WIDTH as f32 / 2.0;
+    let origin_y = HEIGHT as f32 / 2.0;
+    let tx = |x: f32| x * zoom + origin_x;
+    let ty = |y: f32| origin_y - y * zoom;
+    let step = 50.0 * zoom;
+    let mut x = origin_x;
+    while x < WIDTH as f32 {
+        let mut pb = PathBuilder::new();
+        pb.move_to(x, 0.0);
+        pb.line_to(x, HEIGHT as f32);
+        if let Some(p) = pb.finish() {
+            pixmap.stroke_path(&p, &paint, &grid_stroke, Transform::identity(), None);
+        }
+        x += step;
+    }
+    x = origin_x - step;
+    while x >= 0.0 {
+        let mut pb = PathBuilder::new();
+        pb.move_to(x, 0.0);
+        pb.line_to(x, HEIGHT as f32);
+        if let Some(p) = pb.finish() {
+            pixmap.stroke_path(&p, &paint, &grid_stroke, Transform::identity(), None);
+        }
+        x -= step;
+    }
+    let mut y = origin_y;
+    while y < HEIGHT as f32 {
+        let mut pb = PathBuilder::new();
+        pb.move_to(0.0, y);
+        pb.line_to(WIDTH as f32, y);
+        if let Some(p) = pb.finish() {
+            pixmap.stroke_path(&p, &paint, &grid_stroke, Transform::identity(), None);
+        }
+        y += step;
+    }
+    y = origin_y - step;
+    while y >= 0.0 {
+        let mut pb = PathBuilder::new();
+        pb.move_to(0.0, y);
+        pb.line_to(WIDTH as f32, y);
+        if let Some(p) = pb.finish() {
+            pixmap.stroke_path(&p, &paint, &grid_stroke, Transform::identity(), None);
+        }
+        y -= step;
+    }
+    paint.set_color(Color::from_rgba8(90, 90, 90, 255));
+    let mut pb = PathBuilder::new();
+    pb.move_to(origin_x, 0.0);
+    pb.line_to(origin_x, HEIGHT as f32);
+    if let Some(path) = pb.finish() {
+        pixmap.stroke_path(&path, &paint, &grid_stroke, Transform::identity(), None);
+    }
+    let mut pb = PathBuilder::new();
+    pb.move_to(0.0, origin_y);
+    pb.line_to(WIDTH as f32, origin_y);
+    if let Some(path) = pb.finish() {
+        pixmap.stroke_path(&path, &paint, &grid_stroke, Transform::identity(), None);
+    }
+    let buffer = slint::SharedPixelBuffer::<slint::Rgba8Pixel>::clone_from_slice(
+        pixmap.data(),
+        WIDTH,
+        HEIGHT,
+    );
+    Image::from_rgba8_premultiplied(buffer)
+}
+
+fn main() -> Result<(), slint::PlatformError> {
+    let mut backend = TruckBackend::new(640, 480);
+    let app = MainWindow::new()?;
+
+    // basic CRS list as before
+    let crs_entries = list_known_crs();
+    let crs_model = Rc::new(VecModel::from(
+        crs_entries
+            .iter()
+            .map(|e| SharedString::from(format!("{} - {}", e.code, e.name)))
+            .collect::<Vec<_>>(),
+    ));
+    app.set_crs_list(crs_model.into());
+    app.set_crs_index(0);
+    app.set_workspace_mode(1); // start with 3D mode to show truck rendering
+
+    let weak = app.as_weak();
+
+    app.window()
+        .set_rendering_notifier(move |state, _| {
+            if let slint::RenderingState::BeforeRendering = state {
+                if let Some(app) = weak.upgrade() {
+                    let image = backend.render();
+                    app.set_workspace_texture(image);
+                    app.window().request_redraw();
+                }
+            }
+        })
+        .unwrap();
+
+    app.run()
+}

--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -1,0 +1,18 @@
+use slint::Image;
+use truck_cad_engine::TruckCadEngine;
+
+pub struct TruckBackend {
+    engine: TruckCadEngine,
+}
+
+impl TruckBackend {
+    pub fn new(width: u32, height: u32) -> Self {
+        let mut engine = TruckCadEngine::new(width, height);
+        engine.add_unit_cube();
+        Self { engine }
+    }
+
+    pub fn render(&mut self) -> Image {
+        self.engine.render_to_image()
+    }
+}

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -1,0 +1,500 @@
+component Workspace2D inherits Rectangle {
+    in-out property <image> image;
+    in-out property <bool> click_mode;
+    callback clicked(length, length);
+    background: #202020;
+    Image {
+        source: root.image;
+        image-fit: fill;
+        width: 100%;
+        height: 100%;
+    }
+    if root.click_mode : TouchArea {
+        width: 100%;
+        height: 100%;
+        clicked => { root.clicked(self.mouse-x, self.mouse-y); }
+    }
+}
+
+component Workspace3D inherits Rectangle {
+    in-out property <image> texture <=> img.source;
+    out property <length> requested-texture-width: img.width;
+    out property <length> requested-texture-height: img.height;
+    callback mouse_moved(length, length);
+    callback mouse_exited();
+    background: #202020;
+    img := Image {
+        width: 100%;
+        height: 100%;
+        image-fit: fill;
+    }
+    TouchArea {
+        width: 100%;
+        height: 100%;
+        moved => { root.mouse_moved(self.mouse-x, self.mouse-y); }
+        pointer-event(event) => {
+            if event.kind == PointerEventKind.cancel {
+                root.mouse_exited();
+            }
+        }
+    }
+}
+
+import { Button, VerticalBox, HorizontalBox, ComboBox, LineEdit, ListView, CheckBox } from "std-widgets.slint";
+
+export component AddPointDialog inherits Window {
+    callback from_file();
+    callback manual_keyin();
+    callback manual_click();
+    title: "Add Point";
+    VerticalBox {
+        spacing: 6px;
+        Button { text: "From File"; clicked => { root.from_file(); } }
+        Button { text: "Manual (Key In)"; clicked => { root.manual_keyin(); } }
+        Button { text: "Manual (Click on Screen)"; clicked => { root.manual_click(); } }
+    }
+}
+
+export component KeyInDialog inherits Window {
+    in-out property <string> x_value;
+    in-out property <string> y_value;
+    callback accept();
+    callback cancel();
+    title: "Enter Point";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox {
+            Text { text: "X:"; }
+            LineEdit { text <=> root.x_value; }
+        }
+        HorizontalBox {
+            Text { text: "Y:"; }
+            LineEdit { text <=> root.y_value; }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "OK"; clicked => { root.accept(); } }
+            Button { text: "Cancel"; clicked => { root.cancel(); } }
+        }
+    }
+}
+
+export component StationDistanceDialog inherits Window {
+    in-out property <string> x1;
+    in-out property <string> y1;
+    in-out property <string> x2;
+    in-out property <string> y2;
+    callback accept();
+    callback cancel();
+    title: "Station Distance";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox {
+            Text { text: "X1:"; }
+            LineEdit { text <=> root.x1; }
+        }
+        HorizontalBox {
+            Text { text: "Y1:"; }
+            LineEdit { text <=> root.y1; }
+        }
+        HorizontalBox {
+            Text { text: "X2:"; }
+            LineEdit { text <=> root.x2; }
+        }
+        HorizontalBox {
+            Text { text: "Y2:"; }
+            LineEdit { text <=> root.y2; }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "OK"; clicked => { root.accept(); } }
+            Button { text: "Cancel"; clicked => { root.cancel(); } }
+        }
+    }
+}
+
+export component LevelElevationDialog inherits Window {
+    in-out property <string> start_elev;
+    in-out property <string> backsight;
+    in-out property <string> foresight;
+    callback accept();
+    callback cancel();
+    title: "Level Elevation";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox {
+            Text { text: "Start Elev:"; }
+            LineEdit { text <=> root.start_elev; }
+        }
+        HorizontalBox {
+            Text { text: "Backsight:"; }
+            LineEdit { text <=> root.backsight; }
+        }
+        HorizontalBox {
+            Text { text: "Foresight:"; }
+            LineEdit { text <=> root.foresight; }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "OK"; clicked => { root.accept(); } }
+            Button { text: "Cancel"; clicked => { root.cancel(); } }
+        }
+    }
+}
+
+export component CorridorVolumeDialog inherits Window {
+    in-out property <string> width_value;
+    in-out property <string> interval_value;
+    in-out property <string> offset_step_value;
+    callback accept();
+    callback cancel();
+    title: "Corridor Volume";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox {
+            Text { text: "Width:"; }
+            LineEdit { text <=> root.width_value; }
+        }
+        HorizontalBox {
+            Text { text: "Interval:"; }
+            LineEdit { text <=> root.interval_value; }
+        }
+        HorizontalBox {
+            Text { text: "Offset Step:"; }
+            LineEdit { text <=> root.offset_step_value; }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "OK"; clicked => { root.accept(); } }
+            Button { text: "Cancel"; clicked => { root.cancel(); } }
+        }
+    }
+}
+
+export component AddLineDialog inherits Window {
+    callback from_file();
+    callback manual();
+    title: "Add Line";
+    VerticalBox {
+        spacing: 6px;
+        Button { text: "From File"; clicked => { root.from_file(); } }
+        Button { text: "Manual"; clicked => { root.manual(); } }
+    }
+}
+
+export component LineKeyInDialog inherits Window {
+    in-out property <string> x1;
+    in-out property <string> y1;
+    in-out property <string> x2;
+    in-out property <string> y2;
+    callback accept();
+    callback cancel();
+    title: "Enter Line";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox {
+            Text { text: "X1:"; }
+            LineEdit { text <=> root.x1; }
+            Text { text: "Y1:"; }
+            LineEdit { text <=> root.y1; }
+        }
+        HorizontalBox {
+            Text { text: "X2:"; }
+            LineEdit { text <=> root.x2; }
+            Text { text: "Y2:"; }
+            LineEdit { text <=> root.y2; }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "OK"; clicked => { root.accept(); } }
+            Button { text: "Cancel"; clicked => { root.cancel(); } }
+        }
+    }
+}
+
+export component AddPolygonDialog inherits Window {
+    callback from_file();
+    callback manual();
+    title: "Add Polygon";
+    VerticalBox {
+        spacing: 6px;
+        Button { text: "From File"; clicked => { root.from_file(); } }
+        Button { text: "Manual"; clicked => { root.manual(); } }
+    }
+}
+
+export component AddPolylineDialog inherits Window {
+    callback from_file();
+    callback manual();
+    title: "Add Polyline";
+    VerticalBox {
+        spacing: 6px;
+        Button { text: "From File"; clicked => { root.from_file(); } }
+        Button { text: "Manual"; clicked => { root.manual(); } }
+    }
+}
+
+export component PointsDialog inherits Window {
+    in-out property <string> x_value;
+    in-out property <string> y_value;
+    in-out property <[string]> points_model;
+    callback add_point();
+    callback accept();
+    callback cancel();
+    title: "Enter Points";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox {
+            Text { text: "X:"; }
+            LineEdit { text <=> root.x_value; }
+            Text { text: "Y:"; }
+            LineEdit { text <=> root.y_value; }
+            Button { text: "Add"; clicked => { root.add_point(); } }
+        }
+        ListView {
+            for p in root.points_model : Text { text: p; }
+            height: 100px;
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "OK"; clicked => { root.accept(); } }
+            Button { text: "Cancel"; clicked => { root.cancel(); } }
+        }
+    }
+}
+
+export component AddArcDialog inherits Window {
+    callback from_file();
+    callback manual();
+    title: "Add Arc";
+    VerticalBox {
+        spacing: 6px;
+        Button { text: "From File"; clicked => { root.from_file(); } }
+        Button { text: "Manual"; clicked => { root.manual(); } }
+    }
+}
+
+export component ArcKeyInDialog inherits Window {
+    in-out property <string> cx;
+    in-out property <string> cy;
+    in-out property <string> radius;
+    in-out property <string> start_angle;
+    in-out property <string> end_angle;
+    callback accept();
+    callback cancel();
+    title: "Enter Arc";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox {
+            Text { text: "Cx:"; }
+            LineEdit { text <=> root.cx; }
+            Text { text: "Cy:"; }
+            LineEdit { text <=> root.cy; }
+        }
+        HorizontalBox {
+            Text { text: "Radius:"; }
+            LineEdit { text <=> root.radius; }
+        }
+        HorizontalBox {
+            Text { text: "Start:"; }
+            LineEdit { text <=> root.start_angle; }
+            Text { text: "End:"; }
+            LineEdit { text <=> root.end_angle; }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "OK"; clicked => { root.accept(); } }
+            Button { text: "Cancel"; clicked => { root.cancel(); } }
+        }
+    }
+}
+
+export component MainWindow inherits Window {
+    preferred-width: 800px;
+    preferred-height: 600px;
+
+    in-out property <string> status;
+    in property <[string]> crs_list;
+    in-out property <int> crs_index;
+    in property <[string]> cogo_list;
+    in-out property <int> cogo_index;
+    in-out property <int> workspace_mode;
+    in-out property <image> workspace_image;
+    in-out property <image> workspace_texture;
+    in-out property <bool> workspace_click_mode;
+    in-out property <bool> snap_to_grid;
+    in-out property <bool> snap_to_entities;
+    in-out property <float> zoom_level;
+
+    callback workspace_clicked(length, length);
+    callback workspace_mouse_moved(length, length);
+    callback workspace_mouse_exited();
+
+    callback crs_changed(int);
+    callback cogo_selected(int);
+
+    callback new_project();
+    callback open_project();
+    callback save_project();
+    callback add_point();
+    callback add_line();
+    callback add_polygon();
+    callback add_polyline();
+    callback add_arc();
+    callback clear_workspace();
+    callback view_changed(int);
+    callback station_distance();
+    callback traverse_area();
+    callback level_elevation_tool();
+    callback corridor_volume();
+    callback import_geojson();
+    callback import_kml();
+    callback import_dxf();
+    callback import_shp();
+    callback import_las();
+    callback import_e57();
+    callback export_geojson();
+    callback export_kml();
+    callback export_dxf();
+    callback export_shp();
+    callback export_las();
+    callback export_e57();
+    callback import_landxml_surface();
+    callback import_landxml_alignment();
+    callback zoom_in();
+    callback zoom_out();
+
+    menubar := MenuBar {
+        Menu {
+            title: "File";
+            MenuItem { title: "New"; activated => { root.new_project(); } }
+            MenuItem { title: "Open"; activated => { root.open_project(); } }
+            MenuItem { title: "Save"; activated => { root.save_project(); } }
+            Menu {
+                title: "Import";
+                MenuItem { title: "GeoJSON"; activated => { root.import_geojson(); } }
+                MenuItem { title: "KML"; activated => { root.import_kml(); } }
+                MenuItem { title: "DXF"; activated => { root.import_dxf(); } }
+                MenuItem { title: "SHP"; activated => { root.import_shp(); } }
+                MenuItem { title: "LAS"; activated => { root.import_las(); } }
+                MenuItem { title: "E57"; activated => { root.import_e57(); } }
+                MenuItem { title: "LandXML Surface"; activated => { root.import_landxml_surface(); } }
+                MenuItem { title: "LandXML Alignment"; activated => { root.import_landxml_alignment(); } }
+            }
+            Menu {
+                title: "Export";
+                MenuItem { title: "GeoJSON"; activated => { root.export_geojson(); } }
+                MenuItem { title: "KML"; activated => { root.export_kml(); } }
+                MenuItem { title: "DXF"; activated => { root.export_dxf(); } }
+                MenuItem { title: "SHP"; activated => { root.export_shp(); } }
+                MenuItem { title: "LAS"; activated => { root.export_las(); } }
+                MenuItem { title: "E57"; activated => { root.export_e57(); } }
+            }
+        }
+        Menu {
+            title: "Edit";
+            MenuItem { title: "Add Point"; activated => { root.add_point(); } }
+            MenuItem { title: "Add Line"; activated => { root.add_line(); } }
+            MenuItem { title: "Add Polygon"; activated => { root.add_polygon(); } }
+            MenuItem { title: "Add Polyline"; activated => { root.add_polyline(); } }
+            MenuItem { title: "Add Arc"; activated => { root.add_arc(); } }
+            MenuItem { title: "Clear"; activated => { root.clear_workspace(); } }
+        }
+        Menu {
+            title: "Tools";
+            MenuItem { title: "Station Distance"; activated => { root.station_distance(); } }
+            MenuItem { title: "Traverse Area"; activated => { root.traverse_area(); } }
+            MenuItem { title: "Level Elevation"; activated => { root.level_elevation_tool(); } }
+            MenuItem { title: "Corridor Volume"; activated => { root.corridor_volume(); } }
+        }
+        Menu {
+            title: "View";
+            MenuItem { title: "2D Workspace"; activated => { root.view_changed(0); } }
+            MenuItem { title: "3D Workspace"; activated => { root.view_changed(1); } }
+            MenuItem { title: "Zoom In"; activated => { root.zoom_in(); } }
+            MenuItem { title: "Zoom Out"; activated => { root.zoom_out(); } }
+        }
+    }
+
+    VerticalBox {
+        x: 0;
+        y: 0;
+        width: 100%;
+        height: 100%;
+        spacing: 0px;
+
+        toolbar1 := HorizontalBox {
+            width: 100%;
+            height: 30px;
+            spacing: 6px;
+            Button { text: "New"; clicked => { root.new_project(); } }
+            Button { text: "Open"; clicked => { root.open_project(); } }
+            Button { text: "Save"; clicked => { root.save_project(); } }
+            Button { text: "Add Point"; clicked => { root.add_point(); } }
+            Button { text: "Add Line"; clicked => { root.add_line(); } }
+        Button { text: "Add Polygon"; clicked => { root.add_polygon(); } }
+        Button { text: "Add Polyline"; clicked => { root.add_polyline(); } }
+        Button { text: "Add Arc"; clicked => { root.add_arc(); } }
+        Button { text: "Load LandXML Surface"; clicked => { root.import_landxml_surface(); } }
+        Button { text: "Load LandXML Alignment"; clicked => { root.import_landxml_alignment(); } }
+        Button { text: "Corridor Volume"; clicked => { root.corridor_volume(); } }
+        Button { text: "Clear"; clicked => { root.clear_workspace(); } }
+        Text { text: "View:"; }
+        ComboBox {
+            model: ["2D", "3D"];
+            current-index <=> root.workspace_mode;
+            selected => { root.view_changed(root.workspace_mode); }
+        }
+        Text { text: "Cogo:"; }
+        ComboBox {
+            model: root.cogo_list;
+            current-index <=> root.cogo_index;
+            selected => { root.cogo_selected(root.cogo_index); }
+        }
+        }
+
+        toolbar2 := HorizontalBox {
+            width: 100%;
+            height: 30px;
+            spacing: 6px;
+        Text { text: "CRS:"; }
+        ComboBox {
+            model: root.crs_list;
+            current-index <=> root.crs_index;
+            selected => { root.crs_changed(root.crs_index); }
+        }
+        }
+
+        toolbar3 := HorizontalBox {
+            width: 100%;
+            height: 30px;
+            spacing: 6px;
+            CheckBox { text: "Snap Grid"; checked <=> root.snap_to_grid; }
+            CheckBox { text: "Snap Objects"; checked <=> root.snap_to_entities; }
+        }
+
+        Rectangle {
+            width: 100%;
+            vertical-stretch: 1;
+            min-height: 0px;
+
+            if root.workspace_mode == 0 : Workspace2D {
+                x: 0; y: 0; width: 100%; height: 100%;
+                image <=> root.workspace_image;
+                click_mode <=> root.workspace_click_mode;
+                clicked(x, y) => { root.workspace_clicked(x, y); }
+            }
+            if root.workspace_mode == 1 : Workspace3D {
+                x: 0; y: 0; width: 100%; height: 100%;
+                texture <=> root.workspace_texture;
+                mouse_moved(x, y) => { root.workspace_mouse_moved(x, y); }
+                mouse_exited() => { root.workspace_mouse_exited(); }
+            }
+        }
+
+        status_bar := Text {
+            text: root.status;
+            width: 100%;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- copy Slint GUI to new `survey_cad_truck_gui`
- wire Truck CAD engine into the GUI backend
- register new crate in workspace

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_68517389488083288469cadc7391387b