### PR TITLE
Add basic TIN editing

### DIFF
--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -62,10 +62,9 @@ impl TruckBackend {
     }
 
     pub fn add_line(&mut self, a: [f64; 3], b: [f64; 3]) -> usize {
-        let id = self.engine.add_line(
-            Point3::new(a[0], a[1], a[2]),
-            Point3::new(b[0], b[1], b[2]),
-        );
+        let id = self
+            .engine
+            .add_line(Point3::new(a[0], a[1], a[2]), Point3::new(b[0], b[1], b[2]));
         self.line_ids.push(Some(id));
         self.line_ids.len() - 1
     }
@@ -89,32 +88,44 @@ impl TruckBackend {
         }
     }
 
-    #[allow(dead_code)]
     pub fn add_surface(&mut self, vertices: &[Point3], triangles: &[[usize; 3]]) -> usize {
         let id = self.engine.add_surface(vertices, triangles);
         self.surface_ids.push(Some(id));
         self.surface_ids.len() - 1
     }
 
-    #[allow(dead_code)]
-    pub fn update_surface(
-        &mut self,
-        idx: usize,
-        vertices: &[Point3],
-        triangles: &[[usize; 3]],
-    ) {
+    pub fn update_surface(&mut self, idx: usize, vertices: &[Point3], triangles: &[[usize; 3]]) {
         if let Some(Some(id)) = self.surface_ids.get(idx) {
             self.engine.update_surface(*id, vertices, triangles);
         }
     }
 
-    #[allow(dead_code)]
     pub fn remove_surface(&mut self, idx: usize) {
         if idx < self.surface_ids.len() {
             if let Some(id) = self.surface_ids.remove(idx) {
                 self.engine.remove_surface(id);
             }
         }
+    }
+
+    pub fn add_vertex(&mut self, surface: usize, p: Point3) -> Option<usize> {
+        self.engine.add_surface_vertex(surface, p)
+    }
+
+    pub fn move_vertex(&mut self, surface: usize, idx: usize, p: Point3) {
+        self.engine.move_surface_vertex(surface, idx, p);
+    }
+
+    pub fn delete_vertex(&mut self, surface: usize, idx: usize) {
+        self.engine.delete_surface_vertex(surface, idx);
+    }
+
+    pub fn add_triangle(&mut self, surface: usize, tri: [usize; 3]) {
+        self.engine.add_surface_triangle(surface, tri);
+    }
+
+    pub fn delete_triangle(&mut self, surface: usize, tri_idx: usize) {
+        self.engine.delete_surface_triangle(surface, tri_idx);
     }
 
     pub fn clear(&mut self) {

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -213,6 +213,54 @@ export component CorridorVolumeDialog inherits Window {
     }
 }
 
+export component TinVertexDialog inherits Window {
+    in-out property <string> surface_index;
+    in-out property <string> vertex_index;
+    in-out property <string> x_val;
+    in-out property <string> y_val;
+    in-out property <string> z_val;
+    callback accept();
+    callback cancel();
+    title: "TIN Vertex";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox { Text { color: #FFFFFF; text: "Surface:"; } LineEdit { text <=> root.surface_index; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Index:"; } LineEdit { text <=> root.vertex_index; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "X:"; } LineEdit { text <=> root.x_val; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Y:"; } LineEdit { text <=> root.y_val; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Z:"; } LineEdit { text <=> root.z_val; } }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "OK"; clicked => { root.accept(); } }
+            Button { text: "Cancel"; clicked => { root.cancel(); } }
+        }
+    }
+}
+
+export component TinTriangleDialog inherits Window {
+    in-out property <string> surface_index;
+    in-out property <string> tri_index;
+    in-out property <string> v1;
+    in-out property <string> v2;
+    in-out property <string> v3;
+    callback accept();
+    callback cancel();
+    title: "TIN Triangle";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox { Text { color: #FFFFFF; text: "Surface:"; } LineEdit { text <=> root.surface_index; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Index:"; } LineEdit { text <=> root.tri_index; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "V1:"; } LineEdit { text <=> root.v1; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "V2:"; } LineEdit { text <=> root.v2; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "V3:"; } LineEdit { text <=> root.v3; } }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "OK"; clicked => { root.accept(); } }
+            Button { text: "Cancel"; clicked => { root.cancel(); } }
+        }
+    }
+}
+
 export component AddLineDialog inherits Window {
     callback from_file();
     callback manual();
@@ -431,6 +479,11 @@ export component MainWindow inherits Window {
     callback export_e57();
     callback import_landxml_surface();
     callback import_landxml_alignment();
+    callback tin_add_vertex();
+    callback tin_move_vertex();
+    callback tin_delete_vertex();
+    callback tin_add_triangle();
+    callback tin_delete_triangle();
     callback zoom_in();
     callback zoom_out();
     callback workspace_left_pressed(length, length);
@@ -488,6 +541,14 @@ export component MainWindow inherits Window {
             MenuItem { title: "Traverse Area"; activated => { root.traverse_area(); } }
             MenuItem { title: "Level Elevation"; activated => { root.level_elevation_tool(); } }
             MenuItem { title: "Corridor Volume"; activated => { root.corridor_volume(); } }
+        }
+        Menu {
+            title: "TIN";
+            MenuItem { title: "Add Vertex"; activated => { root.tin_add_vertex(); } }
+            MenuItem { title: "Move Vertex"; activated => { root.tin_move_vertex(); } }
+            MenuItem { title: "Delete Vertex"; activated => { root.tin_delete_vertex(); } }
+            MenuItem { title: "Add Triangle"; activated => { root.tin_add_triangle(); } }
+            MenuItem { title: "Delete Triangle"; activated => { root.tin_delete_triangle(); } }
         }
         Menu {
             title: "View";


### PR DESCRIPTION
## Summary
- add TIN editing helpers in TruckCadEngine
- expose TIN editing through TruckBackend
- integrate simple dialogs and menu items for editing TINs
- handle LandXML TIN import in 3D backend

## Testing
- `cargo check -p truck_cad_engine -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_685c0ffb36748328afc03451d91d4ef3