### PR TITLE
Add config persistence in truck GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3681,6 +3681,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7404,6 +7425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8350,6 +8377,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9575,6 +9613,7 @@ dependencies = [
 name = "survey_cad_truck_gui"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "i-slint-common 1.12.0 (git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db)",
  "once_cell",
  "rfd",

--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -17,6 +17,7 @@ rusttype = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 shell-words = "1.1"
+dirs = "6"
 
 [build-dependencies]
 slint-build = "1"


### PR DESCRIPTION
## Summary
- store and load window settings and snapping options in a config file
- use `dirs` crate to place config under user config directory
- restore window and snap state on startup
- save preferences when closing or choosing files

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_68654a51769c832885c0bd41bcc31d65