### PR TITLE
Add interactive line draw mode

### DIFF
--- a/survey_cad_slint_gui/ui/main.slint
+++ b/survey_cad_slint_gui/ui/main.slint
@@ -1,13 +1,28 @@
 component Workspace2D inherits Rectangle {
     in-out property <image> image;
     in-out property <bool> click_mode;
+    callback mouse_moved(length, length);
+    callback mouse_exited();
     callback clicked(length, length);
+    callback right_click(length, length);
     background: #202020;
     Image {
         source: root.image;
         image-fit: fill;
         width: 100%;
         height: 100%;
+    }
+    TouchArea {
+        width: 100%;
+        height: 100%;
+        moved => { root.mouse_moved(self.mouse-x, self.mouse-y); }
+        pointer-event(event) => {
+            if event.kind == PointerEventKind.cancel {
+                root.mouse_exited();
+            } else if event.kind == PointerEventKind.down && event.button == PointerEventButton.right {
+                root.right_click(self.mouse-x, self.mouse-y);
+            }
+        }
     }
     if root.click_mode : TouchArea {
         width: 100%;
@@ -322,6 +337,7 @@ export component MainWindow inherits Window {
     in-out property <image> workspace_image;
     in-out property <image> workspace_texture;
     in-out property <bool> workspace_click_mode;
+    in-out property <bool> line_draw_mode;
     in-out property <bool> snap_to_grid;
     in-out property <bool> snap_to_entities;
     in-out property <float> zoom_level;
@@ -329,6 +345,7 @@ export component MainWindow inherits Window {
     callback workspace_clicked(length, length);
     callback workspace_mouse_moved(length, length);
     callback workspace_mouse_exited();
+    callback right_click(length, length);
 
     callback crs_changed(int);
     callback cogo_selected(int);
@@ -471,6 +488,7 @@ export component MainWindow inherits Window {
             spacing: 6px;
             CheckBox { text: "Snap Grid"; checked <=> root.snap_to_grid; }
             CheckBox { text: "Snap Objects"; checked <=> root.snap_to_entities; }
+            CheckBox { text: "Line Mode"; checked <=> root.line_draw_mode; }
         }
 
         Rectangle {
@@ -483,6 +501,9 @@ export component MainWindow inherits Window {
                 image <=> root.workspace_image;
                 click_mode <=> root.workspace_click_mode;
                 clicked(x, y) => { root.workspace_clicked(x, y); }
+                mouse_moved(x, y) => { root.workspace_mouse_moved(x, y); }
+                mouse_exited() => { root.workspace_mouse_exited(); }
+                right_click(x, y) => { root.right_click(x, y); }
             }
             if root.workspace_mode == 1 : Workspace3D {
                 x: 0; y: 0; width: 100%; height: 100%;


### PR DESCRIPTION
## Summary
- add a line drawing toggle in the Slint UI
- track in-progress polylines and update on mouse movement
- finalize with right-click or double-click

## Testing
- `cargo check -p survey_cad_slint_gui`
- `cargo test -p survey_cad_slint_gui`

------
https://chatgpt.com/codex/tasks/task_e_6852ee1ba01c83288c36fdc33ed06139