### PR TITLE
Fix PointManager window properties

### DIFF
--- a/survey_cad_truck_gui/ui/point_manager.slint
+++ b/survey_cad_truck_gui/ui/point_manager.slint
@@ -60,10 +60,10 @@ export component PointManager inherits Window {
     property <length> group_width: 80px;
     property <length> style_width: 80px;
     title: "Point Manager";
-    width: 600px;
-    height: 400px;
-    resizable: true;
-    minimum-size: { width: 400px; height: 200px; }
+    preferred-width: 600px;
+    preferred-height: 400px;
+    min-width: 400px;
+    min-height: 200px;
 
     VerticalBox {
         spacing: 0px;


### PR DESCRIPTION
## Summary
- use preferred/min size properties for PointManager window
- remove unsupported `resizable` property

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_685ac0db260483289ec884699da72cc1