### PR TITLE
Add flexible arc drawing modes

### DIFF
--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -350,6 +350,19 @@ export component ArcKeyInDialog inherits Window {
     }
 }
 
+export component ArcModeDialog inherits Window {
+    callback center_start_end();
+    callback three_point();
+    callback start_end_radius();
+    title: "Arc Mode";
+    VerticalBox {
+        spacing: 6px;
+        Button { text: "Center-Start-End"; clicked => { root.center_start_end(); } }
+        Button { text: "Three Point"; clicked => { root.three_point(); } }
+        Button { text: "Start-End-Radius"; clicked => { root.start_end_radius(); } }
+    }
+}
+
 export component MainWindow inherits Window {
     preferred-width: 800px;
     preferred-height: 600px;


### PR DESCRIPTION
## Summary
- validate arc parameters
- add dialog to choose arc draw style
- implement new `ArcCenter`, `ArcThreePoint` and `ArcStartEndRadius` modes
- allow cancelling active arc draw with Escape

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6859619ebc8883288400114d9a5b3067