### PR TITLE
Register font in truck GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9574,6 +9574,7 @@ dependencies = [
 name = "survey_cad_truck_gui"
 version = "0.1.0"
 dependencies = [
+ "i-slint-common 1.12.0 (git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db)",
  "once_cell",
  "rfd",
  "rusttype 0.9.3",

--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -6,6 +6,7 @@ build = "build.rs"
 
 [dependencies]
 slint = { git = "https://github.com/slint-ui/slint", rev = "939d605e0688b7ea4cb6e3a5b3f40d918a60a5db", features = ["unstable-wgpu-24"] }
+i-slint-common = { git = "https://github.com/slint-ui/slint", rev = "939d605e0688b7ea4cb6e3a5b3f40d918a60a5db" }
 survey_cad = { path = "../survey_cad" }
 rfd = "0.15"
 tiny-skia = "0.11"

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -2,6 +2,7 @@
 
 use slint::platform::PointerEventButton;
 use slint::{Image, SharedString, VecModel, Model};
+use i_slint_common::sharedfontdb;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -511,6 +512,8 @@ fn read_arc_csv(path: &str) -> std::io::Result<Arc> {
 
 fn main() -> Result<(), slint::PlatformError> {
     let backend = Rc::new(RefCell::new(TruckBackend::new(640, 480)));
+    // Register bundled font before creating the window
+    sharedfontdb::register_font_from_memory(FONT_DATA).unwrap();
     let app = MainWindow::new()?;
 
     // example data so the 2D workspace has something to draw


### PR DESCRIPTION
## Summary
- register bundled font before constructing `MainWindow`
- add `i-slint-common` to access font registration API

## Testing
- `cargo build -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_685436a5ec9883289a9cefcb453daa37