### PR TITLE
Enhance polygon drawing controls

### DIFF
--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -367,6 +367,11 @@ export component MainWindow inherits Window {
     in-out property <bool> snap_to_entities;
     in-out property <float> zoom_level;
 
+    callback key_pressed(string);
+    FocusScope {
+        key-pressed(event) => { root.key_pressed(event.text); return EventResult.accept; }
+    }
+
     callback draw_line_mode();
     callback draw_polygon_mode();
     callback draw_arc_mode();


### PR DESCRIPTION
## Summary
- add a keyboard callback to `MainWindow`
- snap polygon vertices while drawing
- allow double-click or Enter to finish polygons
- reset drawing mode with Escape

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_68595bb9519083288fb6d489117fa0eb