### PR TITLE
Fix line mode panic for missed first click

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -1046,9 +1046,17 @@ fn main() -> Result<(), slint::PlatformError> {
                             DrawingMode::Line { start } => {
                                 if start.is_none() {
                                     *start = Some(p);
-                                } else if let Some(s) = *start {
+                                } else if let Some(s) = start.take() {
                                     lines_ref.borrow_mut().push((s, p));
                                     *drawing_mode.borrow_mut() = DrawingMode::None;
+                                } else {
+                                    if let Some(app) = weak.upgrade() {
+                                        app.set_status(SharedString::from(
+                                            "No start point, line cancelled",
+                                        ));
+                                    }
+                                    *drawing_mode.borrow_mut() = DrawingMode::None;
+                                    return;
                                 }
                             }
                             DrawingMode::Polygon { vertices } => {


### PR DESCRIPTION
## Summary
- handle case when line drawing start point is missing
- report status and exit early if start is invalid

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo test -p survey_cad_truck_gui --no-run`


------
https://chatgpt.com/codex/tasks/task_e_6859575dd9508328b4af299945cb543b