### PR TITLE
Fix startup panic in survey_cad_truck_gui

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -157,6 +157,12 @@ fn render_workspace(
     width: u32,
     height: u32,
 ) -> Image {
+    if width == 0 || height == 0 {
+        // When the window has not been laid out yet slint reports a size of
+        // zero. Returning an empty image avoids panicking until a real size is
+        // available.
+        return Image::default();
+    }
     let mut pixmap = Pixmap::new(width, height).unwrap();
     pixmap.fill(Color::from_rgba8(32, 32, 32, 255));
     let mut paint = Paint::default();


### PR DESCRIPTION
## Summary
- avoid panic when window size is zero

## Testing
- `cargo check -p survey_cad_truck_gui --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685597dc663c8328abc7a8c68e9a79f9