### PR TITLE
Add GUI macro recording and playback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9543,6 +9543,7 @@ dependencies = [
  "env_logger 0.10.2",
  "log",
  "rfd",
+ "shell-words",
  "survey_cad",
 ]
 
@@ -9580,6 +9581,7 @@ dependencies = [
  "rusttype 0.9.3",
  "serde",
  "serde_json",
+ "shell-words",
  "slint",
  "slint-build",
  "survey_cad",

--- a/survey_cad_gui/Cargo.toml
+++ b/survey_cad_gui/Cargo.toml
@@ -12,6 +12,7 @@ bevy_editor_cam = "0.5"
 bevy_gizmos = "0.15"
 log = "0.4"
 env_logger = "0.10"
+shell-words = "1.1"
 
 
 [features]

--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -16,6 +16,7 @@ once_cell = "1"
 rusttype = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
+shell-words = "1.1"
 
 [build-dependencies]
 slint-build = "1"

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -568,6 +568,8 @@ export component MainWindow inherits Window {
     callback tin_delete_vertex();
     callback tin_add_triangle();
     callback tin_delete_triangle();
+    callback macro_record();
+    callback macro_play();
     callback undo();
     callback redo();
     callback move_entity();
@@ -658,6 +660,11 @@ export component MainWindow inherits Window {
             MenuItem { title: "3D Workspace"; activated => { root.view_changed(1); } }
             MenuItem { title: "Zoom In"; activated => { root.zoom_in(); } }
             MenuItem { title: "Zoom Out"; activated => { root.zoom_out(); } }
+        }
+        Menu {
+            title: "Macro";
+            MenuItem { title: "Record"; activated => { root.macro_record(); } }
+            MenuItem { title: "Play"; activated => { root.macro_play(); } }
         }
     }
 


### PR DESCRIPTION
## Summary
- add macro recording/playback menu to GUI
- allow recording user actions to macro text files
- load and play macros to recreate points and lines
- include shell-words dependency for parsing macro files

## Testing
- `cargo check -p survey_cad_gui`

------
https://chatgpt.com/codex/tasks/task_e_685e9d65e6208328bcf66b8cf64575fb