### PR TITLE
Enable persistent layers and styles

### DIFF
--- a/survey_cad/src/geometry/point.rs
+++ b/survey_cad/src/geometry/point.rs
@@ -1,7 +1,7 @@
 //! Basic 2D point types used throughout the crate.
 
 /// Symbol used when rendering a point entity.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum PointSymbol {
     #[default]
     Circle,
@@ -10,7 +10,7 @@ pub enum PointSymbol {
 }
 
 /// Basic visual style information for a point.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PointStyle {
     pub symbol: PointSymbol,
     pub color: [u8; 3],

--- a/survey_cad/src/layers.rs
+++ b/survey_cad/src/layers.rs
@@ -31,7 +31,7 @@ impl Layer {
 }
 
 /// Manager for an arbitrary number of layers.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct LayerManager {
     layers: HashMap<String, Layer>,
 }

--- a/survey_cad_truck_gui/src/persistence.rs
+++ b/survey_cad_truck_gui/src/persistence.rs
@@ -1,0 +1,34 @@
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use survey_cad::layers::LayerManager;
+use survey_cad::geometry::line::LineStyle;
+use survey_cad::geometry::point::PointStyle;
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct StyleSettings {
+    pub point_styles: Vec<(String, PointStyle)>,
+    pub line_styles: Vec<(String, LineStyle)>,
+}
+
+pub fn save_layers(path: &Path, layers: &LayerManager) -> std::io::Result<()> {
+    let json = serde_json::to_string_pretty(layers)?;
+    fs::write(path, json)
+}
+
+pub fn load_layers(path: &Path) -> Option<LayerManager> {
+    let data = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+pub fn save_styles(path: &Path, styles: &StyleSettings) -> std::io::Result<()> {
+    let json = serde_json::to_string_pretty(styles)?;
+    fs::write(path, json)
+}
+
+pub fn load_styles(path: &Path) -> Option<StyleSettings> {
+    let data = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}


### PR DESCRIPTION
## Summary
- add serde support for `PointSymbol`, `PointStyle`, and `LayerManager`
- create `persistence` module for saving/loading layers and styles
- load saved settings at startup and write them when saving a project

## Testing
- `cargo test -p survey_cad`
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_685ed6ef055c83289454e09f9041f258