### PR TITLE
Fix slint compile error

### DIFF
--- a/survey_cad_truck_gui/ui/point_manager.slint
+++ b/survey_cad_truck_gui/ui/point_manager.slint
@@ -87,7 +87,6 @@ export component PointManager inherits Window {
         }
         ListView {
             vertical-stretch: 1;
-            vertical-alignment: start;
             for row[i] in root.points_model : Rectangle {
                 property <bool> selected: root.selected_index == i;
                 background: selected ? #404040 : transparent;


### PR DESCRIPTION
## Summary
- remove unsupported `vertical-alignment` property in `point_manager.slint`

## Testing
- `cargo check -p survey_cad_truck_gui` *(fails: build aborted due to long dependency compilation)*

------
https://chatgpt.com/codex/tasks/task_e_685572cb28888328970fb4e98cd91321