### PR TITLE
Fix clippy field reassignment warnings

### DIFF
--- a/survey_cad/src/io/las.rs
+++ b/survey_cad/src/io/las.rs
@@ -17,9 +17,11 @@ pub fn read_points_las(path: &str) -> io::Result<Vec<Point3>> {
 /// Writes points to a LAS or LAZ file. Compression is inferred from the
 /// file extension when the `laz` feature of the `las` crate is enabled.
 pub fn write_points_las(path: &str, points: &[Point3]) -> io::Result<()> {
-    let mut builder = Builder::default();
-    builder.point_format = Format::new(0).unwrap();
-    builder.version = Version::new(1, 2);
+    let builder = Builder {
+        point_format: Format::new(0).unwrap(),
+        version: Version::new(1, 2),
+        ..Default::default()
+    };
     let header = builder.into_header().map_err(io::Error::other)?;
     let mut writer = Writer::from_path(path, header).map_err(io::Error::other)?;
     for p in points {

--- a/truck_cad_engine/src/lib.rs
+++ b/truck_cad_engine/src/lib.rs
@@ -1,8 +1,8 @@
 use pollster::block_on;
 use slint::{Image, Rgba8Pixel, SharedPixelBuffer};
 use truck_meshalgo::prelude::*;
-use truck_modeling::{self as truck, builder};
 use truck_modeling::base::{Point2, Point3, Vector4};
+use truck_modeling::{self as truck, builder};
 use truck_platform::{wgpu, *};
 use truck_rendimpl::*;
 
@@ -150,8 +150,10 @@ impl TruckCadEngine {
         _weight: f32,
     ) -> usize {
         let poly = PolylineCurve(vec![a, b]);
-        let mut state = WireFrameState::default();
-        state.color = color;
+        let state = WireFrameState {
+            color,
+            ..Default::default()
+        };
         let instance = self.creator.create_instance(&poly, &state);
         self.scene.add_object(&instance);
         self.lines.push(Some(instance));
@@ -170,8 +172,10 @@ impl TruckCadEngine {
         if let Some(Some(inst)) = self.lines.get_mut(id) {
             self.scene.remove_object(inst);
             let poly = PolylineCurve(vec![a, b]);
-            let mut state = WireFrameState::default();
-            state.color = color;
+            let state = WireFrameState {
+                color,
+                ..Default::default()
+            };
             let new_inst = self.creator.create_instance(&poly, &state);
             self.scene.add_object(&new_inst);
             *inst = new_inst;


### PR DESCRIPTION
## Summary
- avoid reassigning `WireFrameState` after `Default::default`
- initialize LAS `Builder` with field defaults directly

## Testing
- `cargo check -p truck_cad_engine`


------
https://chatgpt.com/codex/tasks/task_e_6865646e37008328909cb64ad6ec07a1