### PR TITLE
Implement truck gui actions

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -245,6 +245,59 @@ fn render_workspace(data: &WorkspaceRenderData, zoom: f32) -> Image {
     Image::from_rgba8_premultiplied(buffer)
 }
 
+fn read_line_csv(path: &str) -> std::io::Result<(Point, Point)> {
+    let pts = survey_cad::io::read_points_csv(path, None, None)?;
+    if pts.len() != 2 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "expected exactly two points",
+        ));
+    }
+    Ok((pts[0], pts[1]))
+}
+
+fn read_points_list(path: &str) -> std::io::Result<Vec<Point>> {
+    survey_cad::io::read_points_csv(path, None, None)
+}
+
+fn read_arc_csv(path: &str) -> std::io::Result<Arc> {
+    let lines = survey_cad::io::read_lines(path)?;
+    if lines.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "empty file",
+        ));
+    }
+    let parts: Vec<&str> = lines[0].split(',').collect();
+    if parts.len() != 5 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "expected cx,cy,radius,start,end",
+        ));
+    }
+    let cx: f64 = parts[0]
+        .trim()
+        .parse()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let cy: f64 = parts[1]
+        .trim()
+        .parse()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let r: f64 = parts[2]
+        .trim()
+        .parse()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let sa: f64 = parts[3]
+        .trim()
+        .parse()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let ea: f64 = parts[4]
+        .trim()
+        .parse()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    Ok(Arc::new(Point::new(cx, cy), r, sa, ea))
+}
+
 fn main() -> Result<(), slint::PlatformError> {
     let mut backend = TruckBackend::new(640, 480);
     let app = MainWindow::new()?;
@@ -443,63 +496,622 @@ fn main() -> Result<(), slint::PlatformError> {
 
     {
         let weak = app.as_weak();
+        let lines = lines.clone();
+        let render_image = render_image.clone();
         app.on_add_line(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Add Line not implemented"));
+            let dlg = AddLineDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            {
+                let lines = lines.clone();
+                let render_image = render_image.clone();
+                let weak = weak.clone();
+                let dlg_weak = dlg_weak.clone();
+                dlg.on_from_file(move || {
+                    if let Some(path) = rfd::FileDialog::new()
+                        .add_filter("CSV", &["csv"])
+                        .pick_file()
+                    {
+                        if let Some(p) = path.to_str() {
+                            match read_line_csv(p) {
+                                Ok(l) => {
+                                    lines.borrow_mut().push(l);
+                                    if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from(format!(
+                                            "Total lines: {}",
+                                            lines.borrow().len()
+                                        )));
+                                        if app.get_workspace_mode() == 0 {
+                                            app.set_workspace_image(render_image());
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from(format!(
+                                            "Failed to open: {}",
+                                            e
+                                        )));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if let Some(d) = dlg_weak.upgrade() {
+                        let _ = d.hide();
+                    }
+                });
             }
+            {
+                let lines = lines.clone();
+                let render_image = render_image.clone();
+                let weak = weak.clone();
+                let dlg_weak = dlg_weak.clone();
+                dlg.on_manual(move || {
+                    if let Some(d) = dlg_weak.upgrade() {
+                        let _ = d.hide();
+                    }
+                    let kd = LineKeyInDialog::new().unwrap();
+                    let kd_weak = kd.as_weak();
+                    let kd_weak2 = kd.as_weak();
+                    {
+                        let lines = lines.clone();
+                        let render_image = render_image.clone();
+                        let weak = weak.clone();
+                        kd.on_accept(move || {
+                            if let Some(dlg) = kd_weak2.upgrade() {
+                                if let (Ok(x1), Ok(y1), Ok(x2), Ok(y2)) = (
+                                    dlg.get_x1().parse::<f64>(),
+                                    dlg.get_y1().parse::<f64>(),
+                                    dlg.get_x2().parse::<f64>(),
+                                    dlg.get_y2().parse::<f64>(),
+                                ) {
+                                    lines
+                                        .borrow_mut()
+                                        .push((Point::new(x1, y1), Point::new(x2, y2)));
+                                    if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from(format!(
+                                            "Total lines: {}",
+                                            lines.borrow().len()
+                                        )));
+                                        if app.get_workspace_mode() == 0 {
+                                            app.set_workspace_image(render_image());
+                                        }
+                                    }
+                                }
+                            }
+                            if let Some(k) = kd_weak.upgrade() {
+                                let _ = k.hide();
+                            }
+                        });
+                    }
+                    {
+                        let kd_weak = kd.as_weak();
+                        kd.on_cancel(move || {
+                            if let Some(k) = kd_weak.upgrade() {
+                                let _ = k.hide();
+                            }
+                        });
+                    }
+                    kd.show().unwrap();
+                });
+            }
+            dlg.show().unwrap();
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
+        let render_image = render_image.clone();
         app.on_add_point(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Add Point not implemented"));
+            let dlg = AddPointDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            {
+                let points = points.clone();
+                let render_image = render_image.clone();
+                let weak = weak.clone();
+                let dlg_weak = dlg_weak.clone();
+                dlg.on_from_file(move || {
+                    if let Some(path) = rfd::FileDialog::new()
+                        .add_filter("CSV", &["csv"])
+                        .pick_file()
+                    {
+                        if let Some(p) = path.to_str() {
+                            match survey_cad::io::read_points_csv(p, None, None) {
+                                Ok(pts) => {
+                                    *points.borrow_mut() = pts;
+                                    if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from(format!(
+                                            "Loaded {} points",
+                                            points.borrow().len()
+                                        )));
+                                        if app.get_workspace_mode() == 0 {
+                                            app.set_workspace_image(render_image());
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from(format!(
+                                            "Failed to open: {}",
+                                            e
+                                        )));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if let Some(d) = dlg_weak.upgrade() {
+                        let _ = d.hide();
+                    }
+                });
             }
+            {
+                let points = points.clone();
+                let render_image = render_image.clone();
+                let weak = weak.clone();
+                let dlg_weak = dlg_weak.clone();
+                dlg.on_manual_keyin(move || {
+                    if let Some(d) = dlg_weak.upgrade() {
+                        let _ = d.hide();
+                    }
+                    let key_dlg = KeyInDialog::new().unwrap();
+                    let key_weak = key_dlg.as_weak();
+                    let key_weak2 = key_dlg.as_weak();
+                    {
+                        let points = points.clone();
+                        let render_image = render_image.clone();
+                        let weak = weak.clone();
+                        key_dlg.on_accept(move || {
+                            if let Some(dlg) = key_weak2.upgrade() {
+                                if let (Ok(x), Ok(y)) = (
+                                    dlg.get_x_value().parse::<f64>(),
+                                    dlg.get_y_value().parse::<f64>(),
+                                ) {
+                                    points.borrow_mut().push(Point::new(x, y));
+                                    if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from(format!(
+                                            "Total points: {}",
+                                            points.borrow().len()
+                                        )));
+                                        if app.get_workspace_mode() == 0 {
+                                            app.set_workspace_image(render_image());
+                                        }
+                                    }
+                                }
+                            }
+                            if let Some(k) = key_weak.upgrade() {
+                                let _ = k.hide();
+                            }
+                        });
+                    }
+                    {
+                        let key_weak = key_dlg.as_weak();
+                        key_dlg.on_cancel(move || {
+                            if let Some(k) = key_weak.upgrade() {
+                                let _ = k.hide();
+                            }
+                        });
+                    }
+                    key_dlg.show().unwrap();
+                });
+            }
+            {
+                let weak = weak.clone();
+                let dlg_weak = dlg_weak.clone();
+                dlg.on_manual_click(move || {
+                    if let Some(d) = dlg_weak.upgrade() {
+                        let _ = d.hide();
+                    }
+                    if let Some(app) = weak.upgrade() {
+                        app.set_workspace_click_mode(true);
+                    }
+                });
+            }
+            dlg.show().unwrap();
         });
     }
 
     {
         let weak = app.as_weak();
+        let polygons = polygons.clone();
+        let render_image = render_image.clone();
         app.on_add_polygon(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Add Polygon not implemented"));
+            let dlg = AddPolygonDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            {
+                let polygons = polygons.clone();
+                let render_image = render_image.clone();
+                let weak = weak.clone();
+                let dlg_weak = dlg_weak.clone();
+                dlg.on_from_file(move || {
+                    if let Some(path) = rfd::FileDialog::new()
+                        .add_filter("CSV", &["csv"])
+                        .pick_file()
+                    {
+                        if let Some(p) = path.to_str() {
+                            match read_points_list(p) {
+                                Ok(pts) => {
+                                    if pts.len() >= 3 {
+                                        polygons.borrow_mut().push(pts);
+                                        if let Some(app) = weak.upgrade() {
+                                            app.set_status(SharedString::from(format!(
+                                                "Total polygons: {}",
+                                                polygons.borrow().len()
+                                            )));
+                                            if app.get_workspace_mode() == 0 {
+                                                app.set_workspace_image(render_image());
+                                            }
+                                        }
+                                    } else if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from("Need at least 3 points"));
+                                    }
+                                }
+                                Err(e) => {
+                                    if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from(format!(
+                                            "Failed to open: {}",
+                                            e
+                                        )));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if let Some(d) = dlg_weak.upgrade() {
+                        let _ = d.hide();
+                    }
+                });
             }
+            {
+                let polygons = polygons.clone();
+                let render_image = render_image.clone();
+                let weak = weak.clone();
+                let dlg_weak = dlg_weak.clone();
+                dlg.on_manual(move || {
+                    if let Some(d) = dlg_weak.upgrade() {
+                        let _ = d.hide();
+                    }
+                    let pd = PointsDialog::new().unwrap();
+                    let model = Rc::new(VecModel::<SharedString>::from(Vec::<SharedString>::new()));
+                    pd.set_points_model(model.clone().into());
+                    let pts = Rc::new(RefCell::new(Vec::<Point>::new()));
+                    {
+                        let model = model.clone();
+                        let pd_weak2 = pd.as_weak();
+                        let pts = pts.clone();
+                        pd.on_add_point(move || {
+                            if let Some(d) = pd_weak2.upgrade() {
+                                if let (Ok(x), Ok(y)) = (
+                                    d.get_x_value().parse::<f64>(),
+                                    d.get_y_value().parse::<f64>(),
+                                ) {
+                                    pts.borrow_mut().push(Point::new(x, y));
+                                    model.push(SharedString::from(format!("{:.3},{:.3}", x, y)));
+                                }
+                            }
+                        });
+                    }
+                    {
+                        let polygons = polygons.clone();
+                        let render_image = render_image.clone();
+                        let weak = weak.clone();
+                        let pd_weak2 = pd.as_weak();
+                        let pts = pts.clone();
+                        pd.on_accept(move || {
+                            if pts.borrow().len() >= 3 {
+                                polygons.borrow_mut().push(pts.borrow().clone());
+                                if let Some(app) = weak.upgrade() {
+                                    app.set_status(SharedString::from(format!(
+                                        "Total polygons: {}",
+                                        polygons.borrow().len()
+                                    )));
+                                    if app.get_workspace_mode() == 0 {
+                                        app.set_workspace_image(render_image());
+                                    }
+                                }
+                            }
+                            if let Some(p) = pd_weak2.upgrade() {
+                                let _ = p.hide();
+                            }
+                        });
+                    }
+                    {
+                        let pd_weak2 = pd.as_weak();
+                        pd.on_cancel(move || {
+                            if let Some(p) = pd_weak2.upgrade() {
+                                let _ = p.hide();
+                            }
+                        });
+                    }
+                    pd.show().unwrap();
+                });
+            }
+            dlg.show().unwrap();
         });
     }
 
     {
         let weak = app.as_weak();
+        let polylines = polylines.clone();
+        let render_image = render_image.clone();
         app.on_add_polyline(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Add Polyline not implemented"));
+            let dlg = AddPolylineDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            {
+                let polylines = polylines.clone();
+                let render_image = render_image.clone();
+                let weak = weak.clone();
+                let dlg_weak = dlg_weak.clone();
+                dlg.on_from_file(move || {
+                    if let Some(path) = rfd::FileDialog::new()
+                        .add_filter("CSV", &["csv"])
+                        .pick_file()
+                    {
+                        if let Some(p) = path.to_str() {
+                            match read_points_list(p) {
+                                Ok(pts) => {
+                                    if pts.len() >= 2 {
+                                        polylines.borrow_mut().push(Polyline::new(pts));
+                                        if let Some(app) = weak.upgrade() {
+                                            app.set_status(SharedString::from(format!(
+                                                "Total polylines: {}",
+                                                polylines.borrow().len()
+                                            )));
+                                            if app.get_workspace_mode() == 0 {
+                                                app.set_workspace_image(render_image());
+                                            }
+                                        }
+                                    } else if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from("Need at least 2 points"));
+                                    }
+                                }
+                                Err(e) => {
+                                    if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from(format!(
+                                            "Failed to open: {}",
+                                            e
+                                        )));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if let Some(d) = dlg_weak.upgrade() {
+                        let _ = d.hide();
+                    }
+                });
             }
+            {
+                let polylines = polylines.clone();
+                let render_image = render_image.clone();
+                let weak = weak.clone();
+                let dlg_weak = dlg_weak.clone();
+                dlg.on_manual(move || {
+                    if let Some(d) = dlg_weak.upgrade() {
+                        let _ = d.hide();
+                    }
+                    let pd = PointsDialog::new().unwrap();
+                    let model = Rc::new(VecModel::<SharedString>::from(Vec::<SharedString>::new()));
+                    pd.set_points_model(model.clone().into());
+                    let pts = Rc::new(RefCell::new(Vec::<Point>::new()));
+                    {
+                        let model = model.clone();
+                        let pd_weak2 = pd.as_weak();
+                        let pts = pts.clone();
+                        pd.on_add_point(move || {
+                            if let Some(d) = pd_weak2.upgrade() {
+                                if let (Ok(x), Ok(y)) = (
+                                    d.get_x_value().parse::<f64>(),
+                                    d.get_y_value().parse::<f64>(),
+                                ) {
+                                    pts.borrow_mut().push(Point::new(x, y));
+                                    model.push(SharedString::from(format!("{:.3},{:.3}", x, y)));
+                                }
+                            }
+                        });
+                    }
+                    {
+                        let polylines = polylines.clone();
+                        let render_image = render_image.clone();
+                        let weak = weak.clone();
+                        let pd_weak2 = pd.as_weak();
+                        let pts = pts.clone();
+                        pd.on_accept(move || {
+                            if pts.borrow().len() >= 2 {
+                                polylines.borrow_mut().push(Polyline::new(pts.borrow().clone()));
+                                if let Some(app) = weak.upgrade() {
+                                    app.set_status(SharedString::from(format!(
+                                        "Total polylines: {}",
+                                        polylines.borrow().len()
+                                    )));
+                                    if app.get_workspace_mode() == 0 {
+                                        app.set_workspace_image(render_image());
+                                    }
+                                }
+                            }
+                            if let Some(p) = pd_weak2.upgrade() {
+                                let _ = p.hide();
+                            }
+                        });
+                    }
+                    {
+                        let pd_weak2 = pd.as_weak();
+                        pd.on_cancel(move || {
+                            if let Some(p) = pd_weak2.upgrade() {
+                                let _ = p.hide();
+                            }
+                        });
+                    }
+                    pd.show().unwrap();
+                });
+            }
+            dlg.show().unwrap();
         });
     }
 
     {
         let weak = app.as_weak();
+        let arcs = arcs.clone();
+        let render_image = render_image.clone();
         app.on_add_arc(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Add Arc not implemented"));
+            let dlg = AddArcDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            {
+                let arcs = arcs.clone();
+                let render_image = render_image.clone();
+                let weak = weak.clone();
+                let dlg_weak = dlg_weak.clone();
+                dlg.on_from_file(move || {
+                    if let Some(path) = rfd::FileDialog::new()
+                        .add_filter("CSV", &["csv"])
+                        .pick_file()
+                    {
+                        if let Some(p) = path.to_str() {
+                            match read_arc_csv(p) {
+                                Ok(a) => {
+                                    arcs.borrow_mut().push(a);
+                                    if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from(format!(
+                                            "Total arcs: {}",
+                                            arcs.borrow().len()
+                                        )));
+                                        if app.get_workspace_mode() == 0 {
+                                            app.set_workspace_image(render_image());
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from(format!(
+                                            "Failed to open: {}",
+                                            e
+                                        )));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if let Some(d) = dlg_weak.upgrade() {
+                        let _ = d.hide();
+                    }
+                });
             }
+            {
+                let arcs = arcs.clone();
+                let render_image = render_image.clone();
+                let weak = weak.clone();
+                let dlg_weak = dlg_weak.clone();
+                dlg.on_manual(move || {
+                    if let Some(d) = dlg_weak.upgrade() {
+                        let _ = d.hide();
+                    }
+                    let ad = ArcKeyInDialog::new().unwrap();
+                    let ad_weak = ad.as_weak();
+                    let ad_weak2 = ad.as_weak();
+                    {
+                        let arcs = arcs.clone();
+                        let render_image = render_image.clone();
+                        let weak = weak.clone();
+                        ad.on_accept(move || {
+                            if let Some(dlg) = ad_weak2.upgrade() {
+                                if let (Ok(cx), Ok(cy), Ok(r), Ok(sa), Ok(ea)) = (
+                                    dlg.get_cx().parse::<f64>(),
+                                    dlg.get_cy().parse::<f64>(),
+                                    dlg.get_radius().parse::<f64>(),
+                                    dlg.get_start_angle().parse::<f64>(),
+                                    dlg.get_end_angle().parse::<f64>(),
+                                ) {
+                                    arcs
+                                        .borrow_mut()
+                                        .push(Arc::new(Point::new(cx, cy), r, sa, ea));
+                                    if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from(format!(
+                                            "Total arcs: {}",
+                                            arcs.borrow().len()
+                                        )));
+                                        if app.get_workspace_mode() == 0 {
+                                            app.set_workspace_image(render_image());
+                                        }
+                                    }
+                                }
+                            }
+                            if let Some(a) = ad_weak.upgrade() {
+                                let _ = a.hide();
+                            }
+                        });
+                    }
+                    {
+                        let ad_weak = ad.as_weak();
+                        ad.on_cancel(move || {
+                            if let Some(a) = ad_weak.upgrade() {
+                                let _ = a.hide();
+                            }
+                        });
+                    }
+                    ad.show().unwrap();
+                });
+            }
+            dlg.show().unwrap();
         });
     }
 
     {
         let weak = app.as_weak();
         app.on_station_distance(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Station Distance not implemented"));
-            }
+            let dlg = StationDistanceDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            let weak2 = weak.clone();
+            dlg.on_accept(move || {
+                if let Some(d) = dlg_weak.upgrade() {
+                    let res = (|| {
+                        let x1 = d.get_x1().parse::<f64>().ok()?;
+                        let y1 = d.get_y1().parse::<f64>().ok()?;
+                        let x2 = d.get_x2().parse::<f64>().ok()?;
+                        let y2 = d.get_y2().parse::<f64>().ok()?;
+                        Some(survey_cad::surveying::station_distance(
+                            &survey_cad::surveying::Station::new("A", Point::new(x1, y1)),
+                            &survey_cad::surveying::Station::new("B", Point::new(x2, y2)),
+                        ))
+                    })();
+                    if let Some(app) = weak2.upgrade() {
+                        if let Some(dist) = res {
+                            app.set_status(SharedString::from(format!("Distance: {:.3}", dist)));
+                        } else {
+                            app.set_status(SharedString::from("Invalid input"));
+                        }
+                    }
+                    let _ = d.hide();
+                }
+            });
+            let dlg_weak2 = dlg.as_weak();
+            dlg.on_cancel(move || {
+                if let Some(d) = dlg_weak2.upgrade() {
+                    let _ = d.hide();
+                }
+            });
+            dlg.show().unwrap();
         });
     }
 
     {
         let weak = app.as_weak();
         app.on_traverse_area(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Traverse Area not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("CSV", &["csv"])
+                .pick_file()
+            {
+                if let (Some(p), Some(app)) = (path.to_str(), weak.upgrade()) {
+                    match survey_cad::io::read_points_csv(p, None, None) {
+                        Ok(pts) => {
+                            let trav = survey_cad::surveying::Traverse::new(pts);
+                            app.set_status(SharedString::from(format!("Area: {:.3}", trav.area())));
+                        }
+                        Err(e) => {
+                            app.set_status(SharedString::from(format!("Failed: {}", e)));
+                        }
+                    }
+                }
             }
         });
     }
@@ -507,143 +1119,605 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let weak = app.as_weak();
         app.on_level_elevation_tool(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Level Elevation not implemented"));
-            }
+            let dlg = LevelElevationDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            let weak2 = weak.clone();
+            dlg.on_accept(move || {
+                if let Some(d) = dlg_weak.upgrade() {
+                    let res = (|| {
+                        let start = d.get_start_elev().parse::<f64>().ok()?;
+                        let bs = d.get_backsight().parse::<f64>().ok()?;
+                        let fs = d.get_foresight().parse::<f64>().ok()?;
+                        Some(survey_cad::surveying::level_elevation(start, bs, fs))
+                    })();
+                    if let Some(app) = weak2.upgrade() {
+                        if let Some(elev) = res {
+                            app.set_status(SharedString::from(format!("Elevation: {:.3}", elev)));
+                        } else {
+                            app.set_status(SharedString::from("Invalid input"));
+                        }
+                    }
+                    let _ = d.hide();
+                }
+            });
+            let dlg_weak2 = dlg.as_weak();
+            dlg.on_cancel(move || {
+                if let Some(d) = dlg_weak2.upgrade() {
+                    let _ = d.hide();
+                }
+            });
+            dlg.show().unwrap();
         });
     }
 
     {
         let weak = app.as_weak();
+        let surfaces_clone = surfaces.clone();
+        let alignments_clone = alignments.clone();
         app.on_corridor_volume(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Corridor Volume not implemented"));
-            }
+            let dlg = CorridorVolumeDialog::new().unwrap();
+            dlg.set_width_value("10".into());
+            dlg.set_interval_value("10".into());
+            dlg.set_offset_step_value("1".into());
+            let dlg_weak = dlg.as_weak();
+            let weak2 = weak.clone();
+            let surfs = surfaces_clone.clone();
+            let aligns = alignments_clone.clone();
+            dlg.on_accept(move || {
+                if let Some(d) = dlg_weak.upgrade() {
+                    let res = (|| {
+                        let width = d.get_width_value().parse::<f64>().ok()?;
+                        let interval = d.get_interval_value().parse::<f64>().ok()?;
+                        let step = d.get_offset_step_value().parse::<f64>().ok()?;
+                        let surfs = surfs.borrow();
+                        let aligns = aligns.borrow();
+                        if surfs.len() < 2 || aligns.is_empty() {
+                            return None;
+                        }
+                        let design = &surfs[0];
+                        let ground = &surfs[1];
+                        let hal = &aligns[0];
+                        let len = hal.length();
+                        let val = survey_cad::alignment::VerticalAlignment::new(vec![(0.0, 0.0), (len, 0.0)]);
+                        let al = survey_cad::alignment::Alignment::new(hal.clone(), val);
+                        Some(survey_cad::corridor::corridor_volume(design, ground, &al, width, interval, step))
+                    })();
+                    if let Some(app) = weak2.upgrade() {
+                        if let Some(vol) = res {
+                            app.set_status(SharedString::from(format!("Volume: {:.3}", vol)));
+                        } else {
+                            app.set_status(SharedString::from("Invalid input or missing data"));
+                        }
+                    }
+                    let _ = d.hide();
+                }
+            });
+            let dlg_weak2 = dlg.as_weak();
+            dlg.on_cancel(move || {
+                if let Some(d) = dlg_weak2.upgrade() {
+                    let _ = d.hide();
+                }
+            });
+            dlg.show().unwrap();
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
+        let render_image = render_image.clone();
         app.on_import_geojson(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Import GeoJSON not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("GeoJSON", &["geojson", "json"])
+                .pick_file()
+            {
+                if let Some(p) = path.to_str() {
+                    match survey_cad::io::read_points_geojson(p, None, None) {
+                        Ok(pts) => {
+                            *points.borrow_mut() = pts;
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Imported {} points",
+                                    points.borrow().len()
+                                )));
+                                if app.get_workspace_mode() == 0 {
+                                    app.set_workspace_image(render_image());
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Failed to import: {}",
+                                    e
+                                )));
+                            }
+                        }
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
+        let render_image = render_image.clone();
         app.on_import_kml(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Import KML not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("KML", &["kml", "kmz"])
+                .pick_file()
+            {
+                if let Some(p) = path.to_str() {
+                    #[cfg(feature = "kml")]
+                    match survey_cad::io::kml::read_points_kml(p) {
+                        Ok(pts) => {
+                            *points.borrow_mut() = pts;
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Imported {} points",
+                                    points.borrow().len()
+                                )));
+                                if app.get_workspace_mode() == 0 {
+                                    app.set_workspace_image(render_image());
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Failed to import: {}",
+                                    e
+                                )));
+                            }
+                        }
+                    }
+                    #[cfg(not(feature = "kml"))]
+                    if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("KML support not enabled"));
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
+        let render_image = render_image.clone();
         app.on_import_dxf(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Import DXF not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("DXF", &["dxf"])
+                .pick_file()
+            {
+                if let Some(p) = path.to_str() {
+                    match survey_cad::io::read_dxf(p) {
+                        Ok(ents) => {
+                            *points.borrow_mut() = ents
+                                .into_iter()
+                                .filter_map(|e| match e {
+                                    survey_cad::io::DxfEntity::Point { point, .. } => Some(point),
+                                    _ => None,
+                                })
+                                .collect();
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Imported {} points",
+                                    points.borrow().len()
+                                )));
+                                if app.get_workspace_mode() == 0 {
+                                    app.set_workspace_image(render_image());
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Failed to import: {}",
+                                    e
+                                )));
+                            }
+                        }
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
+        let render_image = render_image.clone();
         app.on_import_shp(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Import SHP not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("SHP", &["shp"])
+                .pick_file()
+            {
+                if let Some(p) = path.to_str() {
+                    #[cfg(feature = "shapefile")]
+                    match survey_cad::io::shp::read_points_shp(p) {
+                        Ok((pts, _)) => {
+                            *points.borrow_mut() = pts;
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Imported {} points",
+                                    points.borrow().len()
+                                )));
+                                if app.get_workspace_mode() == 0 {
+                                    app.set_workspace_image(render_image());
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Failed to import: {}",
+                                    e
+                                )));
+                            }
+                        }
+                    }
+                    #[cfg(not(feature = "shapefile"))]
+                    if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("SHP support not enabled"));
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
+        let render_image = render_image.clone();
         app.on_import_las(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Import LAS not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("LAS", &["las", "laz"])
+                .pick_file()
+            {
+                if let Some(p) = path.to_str() {
+                    #[cfg(feature = "las")]
+                    match survey_cad::io::las::read_points_las(p) {
+                        Ok(pts3) => {
+                            *points.borrow_mut() = pts3.into_iter().map(|p3| Point::new(p3.x, p3.y)).collect();
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Imported {} points",
+                                    points.borrow().len()
+                                )));
+                                if app.get_workspace_mode() == 0 {
+                                    app.set_workspace_image(render_image());
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Failed to import: {}",
+                                    e
+                                )));
+                            }
+                        }
+                    }
+                    #[cfg(not(feature = "las"))]
+                    if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("LAS support not enabled"));
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
+        let render_image = render_image.clone();
         app.on_import_e57(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Import E57 not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("E57", &["e57"])
+                .pick_file()
+            {
+                if let Some(p) = path.to_str() {
+                    #[cfg(feature = "e57")]
+                    match survey_cad::io::e57::read_points_e57(p) {
+                        Ok(pts3) => {
+                            *points.borrow_mut() = pts3.into_iter().map(|p3| Point::new(p3.x, p3.y)).collect();
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Imported {} points",
+                                    points.borrow().len()
+                                )));
+                                if app.get_workspace_mode() == 0 {
+                                    app.set_workspace_image(render_image());
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Failed to import: {}",
+                                    e
+                                )));
+                            }
+                        }
+                    }
+                    #[cfg(not(feature = "e57"))]
+                    if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("E57 support not enabled"));
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
         app.on_export_geojson(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Export GeoJSON not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("GeoJSON", &["geojson", "json"])
+                .save_file()
+            {
+                if let Some(p) = path.to_str() {
+                    if let Err(e) = survey_cad::io::write_points_geojson(p, &points.borrow(), None, None) {
+                        if let Some(app) = weak.upgrade() {
+                            app.set_status(SharedString::from(format!("Failed to export: {}", e)));
+                        }
+                    } else if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("Exported"));
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
         app.on_export_kml(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Export KML not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("KML", &["kml"])
+                .save_file()
+            {
+                if let Some(p) = path.to_str() {
+                    #[cfg(feature = "kml")]
+                    if let Err(e) = survey_cad::io::kml::write_points_kml(p, &points.borrow()) {
+                        if let Some(app) = weak.upgrade() {
+                            app.set_status(SharedString::from(format!("Failed to export: {}", e)));
+                        }
+                    } else if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("Exported"));
+                    }
+                    #[cfg(not(feature = "kml"))]
+                    if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("KML support not enabled"));
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
         app.on_export_dxf(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Export DXF not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("DXF", &["dxf"])
+                .save_file()
+            {
+                if let Some(p) = path.to_str() {
+                    if let Err(e) = survey_cad::io::write_points_dxf(p, &points.borrow(), None, None) {
+                        if let Some(app) = weak.upgrade() {
+                            app.set_status(SharedString::from(format!("Failed to export: {}", e)));
+                        }
+                    } else if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("Exported"));
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
         app.on_export_shp(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Export SHP not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("SHP", &["shp"])
+                .save_file()
+            {
+                if let Some(p) = path.to_str() {
+                    #[cfg(feature = "shapefile")]
+                    if let Err(e) = survey_cad::io::shp::write_points_shp(p, &points.borrow(), None) {
+                        if let Some(app) = weak.upgrade() {
+                            app.set_status(SharedString::from(format!("Failed to export: {}", e)));
+                        }
+                    } else if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("Exported"));
+                    }
+                    #[cfg(not(feature = "shapefile"))]
+                    if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("SHP support not enabled"));
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
         app.on_export_las(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Export LAS not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("LAS", &["las", "laz"])
+                .save_file()
+            {
+                if let Some(p) = path.to_str() {
+                    #[cfg(feature = "las")]
+                    {
+                        let pts3: Vec<survey_cad::geometry::Point3> = points
+                            .borrow()
+                            .iter()
+                            .map(|pt| survey_cad::geometry::Point3::new(pt.x, pt.y, 0.0))
+                            .collect();
+                        if let Err(e) = survey_cad::io::las::write_points_las(p, &pts3) {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!("Failed to export: {}", e)));
+                            }
+                        } else if let Some(app) = weak.upgrade() {
+                            app.set_status(SharedString::from("Exported"));
+                        }
+                    }
+                    #[cfg(not(feature = "las"))]
+                    if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("LAS support not enabled"));
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let points = points.clone();
         app.on_export_e57(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Export E57 not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("E57", &["e57"])
+                .save_file()
+            {
+                if let Some(p) = path.to_str() {
+                    #[cfg(feature = "e57")]
+                    {
+                        let pts3: Vec<survey_cad::geometry::Point3> = points
+                            .borrow()
+                            .iter()
+                            .map(|pt| survey_cad::geometry::Point3::new(pt.x, pt.y, 0.0))
+                            .collect();
+                        if let Err(e) = survey_cad::io::e57::write_points_e57(p, &pts3) {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!("Failed to export: {}", e)));
+                            }
+                        } else if let Some(app) = weak.upgrade() {
+                            app.set_status(SharedString::from("Exported"));
+                        }
+                    }
+                    #[cfg(not(feature = "e57"))]
+                    if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("E57 support not enabled"));
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let surfaces = surfaces.clone();
+        let render_image = render_image.clone();
         app.on_import_landxml_surface(move || {
-            if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Import LandXML Surface not implemented"));
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("LandXML", &["xml"])
+                .pick_file()
+            {
+                if let Some(p) = path.to_str() {
+                    match survey_cad::io::landxml::read_landxml_surface(p) {
+                        Ok(tin) => {
+                            surfaces.borrow_mut().push(tin);
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from("Imported surface"));
+                                if app.get_workspace_mode() == 0 {
+                                    app.set_workspace_image(render_image());
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!("Failed to import: {}", e)));
+                            }
+                        }
+                    }
+                }
             }
         });
     }
 
     {
         let weak = app.as_weak();
+        let alignments = alignments.clone();
+        let render_image = render_image.clone();
         app.on_import_landxml_alignment(move || {
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("LandXML", &["xml"])
+                .pick_file()
+            {
+                if let Some(p) = path.to_str() {
+                    match survey_cad::io::landxml::read_landxml_alignment(p) {
+                        Ok(al) => {
+                            alignments.borrow_mut().push(al);
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from("Imported alignment"));
+                                if app.get_workspace_mode() == 0 {
+                                    app.set_workspace_image(render_image());
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!("Failed to import: {}", e)));
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    {
+        let weak = app.as_weak();
+        let points = points.clone();
+        let lines = lines.clone();
+        let polygons = polygons.clone();
+        let polylines = polylines.clone();
+        let arcs = arcs.clone();
+        let render_image = render_image.clone();
+        app.on_workspace_clicked(move |x, y| {
             if let Some(app) = weak.upgrade() {
-                app.set_status(SharedString::from("Import LandXML Alignment not implemented"));
+                if app.get_workspace_click_mode() {
+                    const WIDTH: f64 = 600.0;
+                    const HEIGHT: f64 = 400.0;
+                    let mut p = Point::new(x as f64 - WIDTH / 2.0, HEIGHT / 2.0 - y as f64);
+                    if app.get_snap_to_grid() {
+                        p.x = p.x.round();
+                        p.y = p.y.round();
+                    }
+                    if app.get_snap_to_entities() {
+                        let mut ents: Vec<survey_cad::io::DxfEntity> = Vec::new();
+                        for pt in points.borrow().iter() {
+                            ents.push(survey_cad::io::DxfEntity::Point { point: *pt, layer: None });
+                        }
+                        for (s, e) in lines.borrow().iter() {
+                            ents.push(survey_cad::io::DxfEntity::Line { line: Line::new(*s, *e), layer: None });
+                        }
+                        for poly in polygons.borrow().iter() {
+                            ents.push(survey_cad::io::DxfEntity::Polyline { polyline: Polyline::new(poly.clone()), layer: None });
+                        }
+                        for pl in polylines.borrow().iter() {
+                            ents.push(survey_cad::io::DxfEntity::Polyline { polyline: pl.clone(), layer: None });
+                        }
+                        for arc in arcs.borrow().iter() {
+                            ents.push(survey_cad::io::DxfEntity::Arc { arc: *arc, layer: None });
+                        }
+                        if let Some(sp) = survey_cad::snap::snap_point(p, &ents, 5.0) {
+                            p = sp;
+                        }
+                    }
+                    points.borrow_mut().push(p);
+                    app.set_workspace_click_mode(false);
+                    app.set_status(SharedString::from(format!("Total points: {}", points.borrow().len())));
+                    if app.get_workspace_mode() == 0 {
+                        app.set_workspace_image(render_image());
+                    }
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- hook up all truck GUI buttons so they actually do something
- allow point/line/polygon/polyline/arc creation
- implement import and export of several file formats
- add station distance, traverse area, level elevation and corridor volume tools
- handle click-to-add point in workspace

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_685197c874ec83288216128206eb5ac5