### PR TITLE
Fix backend_render scope and line import

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -1898,6 +1898,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 let dlg_weak = dlg_weak.clone();
                 let line_style_indices = line_style_indices.clone();
                 let refresh_line_style_dialogs = refresh_line_style_dialogs.clone();
+                let backend_render = backend_render.clone();
                 dlg.on_from_file(move || {
                     if let Some(path) = rfd::FileDialog::new()
                         .add_filter("CSV", &["csv"])
@@ -1907,9 +1908,10 @@ fn main() -> Result<(), slint::PlatformError> {
                             match read_line_csv(p) {
                                 Ok(l) => {
                                     lines.borrow_mut().push(l);
+                                    let (s, e) = l;
                                     backend_render.borrow_mut().add_line(
-                                        [l.start.x, l.start.y, 0.0],
-                                        [l.end.x, l.end.y, 0.0],
+                                        [s.x, s.y, 0.0],
+                                        [e.x, e.y, 0.0],
                                     );
                                     let count = lines.borrow().len();
                                     let mut idx = line_style_indices.borrow_mut();
@@ -1953,6 +1955,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 let dlg_weak = dlg_weak.clone();
                 let line_style_indices = line_style_indices.clone();
                 let refresh_line_style_dialogs = refresh_line_style_dialogs.clone();
+                let backend_render = backend_render.clone();
                 dlg.on_manual(move || {
                     if let Some(d) = dlg_weak.upgrade() {
                         let _ = d.hide();
@@ -1966,6 +1969,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         let weak = weak.clone();
                         let line_style_indices = line_style_indices.clone();
                         let refresh_line_style_dialogs = refresh_line_style_dialogs.clone();
+                        let backend_render = backend_render.clone();
                         kd.on_accept(move || {
                             if let Some(dlg) = kd_weak2.upgrade() {
                                 if let (Ok(x1), Ok(y1), Ok(x2), Ok(y2)) = (
@@ -2035,6 +2039,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 let weak = weak.clone();
                 let dlg_weak = dlg_weak.clone();
                 let point_style_indices = point_style_indices.clone();
+                let backend_render = backend_render.clone();
                 dlg.on_from_file(move || {
                     if let Some(path) = rfd::FileDialog::new()
                         .add_filter("CSV", &["csv"])
@@ -2086,6 +2091,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 let weak = weak.clone();
                 let dlg_weak = dlg_weak.clone();
                 let point_style_indices = point_style_indices.clone();
+                let backend_render = backend_render.clone();
                 dlg.on_manual_keyin(move || {
                     if let Some(d) = dlg_weak.upgrade() {
                         let _ = d.hide();
@@ -2098,6 +2104,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         let render_image = render_image.clone();
                         let weak = weak.clone();
                         let psi = point_style_indices.clone();
+                        let backend_render = backend_render.clone();
                         key_dlg.on_accept(move || {
                             if let Some(dlg) = key_weak2.upgrade() {
                                 if let (Ok(x), Ok(y)) = (
@@ -3553,6 +3560,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let polygons_ref = polygons.clone();
         let arcs_ref = arcs.clone();
         let last_click = last_click.clone();
+        let backend_render = backend.clone();
         app.on_workspace_clicked(move |x, y| {
             if *drawing_mode.borrow() != DrawingMode::None {
                 if let Some(app) = weak.upgrade() {


### PR DESCRIPTION
## Summary
- fix missing `backend_render` captures in UI callbacks
- adapt line CSV import to work with point tuples

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_685be395680083288a03417a28c8f8b1