### PR TITLE
Call request_redraw before running app

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -2549,5 +2549,7 @@ fn main() -> Result<(), slint::PlatformError> {
         })
         .unwrap();
 
+    app.window().request_redraw();
+
     app.run()
 }


### PR DESCRIPTION
## Summary
- trigger redraw after setting rendering notifier in `survey_cad_truck_gui`

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_685434017f2c832898be38680344bfc3