### PR TITLE
Add line styling and labeling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0"
 dependencies = [
  "ab_glyph_rasterizer",
- "owned_ttf_parser",
+ "owned_ttf_parser 0.25.0",
 ]
 
 [[package]]
@@ -4605,7 +4605,7 @@ dependencies = [
  "derive_more 0.99.20",
  "lopdf",
  "printpdf",
- "rusttype",
+ "rusttype 0.8.3",
 ]
 
 [[package]]
@@ -7448,6 +7448,15 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owned_ttf_parser"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e6affeb1632d6ff6a23d2cd40ffed138e82f1532571a26f527c8a284bb2fbb"
+dependencies = [
+ "ttf-parser 0.15.2",
+]
+
+[[package]]
+name = "owned_ttf_parser"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4"
@@ -7823,7 +7832,7 @@ checksum = "1a2472a184bcb128d0e3db65b59ebd11d010259a5e14fd9d048cba8f2c9302d4"
 dependencies = [
  "js-sys",
  "lopdf",
- "rusttype",
+ "rusttype 0.8.3",
  "time 0.2.27",
 ]
 
@@ -8671,6 +8680,16 @@ dependencies = [
  "approx 0.3.2",
  "ordered-float 1.1.1",
  "stb_truetype",
+]
+
+[[package]]
+name = "rusttype"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff8374aa04134254b7995b63ad3dc41c7f7236f69528b28553da7d72efaa967"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser 0.15.2",
 ]
 
 [[package]]
@@ -9555,7 +9574,9 @@ dependencies = [
 name = "survey_cad_truck_gui"
 version = "0.1.0"
 dependencies = [
+ "once_cell",
  "rfd",
+ "rusttype 0.9.3",
  "slint",
  "slint-build",
  "survey_cad",
@@ -10360,6 +10381,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttf-parser"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd"
 
 [[package]]
 name = "ttf-parser"

--- a/survey_cad/src/geometry/line.rs
+++ b/survey_cad/src/geometry/line.rs
@@ -1,6 +1,7 @@
 //! Basic 2D line types used throughout the crate.
 
 use super::{distance, Point};
+use crate::styles::LineWeight;
 
 /// Available drawing styles for a line entity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -11,6 +12,34 @@ pub enum LineType {
     Dashed,
     /// Dotted line style.
     Dotted,
+}
+
+/// Style information for rendering a line.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LineStyle {
+    pub line_type: LineType,
+    pub color: [u8; 3],
+    pub weight: LineWeight,
+}
+
+impl LineStyle {
+    pub fn new(line_type: LineType, color: [u8; 3], weight: LineWeight) -> Self {
+        Self {
+            line_type,
+            color,
+            weight,
+        }
+    }
+}
+
+impl Default for LineStyle {
+    fn default() -> Self {
+        Self {
+            line_type: LineType::Solid,
+            color: [255, 255, 255],
+            weight: LineWeight::default(),
+        }
+    }
 }
 
 /// Representation of a 2D line segment between two points.

--- a/survey_cad/src/geometry/mod.rs
+++ b/survey_cad/src/geometry/mod.rs
@@ -5,7 +5,7 @@ pub mod line3;
 pub mod point;
 pub mod point3;
 
-pub use line::{Line, LineAnnotation, LineType};
+pub use line::{Line, LineAnnotation, LineType, LineStyle};
 pub use line3::Line3;
 pub use point::{NamedPoint, Point, PointSymbol};
 pub use point3::Point3;

--- a/survey_cad/src/styles.rs
+++ b/survey_cad/src/styles.rs
@@ -85,6 +85,32 @@ impl PointLabelStyle {
     }
 }
 
