### PR TITLE
Fix div_ceil clippy warning

### DIFF
--- a/truck-master/truck-platform/src/scene.rs
+++ b/truck-master/truck-platform/src/scene.rs
@@ -751,7 +751,7 @@ impl Scene {
         let bytes_per_pixel = 4u32;
         let unpadded_bytes_per_row = width * bytes_per_pixel;
         let align = COPY_BYTES_PER_ROW_ALIGNMENT;
-        let padded_bytes_per_row = ((unpadded_bytes_per_row + align - 1) / align) * align;
+        let padded_bytes_per_row = unpadded_bytes_per_row.div_ceil(align) * align;
 
         let size = padded_bytes_per_row as u64 * height as u64;
         let buffer = device.create_buffer(&BufferDescriptor {


### PR DESCRIPTION
## Summary
- use the built-in `div_ceil` when calculating padding

## Testing
- `cargo clippy -p truck-platform --tests -- -D warnings`
- `cargo test -p truck-platform`

------
https://chatgpt.com/codex/tasks/task_e_68593b788ce48328b71b2f030a8efc29