### PR TITLE
Fix tests for create_line

### DIFF
--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -3431,6 +3431,8 @@ mod tests {
             Entity::from_raw(1),
             Entity::from_raw(2),
         ]));
+        app.insert_resource(MacroRecorder::default());
+        app.insert_resource(MacroPlaying(false));
 
         app.update();
 


### PR DESCRIPTION
## Summary
- update the `create_line_missing_points` unit test to insert `MacroRecorder` and `MacroPlaying` resources

## Testing
- `cargo test --package survey_cad_gui --bin survey_cad_gui -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6862d46345b0832880f3552cfa8c595e