### PR TITLE
Add DMS formatting utility and update label styles

### DIFF
--- a/survey_cad/src/styles.rs
+++ b/survey_cad/src/styles.rs
@@ -111,6 +111,27 @@ impl LineLabelStyle {
     }
 }
 
+/// Formats a decimal degree value as a degrees-minutes-seconds string.
+pub fn format_dms(angle_deg: f64) -> String {
+    let sign = if angle_deg < 0.0 { "-" } else { "" };
+    let mut angle = angle_deg.abs();
+    let mut deg = angle.floor() as i64;
+    angle = (angle - deg as f64) * 60.0;
+    let mut min = angle.floor() as i64;
+    let mut sec = ((angle - min as f64) * 60.0).round() as i64;
+
+    if sec == 60 {
+        sec = 0;
+        min += 1;
+    }
+    if min == 60 {
+        min = 0;
+        deg += 1;
+    }
+
+    format!("{}{}\u{00B0}{}'{}\"", sign, deg, min, sec)
+}
+
 /// Returns a basic set of default point styles.
 pub fn default_point_styles() -> Vec<(String, PointStyle)> {
     vec![
@@ -134,11 +155,19 @@ pub fn default_point_label_styles() -> Vec<(String, PointLabelStyle)> {
     vec![
         (
             "Small White".to_string(),
-            PointLabelStyle::new(TextStyle::new("small", "Arial", 2.5), [255, 255, 255], [5.0, 5.0]),
+            PointLabelStyle::new(
+                TextStyle::new("small", "Arial", 10.0),
+                [255, 255, 255],
+                [5.0, 5.0],
+            ),
         ),
         (
             "Large Yellow".to_string(),
-            PointLabelStyle::new(TextStyle::new("large", "Arial", 5.0), [255, 255, 0], [5.0, 5.0]),
+            PointLabelStyle::new(
+                TextStyle::new("large", "Arial", 10.0),
+                [255, 255, 0],
+                [5.0, 5.0],
+            ),
         ),
     ]
 }
@@ -168,7 +197,7 @@ pub fn default_line_label_styles() -> Vec<(String, LineLabelStyle)> {
         (
             "Above Small".to_string(),
             LineLabelStyle::new(
-                TextStyle::new("small", "Arial", 8.0),
+                TextStyle::new("small", "Arial", 10.0),
                 [255, 255, 255],
                 LineLabelPosition::Above,
             ),
@@ -176,7 +205,7 @@ pub fn default_line_label_styles() -> Vec<(String, LineLabelStyle)> {
         (
             "Below Small".to_string(),
             LineLabelStyle::new(
-                TextStyle::new("small", "Arial", 8.0),
+                TextStyle::new("small", "Arial", 10.0),
                 [255, 255, 0],
                 LineLabelPosition::Below,
             ),

--- a/survey_cad/tests/format_dms.rs
+++ b/survey_cad/tests/format_dms.rs
@@ -1,0 +1,11 @@
+use survey_cad::styles::format_dms;
+
+#[test]
+fn dms_basic() {
+    assert_eq!(format_dms(123.7516667), "123\u{00B0}45'6\"");
+}
+
+#[test]
+fn dms_negative() {
+    assert_eq!(format_dms(-0.0166667), "-0\u{00B0}1'0\"");
+}

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -15,7 +15,7 @@ use survey_cad::geometry::{
     Arc, Line, LineAnnotation, LineStyle, LineType, Point, PointSymbol, Polyline,
 };
 use survey_cad::point_database::PointDatabase;
-use survey_cad::styles::{LineLabelPosition, LineLabelStyle, PointLabelStyle};
+use survey_cad::styles::{format_dms, LineLabelPosition, LineLabelStyle, PointLabelStyle};
 
 mod truck_backend;
 use truck_backend::TruckBackend;
@@ -369,7 +369,7 @@ fn render_workspace(
             if angle < 0.0 {
                 angle += 360.0;
             }
-            let text = format!("{:.2} m\n{:.1}\u{00B0}", ann.distance, angle);
+            let text = format!("{:.2} m\n{}", ann.distance, format_dms(angle));
             let mid = line.midpoint();
             let dx = e.x - s.x;
             let dy = e.y - s.y;


### PR DESCRIPTION
## Summary
- add `format_dms` helper for degrees‑minutes‑seconds output
- raise default line and point label text sizes
- use `format_dms` for line label display in Truck GUI
- add basic tests for `format_dms`

## Testing
- `timeout 30 cargo test -p survey_cad --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6859955022988328b0c030ba9c5c0ad2