### PR TITLE
Fix PolygonState initialization

### DIFF
--- a/truck_cad_engine/src/lib.rs
+++ b/truck_cad_engine/src/lib.rs
@@ -67,8 +67,10 @@ impl TruckCadEngine {
             builder::tsweep(&e, truck::base::Vector3::unit_y() * 0.1);
         let cube: truck::topology::Solid =
             builder::tsweep(&f, truck::base::Vector3::unit_z() * 0.1);
-        let mut state = PolygonState::default();
-        state.matrix = Matrix4::from_translation(p.to_vec());
+        let state = PolygonState {
+            matrix: Matrix4::from_translation(p.to_vec()),
+            ..Default::default()
+        };
         let mesh = cube.triangulation(0.01).to_polygon();
         let instance = self.creator.create_instance(&mesh, &state);
         self.scene.add_object(&instance);


### PR DESCRIPTION
## Summary
- avoid clippy `field-reassign-with-default` warning in `add_point_marker`

## Testing
- `cargo test -p truck_cad_engine -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_685afcd441408328b2e0d71e44c8e43a