### PR TITLE
Enable vertex dragging in truck 3D workspace

### DIFF
--- a/truck_cad_engine/src/lib.rs
+++ b/truck_cad_engine/src/lib.rs
@@ -447,6 +447,14 @@ impl TruckCadEngine {
             })
     }
 
+    /// Set the color of a point marker.
+    pub fn set_point_marker_color(&mut self, id: usize, color: Vector4) {
+        if let Some(Some(inst)) = self.point_markers.get_mut(id) {
+            inst.instance_state_mut().material.albedo = color;
+            self.scene.update_bind_group(&*inst);
+        }
+    }
+
     /// Set the surface color for highlighting.
     pub fn set_surface_color(&mut self, id: usize, color: Vector4) {
         if let Some(Some(surface)) = self.surfaces.get_mut(id) {


### PR DESCRIPTION
## Summary
- support selecting surface vertices directly in the 3‑D workspace
- add helper functions to TruckBackend for handle highlight and coordinate conversion
- expose point marker color changes in TruckCadEngine

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6866a47d70408328b32da1f6ba89d79a