### PR TITLE
Add surface creation and convex-hull polygon

### DIFF
--- a/survey_cad/src/geometry/mod.rs
+++ b/survey_cad/src/geometry/mod.rs
@@ -28,6 +28,51 @@ pub fn polygon_area(vertices: &[Point]) -> f64 {
     sum.abs() * 0.5
 }
 
+fn orientation(a: Point, b: Point, c: Point) -> f64 {
+    (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+}
+
+/// Computes the convex hull of the provided points using the monotonic chain
+/// algorithm.
+pub fn convex_hull(points: &[Point]) -> Vec<Point> {
+    if points.len() <= 1 {
+        return points.to_vec();
+    }
+    let mut pts: Vec<Point> = points.to_vec();
+    pts.sort_by(|a, b| {
+        a.x
+            .partial_cmp(&b.x)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.y.partial_cmp(&b.y).unwrap_or(std::cmp::Ordering::Equal))
+    });
+    pts.dedup();
+
+    let mut lower = Vec::new();
+    for p in &pts {
+        while lower.len() >= 2
+            && orientation(lower[lower.len() - 2], lower[lower.len() - 1], *p) <= 0.0
+        {
+            lower.pop();
+        }
+        lower.push(*p);
+    }
+
+    let mut upper = Vec::new();
+    for p in pts.iter().rev() {
+        while upper.len() >= 2
+            && orientation(upper[upper.len() - 2], upper[upper.len() - 1], *p) <= 0.0
+        {
+            upper.pop();
+        }
+        upper.push(*p);
+    }
+
+    lower.pop();
+    upper.pop();
+    lower.extend(upper);
+    lower
+}
+
 /// Calculates the Euclidean distance between two 3D points.
 pub fn distance3(a: Point3, b: Point3) -> f64 {
     ((b.x - a.x).powi(2) + (b.y - a.y).powi(2) + (b.z - a.z).powi(2)).sqrt()

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -484,6 +484,7 @@ export component MainWindow inherits Window {
     callback add_polyline();
     callback add_arc();
     callback create_polygon_from_selection();
+    callback create_surface_from_selection();
     callback clear_workspace();
     callback view_changed(int);
     callback station_distance();
@@ -565,6 +566,7 @@ export component MainWindow inherits Window {
             MenuItem { title: "Polygon Mode"; activated => { root.draw_polygon_mode(); } }
             MenuItem { title: "Arc Mode"; activated => { root.draw_arc_mode(); } }
             MenuItem { title: "Create Polygon from Selection"; activated => { root.create_polygon_from_selection(); } }
+            MenuItem { title: "Create Surface from Selection"; activated => { root.create_surface_from_selection(); } }
             MenuItem { title: "Point Manager..."; activated => { root.point_manager(); } }
             MenuItem { title: "Line Styles..."; activated => { root.line_style_manager(); } }
             MenuItem { title: "Layer Manager..."; activated => { root.layer_manager(); } }
@@ -666,6 +668,10 @@ export component MainWindow inherits Window {
         Button {
                 text: "Create Polygon";
                 clicked => { root.create_polygon_from_selection(); }
+            }
+        Button {
+                text: "Create Surface";
+                clicked => { root.create_surface_from_selection(); }
             }
         Button {
                 text: "Load LandXML Surface";


### PR DESCRIPTION
## Summary
- add convex hull function for points
- create polygon from selection using convex hull
- add surface creation from selected points
- expose new action in UI

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_685d386341cc832898167b1c3da5b5ca