### PR TITLE
Add grid settings dialog

### DIFF
--- a/survey_cad/src/io/project.rs
+++ b/survey_cad/src/io/project.rs
@@ -4,6 +4,23 @@ use crate::dtm::Tin;
 use crate::geometry::{Arc, Line, Point, Polyline};
 use crate::layers::Layer;
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GridSettings {
+    pub spacing: f32,
+    pub color: [u8; 3],
+    pub visible: bool,
+}
+
+impl Default for GridSettings {
+    fn default() -> Self {
+        Self {
+            spacing: 50.0,
+            color: [60, 60, 60],
+            visible: true,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Project {
     pub points: Vec<Point>,
@@ -15,6 +32,8 @@ pub struct Project {
     pub layers: Vec<Layer>,
     pub point_style_indices: Vec<usize>,
     pub line_style_indices: Vec<usize>,
+    #[serde(default)]
+    pub grid: GridSettings,
 }
 
 impl Project {
@@ -29,6 +48,7 @@ impl Project {
             layers: Vec::new(),
             point_style_indices: Vec::new(),
             line_style_indices: Vec::new(),
+            grid: GridSettings::default(),
         }
     }
 }

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -476,6 +476,36 @@ export component RotateEntityDialog inherits Window {
     }
 }
 
+export component SettingsDialog inherits Window {
+    in-out property <string> spacing_value;
+    in-out property <string> color_r;
+    in-out property <string> color_g;
+    in-out property <string> color_b;
+    in-out property <bool> show_grid;
+    callback accept();
+    callback cancel();
+    title: "Workspace Settings";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox {
+            Text { color: #FFFFFF; text: "Grid Spacing:"; }
+            LineEdit { text <=> root.spacing_value; width: 60px; }
+        }
+        HorizontalBox {
+            Text { color: #FFFFFF; text: "Grid Color:"; }
+            LineEdit { text <=> root.color_r; width: 40px; }
+            LineEdit { text <=> root.color_g; width: 40px; }
+            LineEdit { text <=> root.color_b; width: 40px; }
+        }
+        CheckBox { text: "Show Grid"; checked <=> root.show_grid; }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "OK"; clicked => { root.accept(); } }
+            Button { text: "Cancel"; clicked => { root.cancel(); } }
+        }
+    }
+}
+
 export component MainWindow inherits Window {
     preferred-width: 800px;
     preferred-height: 600px;
@@ -576,6 +606,7 @@ export component MainWindow inherits Window {
     callback rotate_entity();
     callback zoom_in();
     callback zoom_out();
+    callback settings();
     callback workspace_left_pressed(length, length);
     callback workspace_right_pressed(length, length);
     callback workspace_pointer_pressed(length, length, PointerEvent);
@@ -660,6 +691,7 @@ export component MainWindow inherits Window {
             MenuItem { title: "3D Workspace"; activated => { root.view_changed(1); } }
             MenuItem { title: "Zoom In"; activated => { root.zoom_in(); } }
             MenuItem { title: "Zoom Out"; activated => { root.zoom_out(); } }
+            MenuItem { title: "Settings..."; activated => { root.settings(); } }
         }
         Menu {
             title: "Macro";
@@ -828,6 +860,7 @@ export component MainWindow inherits Window {
                 checked <=> root.show_point_numbers;
                 toggled => { root.point_numbers_changed(root.show_point_numbers); }
             }
+            Button { text: "Settings..."; clicked => { root.settings(); } }
         }
 
         Rectangle {


### PR DESCRIPTION
## Summary
- store grid spacing, color and visibility in `Project`
- draw workspace grid using new settings
- add `SettingsDialog` to edit grid options
- load/save grid settings with project files

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_685eafb1ec88832889e394620c090cac