### PR TITLE
Handle missing GPU for tests

### DIFF
--- a/truck-master/truck-platform/tests/bindgroup.rs
+++ b/truck-master/truck-platform/tests/bindgroup.rs
@@ -68,7 +68,10 @@ fn exec_bind_group_test(backend: Backends, out_dir: &str) {
         },
         ..Default::default()
     };
-    let handler = common::init_device(backend);
+    let Some(handler) = common::try_init_device(backend) else {
+        eprintln!("skip bind_group_test: no suitable backend");
+        return;
+    };
     let mut scene = Scene::new(handler, &desc);
     let plane = new_plane!("shaders/unicolor.wgsl", "vs_main", "fs_main");
     let buffer0 = common::render_one(&mut scene, &plane);

--- a/truck-master/truck-platform/tests/msaa.rs
+++ b/truck-master/truck-platform/tests/msaa.rs
@@ -20,7 +20,10 @@ fn save_buffer<P: AsRef<std::path::Path>>(path: P, vec: &[u8]) {
 fn exec_msaa_test(backend: Backends, out_dir: &str) {
     let out_dir = String::from(out_dir);
     std::fs::create_dir_all(&out_dir).unwrap();
-    let handler = common::init_device(backend);
+    let Some(handler) = common::try_init_device(backend) else {
+        eprintln!("skip msaa_test: no suitable backend");
+        return;
+    };
     let mut scene = Scene::new(
         handler,
         &SceneDescriptor {

--- a/truck-master/truck-platform/tests/wgsl-utils.rs
+++ b/truck-master/truck-platform/tests/wgsl-utils.rs
@@ -27,7 +27,11 @@ fn exec_math_util_test(backend: Backends, out_dir: &str) {
         },
         ..Default::default()
     };
-    let mut scene = Scene::new(common::init_device(backend), &desc);
+    let Some(handler) = common::try_init_device(backend) else {
+        eprintln!("skip math_util_test: no suitable backend");
+        return;
+    };
+    let mut scene = Scene::new(handler, &desc);
     let plane = new_plane!("shaders/unicolor.wgsl", "vs_main", "fs_main");
     let buffer0 = common::render_one(&mut scene, &plane);
     let shader = include_str!("../wgsl-utils/math.wgsl").to_string()

--- a/truck-master/truck-rendimpl/tests/microfacet.rs
+++ b/truck-master/truck-rendimpl/tests/microfacet.rs
@@ -12,7 +12,10 @@ fn exec_microfacet_module_test(backend: Backends, out_dir: &str) {
         backends: backend,
         ..Default::default()
     });
-    let handler = common::init_device(&instance);
+    let Some(handler) = common::try_init_device(&instance) else {
+        eprintln!("skip microfacet_module_test: no suitable backend");
+        return;
+    };
     let mut scene = Scene::new(
         handler,
         &SceneDescriptor {

--- a/truck-master/truck-rendimpl/tests/polygon_bind_group.rs
+++ b/truck-master/truck-rendimpl/tests/polygon_bind_group.rs
@@ -104,7 +104,10 @@ fn exec_polymesh_nontex_bind_group_test(backend: Backends, out_dir: &str) {
         backends: backend,
         ..Default::default()
     });
-    let handler = common::init_device(&instance);
+    let Some(handler) = common::try_init_device(&instance) else {
+        eprintln!("skip polymesh_nontex_bind_group_test: no suitable backend");
+        return;
+    };
     let mut scene = Scene::new(
         handler,
         &SceneDescriptor {
@@ -160,7 +163,10 @@ fn exec_polymesh_tex_bind_group_test(backend: Backends, out_dir: &str) {
         backends: backend,
         ..Default::default()
     });
-    let handler = common::init_device(&instance);
+    let Some(handler) = common::try_init_device(&instance) else {
+        eprintln!("skip polymesh_tex_bind_group_test: no suitable backend");
+        return;
+    };
     let mut scene = Scene::new(
         handler,
         &SceneDescriptor {


### PR DESCRIPTION
## Summary
- gracefully skip GPU-based tests when no backend is available
- add helper `try_init_device` to return `None` if wgpu backends aren't found

## Testing
- `cargo test -p truck-platform -- --test-threads=1 --nocapture bind_group_test`
- `cargo test -p truck-rendimpl -- --test-threads=1 --nocapture microfacet_module_test`


------
https://chatgpt.com/codex/tasks/task_e_6851b00a1dd083288f49b7de392427ff