### PR TITLE
Add project JSON support to truck GUI

### DIFF
--- a/survey_cad/src/geometry/line.rs
+++ b/survey_cad/src/geometry/line.rs
@@ -4,7 +4,7 @@ use super::{distance, Point};
 use crate::styles::LineWeight;
 
 /// Available drawing styles for a line entity.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum LineType {
     /// Continuous solid line.
     Solid,
@@ -15,7 +15,7 @@ pub enum LineType {
 }
 
 /// Style information for rendering a line.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct LineStyle {
     pub line_type: LineType,
     pub color: [u8; 3],
@@ -43,7 +43,7 @@ impl Default for LineStyle {
 }
 
 /// Representation of a 2D line segment between two points.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Line {
     pub start: Point,
     pub end: Point,

--- a/survey_cad/src/io/mod.rs
+++ b/survey_cad/src/io/mod.rs
@@ -19,6 +19,7 @@ pub mod las;
 #[cfg(feature = "shapefile")]
 pub mod shp;
 pub mod ifc;
+pub mod project;
 
 /// Reads a file to string.
 pub fn read_to_string(path: &str) -> io::Result<String> {

--- a/survey_cad/src/io/project.rs
+++ b/survey_cad/src/io/project.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+use crate::dtm::Tin;
+use crate::geometry::{Arc, Line, Point, Polyline};
+use crate::layers::Layer;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Project {
+    pub points: Vec<Point>,
+    pub lines: Vec<Line>,
+    pub polygons: Vec<Vec<Point>>,
+    pub polylines: Vec<Polyline>,
+    pub arcs: Vec<Arc>,
+    pub surfaces: Vec<Tin>,
+    pub layers: Vec<Layer>,
+    pub point_style_indices: Vec<usize>,
+    pub line_style_indices: Vec<usize>,
+}
+
+impl Project {
+    pub fn new() -> Self {
+        Self {
+            points: Vec::new(),
+            lines: Vec::new(),
+            polygons: Vec::new(),
+            polylines: Vec::new(),
+            arcs: Vec::new(),
+            surfaces: Vec::new(),
+            layers: Vec::new(),
+            point_style_indices: Vec::new(),
+            line_style_indices: Vec::new(),
+        }
+    }
+}
+
+pub fn read_project_json(path: &str) -> std::io::Result<Project> {
+    let contents = crate::io::read_to_string(path)?;
+    let proj: Project = serde_json::from_str(&contents)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    Ok(proj)
+}
+
+pub fn write_project_json(path: &str, project: &Project) -> std::io::Result<()> {
+    let json = serde_json::to_string_pretty(project)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    crate::io::write_string(path, &json)
+}

--- a/survey_cad/src/layers.rs
+++ b/survey_cad/src/layers.rs
@@ -4,7 +4,7 @@ use crate::geometry::LineType;
 use crate::styles::{LineWeight, TextStyle};
 
 /// Representation of a drawing layer.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Layer {
     pub name: String,
     pub is_on: bool,

--- a/survey_cad/src/styles.rs
+++ b/survey_cad/src/styles.rs
@@ -2,7 +2,7 @@ use crate::geometry::point::PointStyle;
 
 /// Basic styling structures for drawing entities.
 /// Represents the weight of a line in millimeters.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct LineWeight(pub f32);
 
 impl Default for LineWeight {
@@ -12,7 +12,7 @@ impl Default for LineWeight {
 }
 
 /// Text style definition.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TextStyle {
     pub name: String,
     pub font: String,


### PR DESCRIPTION
## Summary
- create `Project` JSON I/O for points, lines, surfaces and styles
- serialize geometry and style structs with Serde
- load/save JSON projects in the truck GUI

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo test -p survey_cad -- --list`

------
https://chatgpt.com/codex/tasks/task_e_685d58f171208328862577edb24ed3dc