### PR TITLE
Make point list view resizable

### DIFF
--- a/survey_cad_truck_gui/ui/point_manager.slint
+++ b/survey_cad_truck_gui/ui/point_manager.slint
@@ -88,6 +88,8 @@ export component PointManager inherits Window {
             }
         }
         ListView {
+            vertical-stretch: 1;
+            spacing: 0px;
             for row[i] in root.points_model : Rectangle {
                 property <bool> selected: root.selected_index == i;
                 background: selected ? #404040 : transparent;


### PR DESCRIPTION
## Summary
- allow the point list to take remaining space in the Point Manager window

## Testing
- `cargo test --all` *(failed: build timed out)*

------
https://chatgpt.com/codex/tasks/task_e_685ad86ee32883288189cd65aee33f39