### PR TITLE
Add snapping resolver and UI toggles

### DIFF
--- a/survey_cad_truck_gui/src/snap.rs
+++ b/survey_cad_truck_gui/src/snap.rs
@@ -1,0 +1,56 @@
+use survey_cad::geometry::{Arc, Line, Point, Polyline};
+use survey_cad::io::DxfEntity;
+use survey_cad::snap::{snap_point_with_settings, SnapSettings};
+
+pub struct Scene<'a> {
+    pub points: &'a [Point],
+    pub lines: &'a [(Point, Point)],
+    pub polygons: &'a [Vec<Point>],
+    pub polylines: &'a [Polyline],
+    pub arcs: &'a [Arc],
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct SnapOptions {
+    pub snap_points: bool,
+    pub snap_endpoints: bool,
+    pub snap_intersections: bool,
+}
+
+pub fn resolve_snap(
+    target: Point,
+    scene: &Scene,
+    tol: f64,
+    opts: SnapOptions,
+) -> Option<Point> {
+    let mut ents: Vec<DxfEntity> = Vec::new();
+    if opts.snap_points {
+        for p in scene.points {
+            ents.push(DxfEntity::Point { point: *p, layer: None });
+        }
+    }
+    if opts.snap_endpoints || opts.snap_intersections {
+        for (s, e) in scene.lines {
+            ents.push(DxfEntity::Line { line: Line::new(*s, *e), layer: None });
+        }
+        for poly in scene.polygons {
+            ents.push(DxfEntity::Polyline { polyline: Polyline::new(poly.clone()), layer: None });
+        }
+        for pl in scene.polylines {
+            ents.push(DxfEntity::Polyline { polyline: pl.clone(), layer: None });
+        }
+        for arc in scene.arcs {
+            ents.push(DxfEntity::Arc { arc: *arc, layer: None });
+        }
+    }
+    let settings = SnapSettings {
+        endpoints: opts.snap_points || opts.snap_endpoints,
+        midpoints: false,
+        intersections: opts.snap_intersections,
+        nearest: false,
+    };
+    if ents.is_empty() {
+        return None;
+    }
+    snap_point_with_settings(target, &ents, tol, settings)
+}

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -523,10 +523,9 @@ export component MainWindow inherits Window {
     in-out property <bool> snap_to_grid;
     in-out property <bool> snap_to_entities;
     in-out property <bool> show_point_numbers;
+    in-out property <bool> snap_points;
     in-out property <bool> snap_endpoints;
-    in-out property <bool> snap_midpoints;
     in-out property <bool> snap_intersections;
-    in-out property <bool> snap_nearest;
     in-out property <float> zoom_level;
 
     callback key_pressed(string);
@@ -568,10 +567,9 @@ export component MainWindow inherits Window {
     callback point_numbers_changed(bool);
     callback snap_grid_changed(bool);
     callback snap_objects_changed(bool);
+    callback snap_points_changed(bool);
     callback snap_endpoints_changed(bool);
-    callback snap_midpoints_changed(bool);
     callback snap_intersections_changed(bool);
-    callback snap_nearest_changed(bool);
     callback point_manager();
     callback line_style_manager();
     callback layer_manager();
@@ -868,10 +866,9 @@ export component MainWindow inherits Window {
             spacing: 6px;
             CheckBox { text: "Snap Grid"; checked <=> root.snap_to_grid; toggled => { root.snap_grid_changed(root.snap_to_grid); } }
             CheckBox { text: "Snap Objects"; checked <=> root.snap_to_entities; toggled => { root.snap_objects_changed(root.snap_to_entities); } }
+            CheckBox { text: "Points"; checked <=> root.snap_points; toggled => { root.snap_points_changed(root.snap_points); } }
             CheckBox { text: "Endpoints"; checked <=> root.snap_endpoints; toggled => { root.snap_endpoints_changed(root.snap_endpoints); } }
-            CheckBox { text: "Midpoints"; checked <=> root.snap_midpoints; toggled => { root.snap_midpoints_changed(root.snap_midpoints); } }
             CheckBox { text: "Intersections"; checked <=> root.snap_intersections; toggled => { root.snap_intersections_changed(root.snap_intersections); } }
-            CheckBox { text: "Nearest"; checked <=> root.snap_nearest; toggled => { root.snap_nearest_changed(root.snap_nearest); } }
             CheckBox {
                 text: "Point Numbers";
                 checked <=> root.show_point_numbers;


### PR DESCRIPTION
## Summary
- add `snap` helper module for resolving snaps
- expose snap candidate highlight in 2D renderer
- update input handlers to snap via the new resolver
- add UI controls for snapping to points, endpoints and intersections

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_6865451ca1e083289f9f8ebb7ca353e1