### PR TITLE
Add LandXML metadata support

### DIFF
--- a/survey_cad/src/io/mod.rs
+++ b/survey_cad/src/io/mod.rs
@@ -755,8 +755,8 @@ mod tests {
             ],
             triangles: vec![[0, 1, 2]],
         };
-        landxml::write_landxml_surface(path.to_str().unwrap(), &tin).unwrap();
-        let read = landxml::read_landxml_surface(path.to_str().unwrap()).unwrap();
+        landxml::write_landxml_surface(path.to_str().unwrap(), &tin, None).unwrap();
+        let (read, _extras) = landxml::read_landxml_surface(path.to_str().unwrap()).unwrap();
         assert_eq!(read.vertices.len(), 3);
         assert_eq!(read.triangles.len(), 1);
         std::fs::remove_file(path).ok();
@@ -766,8 +766,8 @@ mod tests {
     fn write_and_read_landxml_alignment() {
         let path = std::env::temp_dir().join("align.xml");
         let hal = HorizontalAlignment::new(vec![Point::new(0.0, 0.0), Point::new(1.0, 1.0)]);
-        landxml::write_landxml_alignment(path.to_str().unwrap(), &hal).unwrap();
-        let read = landxml::read_landxml_alignment(path.to_str().unwrap()).unwrap();
+        landxml::write_landxml_alignment(path.to_str().unwrap(), &hal, None).unwrap();
+        let (read, _extras) = landxml::read_landxml_alignment(path.to_str().unwrap()).unwrap();
         assert_eq!(read.elements.len(), 1);
         std::fs::remove_file(path).ok();
     }
@@ -784,8 +784,8 @@ mod tests {
         let arc = Arc::new(Point::new(10.0, 5.0), 5.0, -PI / 2.0, 0.0);
         elements.push(HorizontalElement::Curve { arc });
         let hal = HorizontalAlignment { elements };
-        landxml::write_landxml_alignment(path.to_str().unwrap(), &hal).unwrap();
-        let read = landxml::read_landxml_alignment(path.to_str().unwrap()).unwrap();
+        landxml::write_landxml_alignment(path.to_str().unwrap(), &hal, None).unwrap();
+        let (read, _extras) = landxml::read_landxml_alignment(path.to_str().unwrap()).unwrap();
         assert_eq!(read.elements.len(), 2);
         std::fs::remove_file(path).ok();
     }
@@ -829,8 +829,8 @@ mod tests {
                 vec![Point3::new(0.0, 1.0, 0.0), Point3::new(1.0, 1.0, 0.0)],
             ),
         ];
-        landxml::write_landxml_cross_sections(path.to_str().unwrap(), &secs).unwrap();
-        let read = landxml::read_landxml_cross_sections(path.to_str().unwrap()).unwrap();
+        landxml::write_landxml_cross_sections(path.to_str().unwrap(), &secs, None).unwrap();
+        let (read, _extras) = landxml::read_landxml_cross_sections(path.to_str().unwrap()).unwrap();
         assert_eq!(read.len(), 2);
         std::fs::remove_file(path).ok();
     }

