### PR TITLE
Fix unused function warning in Truck backend

### DIFF
--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -94,6 +94,7 @@ impl TruckBackend {
         self.surface_ids.len() - 1
     }
 
+    #[allow(dead_code)]
     pub fn update_surface(&mut self, idx: usize, vertices: &[Point3], triangles: &[[usize; 3]]) {
         if let Some(Some(id)) = self.surface_ids.get(idx) {
             self.engine.update_surface(*id, vertices, triangles);


### PR DESCRIPTION
## Summary
- suppress `dead_code` warning for `update_surface` in `survey_cad_truck_gui`

## Testing
- `RUSTFLAGS="-D warnings" cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_685c3b51a5608328bcd84bac25dce740