### PR TITLE
Add configurable snap modes with persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9578,10 +9578,13 @@ dependencies = [
  "once_cell",
  "rfd",
  "rusttype 0.9.3",
+ "serde",
+ "serde_json",
  "slint",
  "slint-build",
  "survey_cad",
  "tiny-skia",
+ "truck-modeling",
  "truck_cad_engine",
 ]
 

--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -14,6 +14,8 @@ truck_cad_engine = { path = "../truck_cad_engine" }
 truck-modeling = { path = "../truck-master/truck-modeling" }
 once_cell = "1"
 rusttype = "0.9"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
 
 [build-dependencies]
 slint-build = "1"

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -492,6 +492,10 @@ export component MainWindow inherits Window {
     in-out property <bool> snap_to_grid;
     in-out property <bool> snap_to_entities;
     in-out property <bool> show_point_numbers;
+    in-out property <bool> snap_endpoints;
+    in-out property <bool> snap_midpoints;
+    in-out property <bool> snap_intersections;
+    in-out property <bool> snap_nearest;
     in-out property <float> zoom_level;
 
     callback key_pressed(string);
@@ -530,6 +534,12 @@ export component MainWindow inherits Window {
     callback view_cross_sections();
     callback superelevation_editor();
     callback point_numbers_changed(bool);
+    callback snap_grid_changed(bool);
+    callback snap_objects_changed(bool);
+    callback snap_endpoints_changed(bool);
+    callback snap_midpoints_changed(bool);
+    callback snap_intersections_changed(bool);
+    callback snap_nearest_changed(bool);
     callback point_manager();
     callback line_style_manager();
     callback layer_manager();
@@ -800,8 +810,12 @@ export component MainWindow inherits Window {
             width: 100%;
             height: 30px;
             spacing: 6px;
-            CheckBox { text: "Snap Grid"; checked <=> root.snap_to_grid; }
-            CheckBox { text: "Snap Objects"; checked <=> root.snap_to_entities; }
+            CheckBox { text: "Snap Grid"; checked <=> root.snap_to_grid; toggled => { root.snap_grid_changed(root.snap_to_grid); } }
+            CheckBox { text: "Snap Objects"; checked <=> root.snap_to_entities; toggled => { root.snap_objects_changed(root.snap_to_entities); } }
+            CheckBox { text: "Endpoints"; checked <=> root.snap_endpoints; toggled => { root.snap_endpoints_changed(root.snap_endpoints); } }
+            CheckBox { text: "Midpoints"; checked <=> root.snap_midpoints; toggled => { root.snap_midpoints_changed(root.snap_midpoints); } }
+            CheckBox { text: "Intersections"; checked <=> root.snap_intersections; toggled => { root.snap_intersections_changed(root.snap_intersections); } }
+            CheckBox { text: "Nearest"; checked <=> root.snap_nearest; toggled => { root.snap_nearest_changed(root.snap_nearest); } }
             CheckBox {
                 text: "Point Numbers";
                 checked <=> root.show_point_numbers;


### PR DESCRIPTION
## Summary
- allow selecting snap sub-modes (endpoints, midpoints, intersections, nearest)
- add `SnapSettings` and `snap_point_with_settings` API
- store GUI snap settings in `snap_prefs.json`
- update Truck GUI to respect and persist snap options

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_685d950dc35c8328a0b06c14d44527fb