### PR TITLE
Add superelevation editor

### DIFF
--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -2,6 +2,7 @@ export { PointManager } from "point_manager.slint";
 export { LineStyleManager } from "line_style_manager.slint";
 export { LayerManager } from "layer_manager.slint";
 export { CrossSectionViewer } from "cross_section_viewer.slint";
+export { SuperelevationEditor } from "superelevation_editor.slint";
 
 component Workspace2D inherits Rectangle {
     in-out property <image> image;
@@ -493,6 +494,7 @@ export component MainWindow inherits Window {
     callback corridor_volume();
     callback design_cross_sections();
     callback view_cross_sections();
+    callback superelevation_editor();
     callback point_numbers_changed(bool);
     callback point_manager();
     callback line_style_manager();
@@ -578,6 +580,7 @@ export component MainWindow inherits Window {
             MenuItem { title: "Traverse Area"; activated => { root.traverse_area(); } }
             MenuItem { title: "Level Elevation"; activated => { root.level_elevation_tool(); } }
             MenuItem { title: "Corridor Volume"; activated => { root.corridor_volume(); } }
+            MenuItem { title: "Superelevation..."; activated => { root.superelevation_editor(); } }
             MenuItem { title: "Design Sections"; activated => { root.design_cross_sections(); } }
             MenuItem { title: "Cross Sections"; activated => { root.view_cross_sections(); } }
         }
@@ -692,6 +695,10 @@ export component MainWindow inherits Window {
         Button {
                 text: "Corridor Volume";
                 clicked => { root.corridor_volume(); }
+            }
+        Button {
+                text: "Superelevation...";
+                clicked => { root.superelevation_editor(); }
             }
         Button {
                 text: "Design Sections";

--- a/survey_cad_truck_gui/ui/superelevation_editor.slint
+++ b/survey_cad_truck_gui/ui/superelevation_editor.slint
@@ -1,0 +1,56 @@
+export struct SuperelevationRow {
+    station: string,
+    left: string,
+    right: string,
+}
+
+import { Button, VerticalBox, HorizontalBox, LineEdit, ListView } from "std-widgets.slint";
+
+export component SuperelevationEditor inherits Window {
+    in-out property <[SuperelevationRow]> rows_model;
+    in-out property <int> selected_index;
+    callback add_row();
+    callback remove_row(int);
+    callback edit_station(int, string);
+    callback edit_left(int, string);
+    callback edit_right(int, string);
+    title: "Superelevation Editor";
+    width: 400px;
+    height: 300px;
+
+    VerticalBox {
+        spacing: 4px;
+        Rectangle {
+            width: 100%;
+            height: 20px;
+            border-width: 1px;
+            border-color: #808080;
+            HorizontalBox {
+                spacing: 8px;
+                Text { color: #FFFFFF; text: "Station"; width: 120px; }
+                Text { color: #FFFFFF; text: "Left"; width: 80px; }
+                Text { color: #FFFFFF; text: "Right"; width: 80px; }
+            }
+        }
+        ListView {
+            vertical-stretch: 1;
+            for row[i] in root.rows_model : Rectangle {
+                property <bool> selected: root.selected_index == i;
+                background: selected ? #404040 : transparent;
+                height: 24px;
+                HorizontalBox {
+                    spacing: 8px;
+                    LineEdit { text: row.station; width: 120px; edited(text) => { root.edit_station(i, text); } }
+                    LineEdit { text: row.left; width: 80px; edited(text) => { root.edit_left(i, text); } }
+                    LineEdit { text: row.right; width: 80px; edited(text) => { root.edit_right(i, text); } }
+                }
+                TouchArea { width: 100%; height: 100%; clicked => { root.selected_index = i; } }
+            }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "Add"; clicked => { root.add_row(); } }
+            Button { text: "Remove"; clicked => { root.remove_row(root.selected_index); } }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SuperelevationEditor UI
- expose SuperelevationEditor from main.slint
- hook up new editor in main.rs and rebuild design surface when updated

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_685d4a95e2a88328abe49093c3b42c48