### PR TITLE
Fix clippy lint

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -2970,8 +2970,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                     };
                                     if let Some(app) = weak.upgrade() {
                                         app.set_status(SharedString::from(format!(
-                                            "Loaded {} points",
-                                            len
+                                            "Loaded {len} points"
                                         )));
                                         if app.get_workspace_mode() == 0 {
                                             app.set_workspace_image(render_image());


### PR DESCRIPTION
## Summary
- fix clippy `uninlined-format-args` lint in survey_cad_truck_gui

## Testing
- `cargo clippy -p survey_cad_truck_gui -- -D clippy::uninlined-format-args`
- `cargo test -p survey_cad_truck_gui --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6862c977fd78832882e0f17c381f0825