### PR TITLE
Add cross section viewer

### DIFF
--- a/survey_cad_truck_gui/ui/cross_section_viewer.slint
+++ b/survey_cad_truck_gui/ui/cross_section_viewer.slint
@@ -1,0 +1,27 @@
+import { Button, VerticalBox, HorizontalBox } from "std-widgets.slint";
+
+export component CrossSectionViewer inherits Window {
+    in-out property <image> section_image;
+    in-out property <string> station_label;
+    callback prev();
+    callback next();
+    title: "Cross Section Viewer";
+    preferred-width: 600px;
+    preferred-height: 400px;
+
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "Prev"; clicked => { root.prev(); } }
+            Text { color: #FFFFFF; text: root.station_label; }
+            Button { text: "Next"; clicked => { root.next(); } }
+        }
+        Image {
+            source: root.section_image;
+            image-fit: fill;
+            width: 100%;
+            height: 100%;
+        }
+    }
+}

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -1,6 +1,7 @@
 export { PointManager } from "point_manager.slint";
 export { LineStyleManager } from "line_style_manager.slint";
 export { LayerManager } from "layer_manager.slint";
+export { CrossSectionViewer } from "cross_section_viewer.slint";
 
 component Workspace2D inherits Rectangle {
     in-out property <image> image;
@@ -490,6 +491,7 @@ export component MainWindow inherits Window {
     callback level_elevation_tool();
     callback corridor_volume();
     callback design_cross_sections();
+    callback view_cross_sections();
     callback point_numbers_changed(bool);
     callback point_manager();
     callback line_style_manager();
@@ -571,6 +573,7 @@ export component MainWindow inherits Window {
             MenuItem { title: "Level Elevation"; activated => { root.level_elevation_tool(); } }
             MenuItem { title: "Corridor Volume"; activated => { root.corridor_volume(); } }
             MenuItem { title: "Design Sections"; activated => { root.design_cross_sections(); } }
+            MenuItem { title: "Cross Sections"; activated => { root.view_cross_sections(); } }
         }
         Menu {
             title: "TIN";
@@ -675,6 +678,10 @@ export component MainWindow inherits Window {
         Button {
                 text: "Design Sections";
                 clicked => { root.design_cross_sections(); }
+            }
+        Button {
+                text: "Cross Sections";
+                clicked => { root.view_cross_sections(); }
             }
         Button {
                 text: "Clear";


### PR DESCRIPTION
## Summary
- create `CrossSectionViewer` component for displaying corridor cross sections
- export the new viewer in the main UI and add menu/toolbar actions
- render cross sections and open the viewer from `main.rs`

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_685c4518d4b08328abf86a6ac05732b1