### PR TITLE
Enable interactive cross section editing

### DIFF
--- a/survey_cad/src/corridor.rs
+++ b/survey_cad/src/corridor.rs
@@ -237,6 +237,30 @@ pub fn extract_design_cross_sections(
     sections
 }
 
+/// Builds a surface by connecting consecutive cross sections with triangles.
+pub fn surface_from_cross_sections(sections: &[CrossSection]) -> Tin {
+    if sections.is_empty() {
+        return Tin { vertices: Vec::new(), triangles: Vec::new() };
+    }
+    let pts_per = sections[0].points.len();
+    let mut vertices = Vec::new();
+    for sec in sections {
+        vertices.extend_from_slice(&sec.points);
+    }
+    let mut triangles = Vec::new();
+    for i in 0..(sections.len() - 1) {
+        for j in 0..(pts_per - 1) {
+            let a = i * pts_per + j;
+            let b = a + 1;
+            let c = (i + 1) * pts_per + j;
+            let d = c + 1;
+            triangles.push([a, c, d]);
+            triangles.push([a, d, b]);
+        }
+    }
+    Tin { vertices, triangles }
+}
+
 /// Builds a design surface by applying cross-section subassemblies along an
 /// alignment at the specified station `interval`.
 pub fn build_design_surface(alignment: &Alignment, subs: &[Subassembly], interval: f64) -> Tin {

--- a/survey_cad_truck_gui/ui/cross_section_viewer.slint
+++ b/survey_cad_truck_gui/ui/cross_section_viewer.slint
@@ -5,6 +5,9 @@ export component CrossSectionViewer inherits Window {
     in-out property <string> station_label;
     in-out property <string> elevation_label;
     in-out property <string> slope_label;
+    callback pointer_pressed(length, length);
+    callback pointer_moved(length, length);
+    callback pointer_released();
     callback prev();
     callback next();
     title: "Cross Section Viewer";
@@ -26,6 +29,19 @@ export component CrossSectionViewer inherits Window {
             image-fit: fill;
             width: 100%;
             height: 100%;
+        }
+        TouchArea {
+            width: 100%;
+            height: 100%;
+            pointer-event(event) => {
+                if event.kind == PointerEventKind.down {
+                    root.pointer_pressed(self.mouse-x, self.mouse-y);
+                } else if event.kind == PointerEventKind.up {
+                    root.pointer_released();
+                } else if event.kind == PointerEventKind.move {
+                    root.pointer_moved(self.mouse-x, self.mouse-y);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- update `CrossSectionViewer` with pointer handlers
- expose `surface_from_cross_sections` helper
- allow dragging section points to rebuild corridor surfaces

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo test -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_6867e43f149083289ed3978f21ace71c