### PR TITLE
Fix clippy errors in truck GUI

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -30,7 +30,6 @@ mod snap;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
-use dirs;
 use truck_modeling::base::Point3;
 
 mod truck_backend;
@@ -150,15 +149,6 @@ fn save_config(cfg: &Config) {
     }
 }
 
-fn load_snap_prefs() -> SnapPrefs {
-    load_config().snap
-}
-
-fn save_snap_prefs(p: &SnapPrefs) {
-    let mut cfg = load_config();
-    cfg.snap = p.clone();
-    save_config(&cfg);
-}
 
 #[derive(Default, Clone, PartialEq)]
 enum DrawingMode {


### PR DESCRIPTION
## Summary
- remove redundant `dirs` import
- drop unused snap preference helpers

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo test -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_68655c23d1b48328a37628b7633067f2