### PR TITLE
Make PointManager columns resizable

### DIFF
--- a/survey_cad_truck_gui/ui/point_manager.slint
+++ b/survey_cad_truck_gui/ui/point_manager.slint
@@ -9,6 +9,36 @@ export struct PointRow {
 
 import { Button, VerticalBox, HorizontalBox, LineEdit, ComboBox, ListView } from "std-widgets.slint";
 
+component ColumnSeparator inherits Rectangle {
+    in-out property <length> column_width;
+    property <length> start_x;
+    property <length> start_width;
+    property <bool> dragging;
+    width: 8px;
+    height: 100%;
+    Rectangle {
+        width: 2px;
+        height: 100%;
+        x: (parent.width - self.width) / 2;
+        background: #808080;
+    }
+    TouchArea {
+        width: 100%;
+        height: 100%;
+        pointer-event(ev) => {
+            if ev.kind == PointerEventKind.down {
+                root.start_x = self.mouse-x;
+                root.start_width = root.column_width;
+                root.dragging = true;
+            } else if ev.kind == PointerEventKind.up || ev.kind == PointerEventKind.cancel {
+                root.dragging = false;
+            } else if ev.kind == PointerEventKind.move && root.dragging {
+                root.column_width = root.start_width + self.mouse-x - root.start_x;
+            }
+        }
+    }
+}
+
 export component PointManager inherits Window {
     in-out property <[PointRow]> points_model;
     in-out property <[string]> groups_model;
@@ -23,6 +53,12 @@ export component PointManager inherits Window {
     callback edit_y(int, string);
     callback group_changed(int, int);
     callback style_changed(int, int);
+    property <length> number_width: 30px;
+    property <length> name_width: 250px;
+    property <length> x_width: 60px;
+    property <length> y_width: 60px;
+    property <length> group_width: 80px;
+    property <length> style_width: 80px;
     title: "Point Manager";
     width: 600px;
     height: 400px;
@@ -35,13 +71,18 @@ export component PointManager inherits Window {
             border-width: 1px;
             border-color: #808080;
             HorizontalLayout {
-                spacing: 8px;
-                Text { text: "#"; width: 30px; }
-                Text { text: "Name"; horizontal-stretch: 1; }
-                Text { text: "X"; width: 60px; }
-                Text { text: "Y"; width: 60px; }
-                Text { text: "Group"; width: 80px; }
-                Text { text: "Style"; width: 60px; }
+                spacing: 0px;
+                Text { text: "#"; width: root.number_width; }
+                ColumnSeparator { column_width <=> root.number_width; }
+                Text { text: "Name"; width: root.name_width; }
+                ColumnSeparator { column_width <=> root.name_width; }
+                Text { text: "X"; width: root.x_width; }
+                ColumnSeparator { column_width <=> root.x_width; }
+                Text { text: "Y"; width: root.y_width; }
+                ColumnSeparator { column_width <=> root.y_width; }
+                Text { text: "Group"; width: root.group_width; }
+                ColumnSeparator { column_width <=> root.group_width; }
+                Text { text: "Style"; width: root.style_width; }
             }
         }
         ListView {
@@ -54,7 +95,7 @@ export component PointManager inherits Window {
                     spacing: 8px;
                     Text {
                         text: row.number;
-                        width: 30px;
+                        width: root.number_width;
                         TouchArea {
                             x: 0px;
                             y: 0px;
@@ -63,20 +104,20 @@ export component PointManager inherits Window {
                             clicked => { root.selected_index = i; }
                         }
                     }
-                    LineEdit { text: row.name; horizontal-stretch: 1; edited(text) => { root.edit_name(i, text); } }
-                    LineEdit { text: row.x; width: 60px; edited(text) => { root.edit_x(i, text); } }
-                    LineEdit { text: row.y; width: 60px; edited(text) => { root.edit_y(i, text); } }
+                    LineEdit { text: row.name; width: root.name_width; edited(text) => { root.edit_name(i, text); } }
+                    LineEdit { text: row.x; width: root.x_width; edited(text) => { root.edit_x(i, text); } }
+                    LineEdit { text: row.y; width: root.y_width; edited(text) => { root.edit_y(i, text); } }
                     ComboBox {
                         model: root.groups_model;
                         current-index: row.group_index;
                         selected => { root.group_changed(i, self.current-index); }
-                        width: 80px;
+                        width: root.group_width;
                     }
                     ComboBox {
                         model: root.styles_model;
                         current-index: row.style_index;
                         selected => { root.style_changed(i, self.current-index); }
-                        width: 80px;
+                        width: root.style_width;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add `ColumnSeparator` component for column drags
- expose width properties for each column
- use width properties for headers and rows
- place draggable separators in header layout

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_6854470b08188328ba1b2300749d2141