### PR TITLE
Handle font registration errors and add build check

### DIFF
--- a/survey_cad_truck_gui/README.md
+++ b/survey_cad_truck_gui/README.md
@@ -19,3 +19,10 @@ cargo build -p survey_cad_truck_gui
 
 Rebuilding ensures that any changes in the `.slint` files are reflected in the
 Rust code via the generated bindings.
+
+## Fonts
+
+This application bundles the `DejaVuSans.ttf` font located in the `assets/`
+directory. The build script checks for this file and aborts if it is missing.
+Replace it with a different font by copying the `.ttf` file into `assets/` before
+running `cargo build`.

--- a/survey_cad_truck_gui/build.rs
+++ b/survey_cad_truck_gui/build.rs
@@ -1,3 +1,12 @@
+use std::path::Path;
+
 fn main() {
+    // Ensure the required font is available during the build.
+    if !Path::new("assets/DejaVuSans.ttf").exists() {
+        panic!(
+            "assets/DejaVuSans.ttf not found. Please add the font file to the assets directory."
+        );
+    }
+
     slint_build::compile("ui/main.slint").unwrap();
 }

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -599,8 +599,11 @@ fn read_arc_csv(path: &str) -> std::io::Result<Arc> {
 
 fn main() -> Result<(), slint::PlatformError> {
     let backend = Rc::new(RefCell::new(TruckBackend::new(640, 480)));
-    // Register bundled font before creating the window
-    sharedfontdb::register_font_from_memory(FONT_DATA).unwrap();
+    // Register bundled font before creating the window. If registration fails
+    // we fall back to the system fonts so the application remains usable.
+    if let Err(err) = sharedfontdb::register_font_from_memory(FONT_DATA) {
+        eprintln!("Failed to register bundled font: {err}. Falling back to system fonts");
+    }
     let app = MainWindow::new()?;
     let window_size = Rc::new(RefCell::new(app.window().size()));
 


### PR DESCRIPTION
## Summary
- log a helpful error if font registration fails instead of unwrapping
- verify `DejaVuSans.ttf` exists in `build.rs`
- mention the font requirement in the README

## Testing
- `cargo fmt -p survey_cad_truck_gui`
- `cargo check -p survey_cad_truck_gui` *(fails: could not compile `survey_cad_truck_gui` due to 5 previous errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854813fd4f88328af38d00f9fbe7a38