### PR TITLE
Fix clippy warnings

### DIFF
--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -311,7 +311,7 @@ impl TruckBackend {
             ) {
                 let t = ((x - ax) * (bx - ax) + (y - ay) * (by - ay))
                     / ((bx - ax).powi(2) + (by - ay).powi(2));
-                if t >= 0.0 && t <= 1.0 {
+                if (0.0..=1.0).contains(&t) {
                     let lx = ax + t * (bx - ax);
                     let ly = ay + t * (by - ay);
                     let lz = az + t * (bz - az);


### PR DESCRIPTION
## Summary
- fix manual range check in truck backend
- clean up formatting strings and slice usage in inspector
- silence clippy on long parameter list

## Testing
- `cargo clippy -p survey_cad_truck_gui -- -D warnings`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6862b969f2a483288768bae8ac6ac314