### PR TITLE
Fix clippy field reassignment warning

### DIFF
--- a/truck-master/truck-rendimpl/examples/bsp-animation.rs
+++ b/truck-master/truck-rendimpl/examples/bsp-animation.rs
@@ -49,9 +49,10 @@ impl MyApp {
         vec2 /= vec2.magnitude();
         let vec3 = Vector4::new(1.5, 0.8, 1.5, 1.0);
         let matrix = Matrix4::from_cols(vec0, vec1, vec2, vec3);
-        let mut camera = Camera::default();
-        camera.matrix = matrix;
-        camera
+        Camera {
+            matrix,
+            ..Camera::default()
+        }
     }
     fn init_thread(
         object: Arc<Mutex<StructuredMesh>>,


### PR DESCRIPTION
## Summary
- update camera initialization in bsp-animation example to avoid reassigning fields after `Default`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: gdal not found)*
- `cargo test --all` *(failed: build interrupted due to long compile time)*

------
https://chatgpt.com/codex/tasks/task_e_68519f72b908832891ff8a1a7cd719fe