### PR TITLE
Fix list view alignment

### DIFF
--- a/survey_cad_truck_gui/ui/point_manager.slint
+++ b/survey_cad_truck_gui/ui/point_manager.slint
@@ -87,6 +87,7 @@ export component PointManager inherits Window {
         }
         ListView {
             vertical-stretch: 1;
+            vertical-alignment: start;
             for row[i] in root.points_model : Rectangle {
                 property <bool> selected: root.selected_index == i;
                 background: selected ? #404040 : transparent;


### PR DESCRIPTION
## Summary
- align list view rows below header in point manager

## Testing
- `cargo test -p survey_cad --no-default-features` *(fails: compilation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685566598dd48328b2f8627dc51c969c