### PR TITLE
Add point style support to GUI

### DIFF
--- a/survey_cad/src/geometry/point.rs
+++ b/survey_cad/src/geometry/point.rs
@@ -9,6 +9,21 @@ pub enum PointSymbol {
     Cross,
 }
 
+/// Basic visual style information for a point.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PointStyle {
+    pub symbol: PointSymbol,
+    pub color: [u8; 3],
+    pub size: f32,
+}
+
+impl PointStyle {
+    /// Creates a new point style.
+    pub fn new(symbol: PointSymbol, color: [u8; 3], size: f32) -> Self {
+        Self { symbol, color, size }
+    }
+}
+
 /// Representation of a point with optional name and number.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct NamedPoint {

--- a/survey_cad/src/styles.rs
+++ b/survey_cad/src/styles.rs
@@ -1,3 +1,5 @@
+use crate::geometry::point::PointStyle;
+
 /// Basic styling structures for drawing entities.
 /// Represents the weight of a line in millimeters.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -63,4 +65,54 @@ impl DimensionStyle {
 pub struct DimensionStyleOverride {
     pub text_style: Option<TextStyle>,
     pub scale: Option<f64>,
+}
+
+/// Style definition for point labels.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PointLabelStyle {
+    pub text_style: TextStyle,
+    pub color: [u8; 3],
+    pub offset: [f32; 2],
+}
+
+impl PointLabelStyle {
+    pub fn new(text_style: TextStyle, color: [u8; 3], offset: [f32; 2]) -> Self {
+        Self {
+            text_style,
+            color,
+            offset,
+        }
+    }
+}
+
+/// Returns a basic set of default point styles.
+pub fn default_point_styles() -> Vec<(String, PointStyle)> {
+    vec![
+        (
+            "Green Circle".to_string(),
+            PointStyle::new(crate::geometry::PointSymbol::Circle, [0, 255, 0], 3.0),
+        ),
+        (
+            "Red Square".to_string(),
+            PointStyle::new(crate::geometry::PointSymbol::Square, [255, 0, 0], 3.0),
+        ),
+        (
+            "Blue Cross".to_string(),
+            PointStyle::new(crate::geometry::PointSymbol::Cross, [0, 0, 255], 3.0),
+        ),
+    ]
+}
+
+/// Returns a basic set of default point label styles.
+pub fn default_point_label_styles() -> Vec<(String, PointLabelStyle)> {
+    vec![
+        (
+            "Small White".to_string(),
+            PointLabelStyle::new(TextStyle::new("small", "Arial", 2.5), [255, 255, 255], [5.0, 5.0]),
+        ),
+        (
+            "Large Yellow".to_string(),
+            PointLabelStyle::new(TextStyle::new("large", "Arial", 5.0), [255, 255, 0], [5.0, 5.0]),
+        ),
+    ]
 }

--- a/survey_cad_truck_gui/ui/point_manager.slint
+++ b/survey_cad_truck_gui/ui/point_manager.slint
@@ -4,7 +4,7 @@ export struct PointRow {
     x: string,
     y: string,
     group_index: int,
-    style: string,
+    style_index: int,
 }
 
 import { Button, VerticalBox, HorizontalBox, LineEdit, ComboBox, ListView } from "std-widgets.slint";
@@ -12,6 +12,7 @@ import { Button, VerticalBox, HorizontalBox, LineEdit, ComboBox, ListView } from
 export component PointManager inherits Window {
     in-out property <[PointRow]> points_model;
     in-out property <[string]> groups_model;
+    in-out property <[string]> styles_model;
     in-out property <int> selected_index;
     callback add_point();
     callback remove_point(int);
@@ -21,7 +22,7 @@ export component PointManager inherits Window {
     callback edit_x(int, string);
     callback edit_y(int, string);
     callback group_changed(int, int);
-    callback select_style(int);
+    callback style_changed(int, int);
     title: "Point Manager";
     width: 600px;
     height: 400px;
@@ -61,7 +62,12 @@ export component PointManager inherits Window {
                         selected => { root.group_changed(i, self.current-index); }
                         width: 80px;
                     }
-                    Button { text: row.style; clicked => { root.select_style(i); } width: 60px; }
+                    ComboBox {
+                        model: root.styles_model;
+                        current-index: row.style_index;
+                        selected => { root.style_changed(i, self.current-index); }
+                        width: 80px;
+                    }
                 }
                 TouchArea { width: 100%; height: 100%; clicked => { root.selected_index = i; } }
             }


### PR DESCRIPTION
## Summary
- implement `PointStyle` for point geometry
- add `PointLabelStyle` and default style lists
- update Point Manager UI to choose styles
- draw points using selected styles in truck GUI

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo test -p survey_cad --no-run`


------
https://chatgpt.com/codex/tasks/task_e_685315126f3c83288575ee82ccbaad1d