### PR TITLE
Fix Clippy uninlined format arguments

### DIFF
--- a/survey_cad/src/io/mod.rs
+++ b/survey_cad/src/io/mod.rs
@@ -319,9 +319,9 @@ pub fn write_dxf(path: &str, entities: &[DxfEntity]) -> io::Result<()> {
                     writeln!(file, "{l}")?;
                 }
                 writeln!(file, "10")?;
-                writeln!(file, "{}", point.x)?;
+                writeln!(file, "{x}", x = point.x)?;
                 writeln!(file, "20")?;
-                writeln!(file, "{}", point.y)?;
+                writeln!(file, "{y}", y = point.y)?;
                 writeln!(file, "30")?;
                 writeln!(file, "0.0")?;
             }
@@ -333,13 +333,13 @@ pub fn write_dxf(path: &str, entities: &[DxfEntity]) -> io::Result<()> {
                     writeln!(file, "{l}")?;
                 }
                 writeln!(file, "10")?;
-                writeln!(file, "{}", line.start.x)?;
+                writeln!(file, "{x}", x = line.start.x)?;
                 writeln!(file, "20")?;
-                writeln!(file, "{}", line.start.y)?;
+                writeln!(file, "{y}", y = line.start.y)?;
                 writeln!(file, "11")?;
-                writeln!(file, "{}", line.end.x)?;
+                writeln!(file, "{x}", x = line.end.x)?;
                 writeln!(file, "21")?;
-                writeln!(file, "{}", line.end.y)?;
+                writeln!(file, "{y}", y = line.end.y)?;
             }
             DxfEntity::Polyline { polyline, layer } => {
                 writeln!(file, "0")?;
@@ -360,9 +360,9 @@ pub fn write_dxf(path: &str, entities: &[DxfEntity]) -> io::Result<()> {
                         writeln!(file, "{l}")?;
                     }
                     writeln!(file, "10")?;
-                    writeln!(file, "{}", v.x)?;
+                    writeln!(file, "{x}", x = v.x)?;
                     writeln!(file, "20")?;
-                    writeln!(file, "{}", v.y)?;
+                    writeln!(file, "{y}", y = v.y)?;
                     writeln!(file, "30")?;
                     writeln!(file, "0.0")?;
                 }
@@ -377,15 +377,15 @@ pub fn write_dxf(path: &str, entities: &[DxfEntity]) -> io::Result<()> {
                     writeln!(file, "{l}")?;
                 }
                 writeln!(file, "10")?;
-                writeln!(file, "{}", arc.center.x)?;
+                writeln!(file, "{x}", x = arc.center.x)?;
                 writeln!(file, "20")?;
-                writeln!(file, "{}", arc.center.y)?;
+                writeln!(file, "{y}", y = arc.center.y)?;
                 writeln!(file, "40")?;
-                writeln!(file, "{}", arc.radius)?;
+                writeln!(file, "{radius}", radius = arc.radius)?;
                 writeln!(file, "50")?;
-                writeln!(file, "{}", arc.start_angle.to_degrees())?;
+                writeln!(file, "{angle}", angle = arc.start_angle.to_degrees())?;
                 writeln!(file, "51")?;
-                writeln!(file, "{}", arc.end_angle.to_degrees())?;
+                writeln!(file, "{angle}", angle = arc.end_angle.to_degrees())?;
             }
             DxfEntity::Text {
                 position,
@@ -400,11 +400,11 @@ pub fn write_dxf(path: &str, entities: &[DxfEntity]) -> io::Result<()> {
                     writeln!(file, "{l}")?;
                 }
                 writeln!(file, "10")?;
-                writeln!(file, "{}", position.x)?;
+                writeln!(file, "{x}", x = position.x)?;
                 writeln!(file, "20")?;
-                writeln!(file, "{}", position.y)?;
+                writeln!(file, "{y}", y = position.y)?;
                 writeln!(file, "40")?;
-                writeln!(file, "{}", height)?;
+                writeln!(file, "{height}")?;
                 writeln!(file, "1")?;
                 writeln!(file, "{value}")?;
             }

--- a/survey_cad/src/surveying/field_code.rs
+++ b/survey_cad/src/surveying/field_code.rs
@@ -63,7 +63,7 @@ impl fmt::Display for FieldCode {
             CodeAction::Begin => write!(f, "B{}", self.code),
             CodeAction::Continue => write!(f, "C{}", self.code),
             CodeAction::End => write!(f, "E{}", self.code),
-            CodeAction::None => write!(f, "{}", self.code),
+            CodeAction::None => write!(f, "{code}", code = self.code),
         }
     }
 }

--- a/survey_cad_cli/src/commands/mod.rs
+++ b/survey_cad_cli/src/commands/mod.rs
@@ -58,7 +58,7 @@ fn macro_record(path: &str) {
                 if l.trim().is_empty() {
                     break;
                 }
-                if let Err(e) = writeln!(file, "{}", l) {
+                if let Err(e) = writeln!(file, "{l}") {
                     eprintln!("Error writing {}: {}", path, e);
                     break;
                 }
@@ -457,7 +457,7 @@ pub fn run(command: crate::Commands, epsg: u32) {
                         Ok(mut file) => {
                             for p in pts {
                                 if let Some(n) = p.number {
-                                    if write!(file, "{}", n).is_err() {
+                                    if write!(file, "{n}").is_err() {
                                         continue;
                                     }
                                 }
@@ -467,7 +467,7 @@ pub fn run(command: crate::Commands, epsg: u32) {
                                     continue;
                                 }
                                 if let Some(desc) = p.description {
-                                    let _ = writeln!(file, "{}", desc);
+                                    let _ = writeln!(file, "{desc}");
                                 } else {
                                     let _ = writeln!(file);
                                 }

--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -262,7 +262,7 @@ struct MacroPlaying(bool);
 
 fn record_macro(rec: &mut MacroRecorder, line: &str) {
     if let Some(file) = &mut rec.file {
-        let _ = writeln!(file, "{}", line);
+        let _ = writeln!(file, "{line}");
     }
 }
 

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -173,7 +173,7 @@ struct MacroPlaying(bool);
 
 fn record_macro(rec: &mut MacroRecorder, line: &str) {
     if let Some(file) = &mut rec.file {
-        let _ = writeln!(file, "{}", line);
+        let _ = writeln!(file, "{line}");
     }
 }
 
@@ -4998,7 +4998,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     backend_render.borrow_mut().add_point(0.0, 0.0, 0.0);
                     let idx = point_db.borrow().len();
                     model.push(PointRow {
-                        number: SharedString::from(format!("{}", idx)),
+                        number: SharedString::from(format!("{idx}")),
                         name: SharedString::from(""),
                         x: SharedString::from("0.000"),
                         y: SharedString::from("0.000"),


### PR DESCRIPTION
## Summary
- address clippy::uninlined-format-args warnings by using inline formatting
- update CLI, GUI and truck GUI to use inline variable captures

## Testing
- `cargo check -p survey_cad`
- `cargo check -p survey_cad_gui` *(failed: build cancelled)*
- `cargo check -p survey_cad_cli` *(failed: build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6862842cae548328af96068dde41c5c8