### PR TITLE
Introduce PointDatabase for truck GUI

### DIFF
--- a/survey_cad/src/io/mod.rs
+++ b/survey_cad/src/io/mod.rs
@@ -115,6 +115,29 @@ pub fn write_points_csv(
     Ok(())
 }
 
+use crate::point_database::PointDatabase;
+
+pub fn read_point_database_csv(
+    path: &str,
+    db: &mut PointDatabase,
+    src_epsg: Option<u32>,
+    dst_epsg: Option<u32>,
+) -> io::Result<()> {
+    let pts = read_points_csv(path, src_epsg, dst_epsg)?;
+    db.clear();
+    db.extend(pts);
+    Ok(())
+}
+
+pub fn write_point_database_csv(
+    path: &str,
+    db: &PointDatabase,
+    src_epsg: Option<u32>,
+    dst_epsg: Option<u32>,
+) -> io::Result<()> {
+    write_points_csv(path, db.points(), src_epsg, dst_epsg)
+}
+
 /// Writes 3D points to a CSV file in `x,y,z` format commonly used for GNSS exports.
 pub fn write_points_csv_gnss(path: &str, points: &[Point3]) -> io::Result<()> {
     let mut file = File::create(path)?;

--- a/survey_cad/src/lib.rs
+++ b/survey_cad/src/lib.rs
@@ -29,8 +29,10 @@ pub mod reporting;
 pub mod truck_integration;
 pub mod variable_offset;
 pub mod workspace;
+pub mod point_database;
 
 #[cfg(feature = "render")]
 pub use lidar::point_cloud_to_mesh;
 pub use lidar::{classify_points, extract_breaklines, filter_noise, Classification};
 pub use local_grid::LocalGrid;
+pub use point_database::{PointDatabase, PointGroup};

--- a/survey_cad/src/point_database.rs
+++ b/survey_cad/src/point_database.rs
@@ -1,0 +1,154 @@
+use crate::geometry::Point;
+
+/// Group of point IDs with a name.
+#[derive(Debug, Clone, Default)]
+pub struct PointGroup {
+    pub name: String,
+    pub point_ids: Vec<usize>,
+}
+
+/// Simple in-memory database for survey points.
+#[derive(Debug, Clone, Default)]
+pub struct PointDatabase {
+    points: Vec<Point>,
+    groups: Vec<PointGroup>,
+}
+
+impl std::ops::Deref for PointDatabase {
+    type Target = Vec<Point>;
+    fn deref(&self) -> &Self::Target {
+        &self.points
+    }
+}
+
+impl std::ops::DerefMut for PointDatabase {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.points
+    }
+}
+
+impl PointDatabase {
+    /// Create a new empty database.
+    pub fn new() -> Self {
+        Self {
+            points: Vec::new(),
+            groups: Vec::new(),
+        }
+    }
+
+    /// Returns a slice of all points.
+    pub fn points(&self) -> &[Point] {
+        &self.points
+    }
+
+    /// Returns a mutable slice of all points.
+    pub fn points_mut(&mut self) -> &mut [Point] {
+        &mut self.points
+    }
+
+    /// Adds a point and returns its ID.
+    pub fn add_point(&mut self, point: Point) -> usize {
+        self.points.push(point);
+        self.points.len() - 1
+    }
+
+    /// Updates an existing point.
+    pub fn update_point(&mut self, id: usize, point: Point) -> bool {
+        if let Some(p) = self.points.get_mut(id) {
+            *p = point;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Removes the point with the given ID.
+    pub fn remove_point(&mut self, id: usize) -> Option<Point> {
+        if id >= self.points.len() {
+            return None;
+        }
+        for g in &mut self.groups {
+            g.point_ids.retain(|&pid| pid != id);
+            for pid in &mut g.point_ids {
+                if *pid > id {
+                    *pid -= 1;
+                }
+            }
+        }
+        Some(self.points.remove(id))
+    }
+
+    /// Adds a new group and returns its ID.
+    pub fn add_group<S: Into<String>>(&mut self, name: S) -> usize {
+        self.groups.push(PointGroup {
+            name: name.into(),
+            point_ids: Vec::new(),
+        });
+        self.groups.len() - 1
+    }
+
+    /// Removes a group.
+    pub fn remove_group(&mut self, id: usize) -> Option<PointGroup> {
+        if id >= self.groups.len() {
+            None
+        } else {
+            Some(self.groups.remove(id))
+        }
+    }
+
+    /// Assigns a point to a group.
+    pub fn assign_point(&mut self, point_id: usize, group_id: usize) -> bool {
+        if point_id >= self.points.len() || group_id >= self.groups.len() {
+            return false;
+        }
+        let g = &mut self.groups[group_id];
+        if !g.point_ids.contains(&point_id) {
+            g.point_ids.push(point_id);
+        }
+        true
+    }
+
+    /// Removes a point from a group.
+    pub fn remove_point_from_group(&mut self, point_id: usize, group_id: usize) -> bool {
+        if let Some(g) = self.groups.get_mut(group_id) {
+            let len = g.point_ids.len();
+            g.point_ids.retain(|&pid| pid != point_id);
+            len != g.point_ids.len()
+        } else {
+            false
+        }
+    }
+
+    /// Returns an iterator over all points with their IDs.
+    pub fn iter_points(&self) -> impl Iterator<Item = (usize, &Point)> {
+        self.points.iter().enumerate()
+    }
+
+    /// Returns an iterator over all groups with their IDs.
+    pub fn iter_groups(&self) -> impl Iterator<Item = (usize, &PointGroup)> {
+        self.groups.iter().enumerate()
+    }
+
+    /// Returns an iterator over points in a specific group.
+    pub fn iter_group_points(
+        &self,
+        group_id: usize,
+    ) -> Option<impl Iterator<Item = (usize, &Point)>> {
+        if group_id >= self.groups.len() {
+            None
+        } else {
+            Some(
+                self.groups[group_id]
+                    .point_ids
+                    .iter()
+                    .filter_map(move |&pid| self.points.get(pid).map(|p| (pid, p))),
+            )
+        }
+    }
+
+    /// Clears all points and groups.
+    pub fn clear(&mut self) {
+        self.points.clear();
+        self.groups.clear();
+    }
+}


### PR DESCRIPTION
## Summary
- add `PointDatabase` with groups to survey_cad
- expose `PointDatabase` from library and add csv helpers
- refactor truck GUI to use `PointDatabase` for point storage

## Testing
- `cargo fmt -- survey_cad/src/point_database.rs survey_cad/src/lib.rs survey_cad/src/io/mod.rs survey_cad_truck_gui/src/main.rs`

------
https://chatgpt.com/codex/tasks/task_e_6853035711108328b55480f6b22b8501