--- a/survey_cad/src/io/project.rs
+++ b/survey_cad/src/io/project.rs
@@ -33,6 +33,12 @@ pub struct Project {
     #[serde(default)]
     pub alignments: Vec<crate::alignment::Alignment>,
     pub surfaces: Vec<Tin>,
+    #[serde(default)]
+    pub surface_units: Vec<String>,
+    #[serde(default)]
+    pub surface_styles: Vec<String>,
+    #[serde(default)]
+    pub surface_descriptions: Vec<String>,
     pub layers: Vec<Layer>,
     pub point_style_indices: Vec<usize>,
     pub line_style_indices: Vec<usize>,
@@ -59,6 +65,9 @@ impl Project {
             dimensions: Vec::new(),
             alignments: Vec::new(),
             surfaces: Vec::new(),
+            surface_units: Vec::new(),
+            surface_styles: Vec::new(),
+            surface_descriptions: Vec::new(),
             layers: Vec::new(),
             point_style_indices: Vec::new(),
             line_style_indices: Vec::new(),

--- a/survey_cad_cli/src/commands/mod.rs
+++ b/survey_cad_cli/src/commands/mod.rs
@@ -304,7 +304,7 @@ fn write_polygons_csv(path: &str, polygons: &[Vec<Point>]) -> std::io::Result<()
 
 fn read_surface(path: &str) -> std::io::Result<Tin> {
     if path.to_ascii_lowercase().ends_with(".xml") {
-        read_landxml_surface(path)
+        read_landxml_surface(path).map(|(t, _)| t)
     } else {
         let lines = read_lines(path)?;
         let mut pts = Vec::new();

--- a/survey_cad_gui/src/main.rs
+++ b/survey_cad_gui/src/main.rs
@@ -3140,7 +3140,7 @@ fn handle_open_button(
                     }
                 }
             } else if lower.ends_with(".xml") {
-                if let Ok(tin) = landxml::read_landxml_surface(path_str) {
+                if let Ok((tin, _)) = landxml::read_landxml_surface(path_str) {
                     let mesh = build_surface_mesh(&tin);
                     let handle = meshes.add(mesh);
                     let mat = materials.add(StandardMaterial {
@@ -3152,7 +3152,7 @@ fn handle_open_button(
                         .insert(SurfaceMesh);
                     surface_tin.0.push(tin);
                     surface_data.set_changed();
-                } else if let Ok(hal) = landxml::read_landxml_alignment(path_str) {
+                } else if let Ok((hal, _)) = landxml::read_landxml_alignment(path_str) {
                     for elem in hal.elements {
                         use survey_cad::alignment::HorizontalElement::*;
                         match elem {
@@ -3232,7 +3232,7 @@ fn handle_save_button(
                 let _ = write_points_csv(path_str, &pts, None, None);
             } else if lower.ends_with(".xml") {
                 if let Some(tin) = tin_res.0.last() {
-                    let _ = landxml::write_landxml_surface(path_str, tin);
+                    let _ = landxml::write_landxml_surface(path_str, tin, None);
                 } else if alignment.points.len() > 1 {
                     let mut pts = Vec::new();
                     for e in &alignment.points {
@@ -3241,7 +3241,7 @@ fn handle_save_button(
                         }
                     }
                     let hal = survey_cad::alignment::HorizontalAlignment::new(pts);
-                    let _ = landxml::write_landxml_alignment(path_str, &hal);
+                    let _ = landxml::write_landxml_alignment(path_str, &hal, None);
                 }
             } else if lower.ends_with(".shp") {
                 #[cfg(feature = "shapefile")]

--- a/survey_cad_slint_gui/src/main.rs
+++ b/survey_cad_slint_gui/src/main.rs
@@ -821,7 +821,7 @@ fn main() -> Result<(), slint::PlatformError> {
             {
                 if let Some(p) = path.to_str() {
                     match survey_cad::io::landxml::read_landxml_surface(p) {
-                        Ok(tin) => {
+                        Ok((tin, _)) => {
                             surfaces.borrow_mut().push(tin);
                             if let Some(app) = weak.upgrade() {
                                 app.set_status(SharedString::from("Imported surface"));
@@ -853,7 +853,7 @@ fn main() -> Result<(), slint::PlatformError> {
             {
                 if let Some(p) = path.to_str() {
                     match survey_cad::io::landxml::read_landxml_alignment(p) {
-                        Ok(al) => {
+                        Ok((al, _)) => {
                             alignments.borrow_mut().push(al);
                             if let Some(app) = weak.upgrade() {
                                 app.set_status(SharedString::from("Imported alignment"));


### PR DESCRIPTION
## Summary
- extend Project to store surface units/styles/descriptions
- support reading/writing these attributes in LandXML helpers
- include metadata when exporting LandXML surfaces and sections
- track metadata in truck GUI

## Testing
- `cargo test -p survey_cad`
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_6867ea5219f48328ad60be3bad5c49d6