### PR TITLE
Fix Slint global style compilation

### DIFF
--- a/survey_cad_slint_gui/ui/main.slint
+++ b/survey_cad_slint_gui/ui/main.slint
@@ -55,11 +55,7 @@ component Workspace3D inherits Rectangle {
     }
 }
 
-import { Button, VerticalBox, HorizontalBox, ComboBox, LineEdit, ListView, CheckBox } from "std-widgets.slint";
-
-export global AppStyle {
-    Text { color: #FFFFFF; }
-}
+import { Button, VerticalBox, HorizontalBox, ComboBox, LineEdit, ListView, CheckBox, Palette } from "std-widgets.slint";
 
 export component AddPointDialog inherits Window {
     callback from_file();
@@ -83,11 +79,11 @@ export component KeyInDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "X:"; }
+            Text { color: #FFFFFF; text: "X:"; }
             LineEdit { text <=> root.x_value; }
         }
         HorizontalBox {
-            Text { text: "Y:"; }
+            Text { color: #FFFFFF; text: "Y:"; }
             LineEdit { text <=> root.y_value; }
         }
         HorizontalBox {
@@ -109,19 +105,19 @@ export component StationDistanceDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "X1:"; }
+            Text { color: #FFFFFF; text: "X1:"; }
             LineEdit { text <=> root.x1; }
         }
         HorizontalBox {
-            Text { text: "Y1:"; }
+            Text { color: #FFFFFF; text: "Y1:"; }
             LineEdit { text <=> root.y1; }
         }
         HorizontalBox {
-            Text { text: "X2:"; }
+            Text { color: #FFFFFF; text: "X2:"; }
             LineEdit { text <=> root.x2; }
         }
         HorizontalBox {
-            Text { text: "Y2:"; }
+            Text { color: #FFFFFF; text: "Y2:"; }
             LineEdit { text <=> root.y2; }
         }
         HorizontalBox {
@@ -142,15 +138,15 @@ export component LevelElevationDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "Start Elev:"; }
+            Text { color: #FFFFFF; text: "Start Elev:"; }
             LineEdit { text <=> root.start_elev; }
         }
         HorizontalBox {
-            Text { text: "Backsight:"; }
+            Text { color: #FFFFFF; text: "Backsight:"; }
             LineEdit { text <=> root.backsight; }
         }
         HorizontalBox {
-            Text { text: "Foresight:"; }
+            Text { color: #FFFFFF; text: "Foresight:"; }
             LineEdit { text <=> root.foresight; }
         }
         HorizontalBox {
@@ -171,15 +167,15 @@ export component CorridorVolumeDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "Width:"; }
+            Text { color: #FFFFFF; text: "Width:"; }
             LineEdit { text <=> root.width_value; }
         }
         HorizontalBox {
-            Text { text: "Interval:"; }
+            Text { color: #FFFFFF; text: "Interval:"; }
             LineEdit { text <=> root.interval_value; }
         }
         HorizontalBox {
-            Text { text: "Offset Step:"; }
+            Text { color: #FFFFFF; text: "Offset Step:"; }
             LineEdit { text <=> root.offset_step_value; }
         }
         HorizontalBox {
@@ -212,15 +208,15 @@ export component LineKeyInDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "X1:"; }
+            Text { color: #FFFFFF; text: "X1:"; }
             LineEdit { text <=> root.x1; }
-            Text { text: "Y1:"; }
+            Text { color: #FFFFFF; text: "Y1:"; }
             LineEdit { text <=> root.y1; }
         }
         HorizontalBox {
-            Text { text: "X2:"; }
+            Text { color: #FFFFFF; text: "X2:"; }
             LineEdit { text <=> root.x2; }
-            Text { text: "Y2:"; }
+            Text { color: #FFFFFF; text: "Y2:"; }
             LineEdit { text <=> root.y2; }
         }
         HorizontalBox {
@@ -264,14 +260,14 @@ export component PointsDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "X:"; }
+            Text { color: #FFFFFF; text: "X:"; }
             LineEdit { text <=> root.x_value; }
-            Text { text: "Y:"; }
+            Text { color: #FFFFFF; text: "Y:"; }
             LineEdit { text <=> root.y_value; }
             Button { text: "Add"; clicked => { root.add_point(); } }
         }
         ListView {
-            for p in root.points_model : Text { text: p; }
+            for p in root.points_model : Text { color: #FFFFFF; text: p; }
             height: 100px;
         }
         HorizontalBox {
@@ -305,19 +301,19 @@ export component ArcKeyInDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "Cx:"; }
+            Text { color: #FFFFFF; text: "Cx:"; }
             LineEdit { text <=> root.cx; }
-            Text { text: "Cy:"; }
+            Text { color: #FFFFFF; text: "Cy:"; }
             LineEdit { text <=> root.cy; }
         }
         HorizontalBox {
-            Text { text: "Radius:"; }
+            Text { color: #FFFFFF; text: "Radius:"; }
             LineEdit { text <=> root.radius; }
         }
         HorizontalBox {
-            Text { text: "Start:"; }
+            Text { color: #FFFFFF; text: "Start:"; }
             LineEdit { text <=> root.start_angle; }
-            Text { text: "End:"; }
+            Text { color: #FFFFFF; text: "End:"; }
             LineEdit { text <=> root.end_angle; }
         }
         HorizontalBox {
@@ -496,13 +492,13 @@ export component MainWindow inherits Window {
                 text: "Clear";
                 clicked => { root.clear_workspace(); }
             }
-        Text { text: "View:"; }
+        Text { color: #FFFFFF; text: "View:"; }
         ComboBox {
             model: ["2D", "3D"];
             current-index <=> root.workspace_mode;
             selected => { root.view_changed(root.workspace_mode); }
         }
-        Text { text: "Cogo:"; }
+        Text { color: #FFFFFF; text: "Cogo:"; }
         ComboBox {
             model: root.cogo_list;
             current-index <=> root.cogo_index;
@@ -514,7 +510,7 @@ export component MainWindow inherits Window {
             width: 100%;
             height: 30px;
             spacing: 6px;
-        Text { text: "CRS:"; }
+        Text { color: #FFFFFF; text: "CRS:"; }
         ComboBox {
             model: root.crs_list;
             current-index <=> root.crs_index;
@@ -554,6 +550,7 @@ export component MainWindow inherits Window {
         }
 
         status_bar := Text {
+            color: #FFFFFF;
             text: root.status;
             width: 100%;
         }

--- a/survey_cad_truck_gui/ui/line_style_manager.slint
+++ b/survey_cad_truck_gui/ui/line_style_manager.slint
@@ -24,9 +24,9 @@ export component LineStyleManager inherits Window {
             border-color: #808080;
             HorizontalBox {
                 spacing: 8px;
-                Text { text: "Start"; width: 140px; }
-                Text { text: "End"; width: 140px; }
-                Text { text: "Style"; width: 80px; }
+                Text { color: #FFFFFF; text: "Start"; width: 140px; }
+                Text { color: #FFFFFF; text: "End"; width: 140px; }
+                Text { color: #FFFFFF; text: "Style"; width: 80px; }
             }
         }
         ListView {
@@ -37,8 +37,8 @@ export component LineStyleManager inherits Window {
                 height: 24px;
                 HorizontalBox {
                     spacing: 8px;
-                    Text { text: row.start; width: 140px; }
-                    Text { text: row.end; width: 140px; }
+                    Text { color: #FFFFFF; text: row.start; width: 140px; }
+                    Text { color: #FFFFFF; text: row.end; width: 140px; }
                     ComboBox {
                         model: root.styles_model;
                         current-index: row.style_index;

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -81,11 +81,7 @@ component Workspace3D inherits Rectangle {
     }
 }
 
-import { Button, VerticalBox, HorizontalBox, ComboBox, LineEdit, ListView, CheckBox } from "std-widgets.slint";
-
-export global AppStyle {
-    Text { color: #FFFFFF; }
-}
+import { Button, VerticalBox, HorizontalBox, ComboBox, LineEdit, ListView, CheckBox, Palette } from "std-widgets.slint";
 
 export component AddPointDialog inherits Window {
     callback from_file();
@@ -109,11 +105,11 @@ export component KeyInDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "X:"; }
+            Text { color: #FFFFFF; text: "X:"; }
             LineEdit { text <=> root.x_value; }
         }
         HorizontalBox {
-            Text { text: "Y:"; }
+            Text { color: #FFFFFF; text: "Y:"; }
             LineEdit { text <=> root.y_value; }
         }
         HorizontalBox {
@@ -135,19 +131,19 @@ export component StationDistanceDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "X1:"; }
+            Text { color: #FFFFFF; text: "X1:"; }
             LineEdit { text <=> root.x1; }
         }
         HorizontalBox {
-            Text { text: "Y1:"; }
+            Text { color: #FFFFFF; text: "Y1:"; }
             LineEdit { text <=> root.y1; }
         }
         HorizontalBox {
-            Text { text: "X2:"; }
+            Text { color: #FFFFFF; text: "X2:"; }
             LineEdit { text <=> root.x2; }
         }
         HorizontalBox {
-            Text { text: "Y2:"; }
+            Text { color: #FFFFFF; text: "Y2:"; }
             LineEdit { text <=> root.y2; }
         }
         HorizontalBox {
@@ -168,15 +164,15 @@ export component LevelElevationDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "Start Elev:"; }
+            Text { color: #FFFFFF; text: "Start Elev:"; }
             LineEdit { text <=> root.start_elev; }
         }
         HorizontalBox {
-            Text { text: "Backsight:"; }
+            Text { color: #FFFFFF; text: "Backsight:"; }
             LineEdit { text <=> root.backsight; }
         }
         HorizontalBox {
-            Text { text: "Foresight:"; }
+            Text { color: #FFFFFF; text: "Foresight:"; }
             LineEdit { text <=> root.foresight; }
         }
         HorizontalBox {
@@ -197,15 +193,15 @@ export component CorridorVolumeDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "Width:"; }
+            Text { color: #FFFFFF; text: "Width:"; }
             LineEdit { text <=> root.width_value; }
         }
         HorizontalBox {
-            Text { text: "Interval:"; }
+            Text { color: #FFFFFF; text: "Interval:"; }
             LineEdit { text <=> root.interval_value; }
         }
         HorizontalBox {
-            Text { text: "Offset Step:"; }
+            Text { color: #FFFFFF; text: "Offset Step:"; }
             LineEdit { text <=> root.offset_step_value; }
         }
         HorizontalBox {
@@ -238,15 +234,15 @@ export component LineKeyInDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "X1:"; }
+            Text { color: #FFFFFF; text: "X1:"; }
             LineEdit { text <=> root.x1; }
-            Text { text: "Y1:"; }
+            Text { color: #FFFFFF; text: "Y1:"; }
             LineEdit { text <=> root.y1; }
         }
         HorizontalBox {
-            Text { text: "X2:"; }
+            Text { color: #FFFFFF; text: "X2:"; }
             LineEdit { text <=> root.x2; }
-            Text { text: "Y2:"; }
+            Text { color: #FFFFFF; text: "Y2:"; }
             LineEdit { text <=> root.y2; }
         }
         HorizontalBox {
@@ -290,14 +286,14 @@ export component PointsDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "X:"; }
+            Text { color: #FFFFFF; text: "X:"; }
             LineEdit { text <=> root.x_value; }
-            Text { text: "Y:"; }
+            Text { color: #FFFFFF; text: "Y:"; }
             LineEdit { text <=> root.y_value; }
             Button { text: "Add"; clicked => { root.add_point(); } }
         }
         ListView {
-            for p in root.points_model : Text { text: p; }
+            for p in root.points_model : Text { color: #FFFFFF; text: p; }
             height: 100px;
         }
         HorizontalBox {
@@ -331,19 +327,19 @@ export component ArcKeyInDialog inherits Window {
     VerticalBox {
         spacing: 6px;
         HorizontalBox {
-            Text { text: "Cx:"; }
+            Text { color: #FFFFFF; text: "Cx:"; }
             LineEdit { text <=> root.cx; }
-            Text { text: "Cy:"; }
+            Text { color: #FFFFFF; text: "Cy:"; }
             LineEdit { text <=> root.cy; }
         }
         HorizontalBox {
-            Text { text: "Radius:"; }
+            Text { color: #FFFFFF; text: "Radius:"; }
             LineEdit { text <=> root.radius; }
         }
         HorizontalBox {
-            Text { text: "Start:"; }
+            Text { color: #FFFFFF; text: "Start:"; }
             LineEdit { text <=> root.start_angle; }
-            Text { text: "End:"; }
+            Text { color: #FFFFFF; text: "End:"; }
             LineEdit { text <=> root.end_angle; }
         }
         HorizontalBox {
@@ -582,13 +578,13 @@ export component MainWindow inherits Window {
                 text: "Clear";
                 clicked => { root.clear_workspace(); }
             }
-        Text { text: "View:"; }
+        Text { color: #FFFFFF; text: "View:"; }
         ComboBox {
             model: ["2D", "3D"];
             current-index <=> root.workspace_mode;
             selected => { root.view_changed(root.workspace_mode); }
         }
-        Text { text: "Cogo:"; }
+        Text { color: #FFFFFF; text: "Cogo:"; }
         ComboBox {
             model: root.cogo_list;
             current-index <=> root.cogo_index;
@@ -600,7 +596,7 @@ export component MainWindow inherits Window {
             width: 100%;
             height: 30px;
             spacing: 6px;
-        Text { text: "CRS:"; }
+        Text { color: #FFFFFF; text: "CRS:"; }
         ComboBox {
             model: root.crs_list;
             current-index <=> root.crs_index;

--- a/survey_cad_truck_gui/ui/point_manager.slint
+++ b/survey_cad_truck_gui/ui/point_manager.slint
@@ -72,17 +72,17 @@ export component PointManager inherits Window {
             border-color: #808080;
             HorizontalLayout {
                 spacing: 0px;
-                Text { text: "#"; width: root.number_width; }
+                Text { color: #FFFFFF; text: "#"; width: root.number_width; }
                 ColumnSeparator { column_width <=> root.number_width; }
-                Text { text: "Name"; width: root.name_width; }
+                Text { color: #FFFFFF; text: "Name"; width: root.name_width; }
                 ColumnSeparator { column_width <=> root.name_width; }
-                Text { text: "X"; width: root.x_width; }
+                Text { color: #FFFFFF; text: "X"; width: root.x_width; }
                 ColumnSeparator { column_width <=> root.x_width; }
-                Text { text: "Y"; width: root.y_width; }
+                Text { color: #FFFFFF; text: "Y"; width: root.y_width; }
                 ColumnSeparator { column_width <=> root.y_width; }
-                Text { text: "Group"; width: root.group_width; }
+                Text { color: #FFFFFF; text: "Group"; width: root.group_width; }
                 ColumnSeparator { column_width <=> root.group_width; }
-                Text { text: "Style"; width: root.style_width; }
+                Text { color: #FFFFFF; text: "Style"; width: root.style_width; }
             }
         }
         ListView {
@@ -94,6 +94,7 @@ export component PointManager inherits Window {
                 HorizontalLayout {
                     spacing: 8px;
                     Text {
+    color: #FFFFFF;
                         text: row.number;
                         width: root.number_width;
                         TouchArea {


### PR DESCRIPTION
## Summary
- remove invalid `export global AppStyle` block
- explicitly set button and label text colors

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo check -p survey_cad_slint_gui`


------
https://chatgpt.com/codex/tasks/task_e_6859aa39fbe08328923888e4743ddf4f