### PR TITLE
Add entity inspector window

### DIFF
--- a/survey_cad_truck_gui/ui/entity_inspector.slint
+++ b/survey_cad_truck_gui/ui/entity_inspector.slint
@@ -1,0 +1,36 @@
+export component EntityInspector inherits Window {
+    in-out property <[string]> layers_model;
+    in-out property <[string]> styles_model;
+    in-out property <int> layer_index;
+    in-out property <int> style_index;
+    in-out property <string> metadata;
+    in-out property <string> entity_type;
+
+    callback layer_changed(int);
+    callback style_changed(int);
+    callback metadata_changed(string);
+
+    title: "Inspector";
+    width: 300px;
+    height: 150px;
+
+    VerticalBox {
+        spacing: 6px;
+        Text { color: #FFFFFF; text: "Type: " + root.entity_type; }
+        HorizontalBox {
+            spacing: 6px;
+            Text { color: #FFFFFF; text: "Layer:"; width: 60px; }
+            ComboBox { model: root.layers_model; current-index: root.layer_index; selected => { root.layer_changed(self.current-index); } }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Text { color: #FFFFFF; text: "Style:"; width: 60px; }
+            ComboBox { model: root.styles_model; current-index: root.style_index; selected => { root.style_changed(self.current-index); } }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Text { color: #FFFFFF; text: "Meta:"; width: 60px; }
+            LineEdit { text <=> root.metadata; edited(text) => { root.metadata_changed(text); } }
+        }
+    }
+}

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -3,6 +3,7 @@ export { LineStyleManager } from "line_style_manager.slint";
 export { LayerManager } from "layer_manager.slint";
 export { CrossSectionViewer } from "cross_section_viewer.slint";
 export { SuperelevationEditor } from "superelevation_editor.slint";
+export { EntityInspector } from "entity_inspector.slint";
 
 component Workspace2D inherits Rectangle {
     in-out property <image> image;
@@ -573,6 +574,7 @@ export component MainWindow inherits Window {
     callback point_manager();
     callback line_style_manager();
     callback layer_manager();
+    callback inspector();
     callback import_geojson();
     callback import_kml();
     callback import_dxf();
@@ -665,6 +667,7 @@ export component MainWindow inherits Window {
             MenuItem { title: "Point Manager..."; activated => { root.point_manager(); } }
             MenuItem { title: "Line Styles..."; activated => { root.line_style_manager(); } }
             MenuItem { title: "Layer Manager..."; activated => { root.layer_manager(); } }
+            MenuItem { title: "Inspector..."; activated => { root.inspector(); } }
             MenuItem { title: "Clear"; activated => { root.clear_workspace(); } }
         }
         Menu {
@@ -738,6 +741,10 @@ export component MainWindow inherits Window {
             Button {
                 text: "Layer Manager...";
                 clicked => { root.layer_manager(); }
+            }
+            Button {
+                text: "Inspector...";
+                clicked => { root.inspector(); }
             }
             Button {
                 text: "Add Line";


### PR DESCRIPTION
## Summary
- export new `EntityInspector` component
- hook inspector callback and menu/button entries
- provide helper to open inspector for selected point and edit layer/style/metadata

## Testing
- `cargo check -p survey_cad_truck_gui` *(fails: network-dependent crates)*

------
https://chatgpt.com/codex/tasks/task_e_685eded3894c83288db6a0a07dd00cd9