### PR TITLE
Update Truck backend sync

### DIFF
--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -11,6 +11,7 @@ survey_cad = { path = "../survey_cad" }
 rfd = "0.15"
 tiny-skia = "0.11"
 truck_cad_engine = { path = "../truck_cad_engine" }
+truck-modeling = { path = "../truck-master/truck-modeling" }
 once_cell = "1"
 rusttype = "0.9"
 

--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -1,5 +1,6 @@
 use slint::Image;
 use truck_cad_engine::TruckCadEngine;
+use truck_modeling::base::Point3;
 
 pub struct TruckBackend {
     engine: TruckCadEngine,
@@ -30,5 +31,51 @@ impl TruckBackend {
 
     pub fn resize(&mut self, width: u32, height: u32) {
         self.engine.resize(width, height);
+    }
+
+    pub fn add_point(&mut self, x: f64, y: f64, z: f64) -> usize {
+        self.engine.add_point_marker(Point3::new(x, y, z))
+    }
+
+    pub fn update_point(&mut self, id: usize, x: f64, y: f64, z: f64) {
+        self.engine.update_point_marker(id, Point3::new(x, y, z));
+    }
+
+    pub fn remove_point(&mut self, id: usize) {
+        self.engine.remove_point_marker(id);
+    }
+
+    pub fn add_line(&mut self, a: [f64; 3], b: [f64; 3]) -> usize {
+        self.engine
+            .add_line(Point3::new(a[0], a[1], a[2]), Point3::new(b[0], b[1], b[2]))
+    }
+
+    pub fn update_line(&mut self, id: usize, a: [f64; 3], b: [f64; 3]) {
+        self.engine.update_line(
+            id,
+            Point3::new(a[0], a[1], a[2]),
+            Point3::new(b[0], b[1], b[2]),
+        );
+    }
+
+    pub fn remove_line(&mut self, id: usize) {
+        self.engine.remove_line(id);
+    }
+
+    pub fn add_surface(&mut self, vertices: &[Point3], triangles: &[[usize; 3]]) -> usize {
+        self.engine.add_surface(vertices, triangles)
+    }
+
+    pub fn update_surface(
+        &mut self,
+        id: usize,
+        vertices: &[Point3],
+        triangles: &[[usize; 3]],
+    ) {
+        self.engine.update_surface(id, vertices, triangles);
+    }
+
+    pub fn remove_surface(&mut self, id: usize) {
+        self.engine.remove_surface(id);
     }
 }


### PR DESCRIPTION
## Summary
- add marker/line/surface methods to `TruckCadEngine`
- expose new helpers via `TruckBackend`
- call backend add/update functions from GUI events
- refresh 3d view after geometry changes

## Testing
- `cargo test --all --quiet` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685ae7591f308328ae835feef95240b9