### PR TITLE
Fix LAS builder initialization

### DIFF
--- a/survey_cad/src/io/las.rs
+++ b/survey_cad/src/io/las.rs
@@ -17,11 +17,9 @@ pub fn read_points_las(path: &str) -> io::Result<Vec<Point3>> {
 /// Writes points to a LAS or LAZ file. Compression is inferred from the
 /// file extension when the `laz` feature of the `las` crate is enabled.
 pub fn write_points_las(path: &str, points: &[Point3]) -> io::Result<()> {
-    let builder = Builder {
-        point_format: Format::new(0).unwrap(),
-        version: Version::new(1, 2),
-        ..Default::default()
-    };
+    let mut builder = Builder::default();
+    builder.point_format = Format::new(0).unwrap();
+    builder.version = Version::new(1, 2);
     let header = builder.into_header().map_err(io::Error::other)?;
     let mut writer = Writer::from_path(path, header).map_err(io::Error::other)?;
     for p in points {


### PR DESCRIPTION
## Summary
- fix compile error with LAS builder

## Testing
- `cargo check -p survey_cad --features las`
- `cargo test -p survey_cad --features las`

------
https://chatgpt.com/codex/tasks/task_e_68656f662aa08328bac880429527e249