+/// Position of a line label relative to the line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineLabelPosition {
+    Above,
+    Below,
+    Center,
+}
+
+/// Style definition for line labels.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LineLabelStyle {
+    pub text_style: TextStyle,
+    pub color: [u8; 3],
+    pub position: LineLabelPosition,
+}
+
+impl LineLabelStyle {
+    pub fn new(text_style: TextStyle, color: [u8; 3], position: LineLabelPosition) -> Self {
+        Self {
+            text_style,
+            color,
+            position,
+        }
+    }
+}
+
 /// Returns a basic set of default point styles.
 pub fn default_point_styles() -> Vec<(String, PointStyle)> {
     vec![
@@ -113,6 +139,47 @@ pub fn default_point_label_styles() -> Vec<(String, PointLabelStyle)> {
         (
             "Large Yellow".to_string(),
             PointLabelStyle::new(TextStyle::new("large", "Arial", 5.0), [255, 255, 0], [5.0, 5.0]),
+        ),
+    ]
+}
+
+/// Returns a basic set of default line styles.
+pub fn default_line_styles() -> Vec<(String, crate::geometry::line::LineStyle)> {
+    use crate::geometry::line::{LineStyle, LineType};
+    vec![
+        (
+            "White Solid".to_string(),
+            LineStyle::new(LineType::Solid, [255, 255, 255], LineWeight(1.0)),
+        ),
+        (
+            "Red Dashed".to_string(),
+            LineStyle::new(LineType::Dashed, [255, 0, 0], LineWeight(1.0)),
+        ),
+        (
+            "Blue Dotted".to_string(),
+            LineStyle::new(LineType::Dotted, [0, 0, 255], LineWeight(1.0)),
+        ),
+    ]
+}
+
+/// Returns a basic set of default line label styles.
+pub fn default_line_label_styles() -> Vec<(String, LineLabelStyle)> {
+    vec![
+        (
+            "Above Small".to_string(),
+            LineLabelStyle::new(
+                TextStyle::new("small", "Arial", 3.0),
+                [255, 255, 255],
+                LineLabelPosition::Above,
+            ),
+        ),
+        (
+            "Below Small".to_string(),
+            LineLabelStyle::new(
+                TextStyle::new("small", "Arial", 3.0),
+                [255, 255, 0],
+                LineLabelPosition::Below,
+            ),
         ),
     ]
 }

--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -10,6 +10,8 @@ survey_cad = { path = "../survey_cad" }
 rfd = "0.15"
 tiny-skia = "0.11"
 truck_cad_engine = { path = "../truck_cad_engine" }
+once_cell = "1"
+rusttype = "0.9"
 
 [build-dependencies]
 slint-build = "1"

--- a/survey_cad_truck_gui/ui/line_style_manager.slint
+++ b/survey_cad_truck_gui/ui/line_style_manager.slint
@@ -1,0 +1,53 @@
+export struct LineRow {
+    start: string,
+    end: string,
+    style_index: int,
+}
+
+import { VerticalBox, HorizontalBox, ComboBox, ListView } from "std-widgets.slint";
+
+export component LineStyleManager inherits Window {
+    in-out property <[LineRow]> lines_model;
+    in-out property <[string]> styles_model;
+    in-out property <int> selected_index;
+    callback style_changed(int, int);
+    title: "Line Style Manager";
+    width: 500px;
+    height: 300px;
+
+    VerticalBox {
+        spacing: 4px;
+        Rectangle {
+            width: 100%;
+            height: 20px;
+            border-width: 1px;
+            border-color: #808080;
+            HorizontalBox {
+                spacing: 8px;
+                Text { text: "Start"; width: 140px; }
+                Text { text: "End"; width: 140px; }
+                Text { text: "Style"; width: 80px; }
+            }
+        }
+        ListView {
+            vertical-stretch: 1;
+            for row[i] in root.lines_model : Rectangle {
+                property <bool> selected: root.selected_index == i;
+                background: selected ? #404040 : transparent;
+                height: 24px;
+                HorizontalBox {
+                    spacing: 8px;
+                    Text { text: row.start; width: 140px; }
+                    Text { text: row.end; width: 140px; }
+                    ComboBox {
+                        model: root.styles_model;
+                        current-index: row.style_index;
+                        selected => { root.style_changed(i, self.current-index); }
+                        width: 80px;
+                    }
+                }
+                TouchArea { width: 100%; height: 100%; clicked => { root.selected_index = i; } }
+            }
+        }
+    }
+}

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -1,4 +1,5 @@
 export { PointManager } from "point_manager.slint";
+export { LineStyleManager } from "line_style_manager.slint";
 
 component Workspace2D inherits Rectangle {
     in-out property <image> image;
@@ -389,6 +390,7 @@ export component MainWindow inherits Window {
     callback level_elevation_tool();
     callback corridor_volume();
     callback point_manager();
+    callback line_style_manager();
     callback import_geojson();
     callback import_kml();
     callback import_dxf();
@@ -447,6 +449,7 @@ export component MainWindow inherits Window {
             MenuItem { title: "Add Arc"; activated => { root.add_arc(); } }
             MenuItem { title: "Create Polygon from Selection"; activated => { root.create_polygon_from_selection(); } }
             MenuItem { title: "Point Manager..."; activated => { root.point_manager(); } }
+            MenuItem { title: "Line Styles..."; activated => { root.line_style_manager(); } }
             MenuItem { title: "Clear"; activated => { root.clear_workspace(); } }
         }
         Menu {
@@ -481,6 +484,7 @@ export component MainWindow inherits Window {
             Button { text: "Save"; clicked => { root.save_project(); } }
             Button { text: "Add Point"; clicked => { root.add_point(); } }
             Button { text: "Point Manager..."; clicked => { root.point_manager(); } }
+            Button { text: "Line Styles..."; clicked => { root.line_style_manager(); } }
             Button { text: "Add Line"; clicked => { root.add_line(); } }
         Button { text: "Add Polygon"; clicked => { root.add_polygon(); } }
         Button { text: "Add Polyline"; clicked => { root.add_polyline(); } }


### PR DESCRIPTION
## Summary
- define `LineStyle` and new label style types
- provide default line/line-label styles
- draw lines according to style with optional label text
- expose new `Line Style Manager` UI for editing

## Testing
- `cargo test --quiet` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_685320f620908328808169231c6605c5