### PR TITLE
Fix font paths for truck GUI

### DIFF
--- a/survey_cad/src/reporting.rs
+++ b/survey_cad/src/reporting.rs
@@ -6,7 +6,10 @@ use umya_spreadsheet::{self, writer::xlsx, Spreadsheet};
 
 #[cfg(feature = "reporting")]
 fn write_pdf(path: &str, title: &str, rows: &[String]) -> std::io::Result<()> {
-    let font_family = genpdf::fonts::from_files("/usr/share/fonts", "LiberationSans", None)
+    // Load fonts from the crate's `assets` directory. The font files are not
+    // stored in the repository; place them in `survey_cad/assets` as needed.
+    let font_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/assets");
+    let font_family = genpdf::fonts::from_files(font_dir, "DejaVuSans", None)
         .map_err(|e| std::io::Error::other(e.to_string()))?;
     let mut doc = Document::new(font_family);
     doc.set_title(title);

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -24,7 +24,11 @@ use rusttype::{Font, Scale, point};
 
 slint::include_modules!();
 
-static FONT_DATA: &[u8] = include_bytes!("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf");
+// Load font from the crate's `assets` directory. The binary font file is not
+// committed to the repository; place `DejaVuSans.ttf` inside the `assets`
+// folder next to this crate's `Cargo.toml`.
+static FONT_DATA: &[u8] =
+    include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/DejaVuSans.ttf"));
 static FONT: Lazy<Font<'static>> = Lazy::new(|| Font::try_from_bytes(FONT_DATA).unwrap());
 
 struct WorkspaceRenderData<'a> {


### PR DESCRIPTION
## Summary
- remove embedded DejaVuSans font from repo
- load fonts from a local `assets` directory for PDF generation
- load Truck GUI font from `assets/DejaVuSans.ttf`

## Testing
- `cargo check -p survey_cad` *(passes)*
- `cargo check -p survey_cad_truck_gui` *(failed: network limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6854117291848328827beca3dd03764a