### PR TITLE
Improve font fallback and UI text color

### DIFF
--- a/survey_cad_slint_gui/ui/main.slint
+++ b/survey_cad_slint_gui/ui/main.slint
@@ -57,6 +57,10 @@ component Workspace3D inherits Rectangle {
 
 import { Button, VerticalBox, HorizontalBox, ComboBox, LineEdit, ListView, CheckBox } from "std-widgets.slint";
 
+export global AppStyle {
+    Text { color: #FFFFFF; }
+}
+
 export component AddPointDialog inherits Window {
     callback from_file();
     callback manual_keyin();

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -939,6 +939,7 @@ fn main() -> Result<(), slint::PlatformError> {
     // we fall back to the system fonts so the application remains usable.
     if let Err(err) = sharedfontdb::register_font_from_memory(FONT_DATA) {
         eprintln!("Failed to register bundled font: {err}. Falling back to system fonts");
+        sharedfontdb::FONT_DB.with_borrow_mut(|db| db.make_mut().load_system_fonts());
     }
     let app = MainWindow::new()?;
     let window_size = Rc::new(RefCell::new(app.window().size()));

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -83,6 +83,10 @@ component Workspace3D inherits Rectangle {
 
 import { Button, VerticalBox, HorizontalBox, ComboBox, LineEdit, ListView, CheckBox } from "std-widgets.slint";
 
+export global AppStyle {
+    Text { color: #FFFFFF; }
+}
+
 export component AddPointDialog inherits Window {
     callback from_file();
     callback manual_keyin();


### PR DESCRIPTION
## Summary
- ensure bundled font registration falls back to system fonts
- set default text color to white in Slint UI files

## Testing
- `cargo check -p survey_cad_truck_gui -p survey_cad_slint_gui` *(fails: environment timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68599baf327083289498cc2aaa66d694