### PR TITLE
Fix pointer pressed callback in truck GUI

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -64,7 +64,7 @@ struct CursorFeedback {
     frame: u32,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 enum DrawingMode {
     None,
     Line { start: Option<Point> },
@@ -983,12 +983,12 @@ fn main() -> Result<(), slint::PlatformError> {
         let arcs_ref = arcs.clone();
         let render_image = render_image.clone();
         let weak = app.as_weak();
-        app.on_workspace_pointer_pressed(move |ev| {
+        app.on_workspace_pointer_pressed(move |x, y, ev| {
             if *drawing_mode.borrow() != DrawingMode::None {
                 if ev.button == PointerEventButton::Left {
                     if let Some(app) = weak.upgrade() {
                         let size = app.window().size();
-                        let p = screen_to_workspace(ev.x, ev.y, &offset, &zoom, size.width as f32, size.height as f32);
+                        let p = screen_to_workspace(x as f32, y as f32, &offset, &zoom, size.width as f32, size.height as f32);
                         match &mut *drawing_mode.borrow_mut() {
                             DrawingMode::Line { start } => {
                                 if start.is_none() {
@@ -1022,16 +1022,14 @@ fn main() -> Result<(), slint::PlatformError> {
                         }
                     }
                 }
-            } else {
-                if ev.button == PointerEventButton::Middle {
-                    *pan_2d_flag.borrow_mut() = true;
-                } else if ev.button == PointerEventButton::Left {
-                    let mut ds = drag_select.borrow_mut();
-                    ds.start = (ev.x as f32, ev.y as f32);
-                    ds.end = ds.start;
-                    ds.active = true;
-                    *last_pos_2d.borrow_mut() = (ev.x as f64, ev.y as f64);
-                }
+            } else if ev.button == PointerEventButton::Middle {
+                *pan_2d_flag.borrow_mut() = true;
+            } else if ev.button == PointerEventButton::Left {
+                let mut ds = drag_select.borrow_mut();
+                ds.start = (x as f32, y as f32);
+                ds.end = ds.start;
+                ds.active = true;
+                *last_pos_2d.borrow_mut() = (x as f64, y as f64);
             }
         });
     }

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -6,7 +6,7 @@ component Workspace2D inherits Rectangle {
     in-out property <bool> click_mode;
     callback clicked(length, length);
     callback mouse_moved(length, length);
-    callback pointer_pressed(PointerEvent);
+    callback pointer_pressed(length, length, PointerEvent);
     callback pointer_released();
     callback scrolled(length, length);
     background: #202020;
@@ -26,7 +26,7 @@ component Workspace2D inherits Rectangle {
         }
         pointer-event(event) => {
             if event.kind == PointerEventKind.down {
-                root.pointer_pressed(event);
+                root.pointer_pressed(self.mouse-x, self.mouse-y, event);
             } else if event.kind == PointerEventKind.up {
                 root.pointer_released();
             } else if event.kind == PointerEventKind.move {
@@ -413,7 +413,7 @@ export component MainWindow inherits Window {
     callback zoom_out();
     callback workspace_left_pressed(length, length);
     callback workspace_right_pressed(length, length);
-    callback workspace_pointer_pressed(PointerEvent);
+    callback workspace_pointer_pressed(length, length, PointerEvent);
     callback workspace_pointer_released();
     callback workspace_scrolled(length, length);
 
@@ -603,7 +603,7 @@ export component MainWindow inherits Window {
                 click_mode <=> root.workspace_click_mode;
                 clicked(x, y) => { root.workspace_clicked(x, y); }
                 mouse_moved(x, y) => { root.workspace_mouse_moved(x, y); }
-                pointer_pressed(ev) => { root.workspace_pointer_pressed(ev); }
+                pointer_pressed(x, y, ev) => { root.workspace_pointer_pressed(x, y, ev); }
                 pointer_released() => { root.workspace_pointer_released(); }
                 scrolled(dx, dy) => { root.workspace_scrolled(dx, dy); }
             }


### PR DESCRIPTION
## Summary
- adjust DrawingMode to derive `PartialEq`
- change Workspace2D pointer events to pass coordinates
- collapse `else if` block in pointer handler

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo test -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_68557fa767208328b181df956584ff22