### PR TITLE
Fix clippy uninlined-format-args

### DIFF
--- a/survey_cad/src/io/landxml.rs
+++ b/survey_cad/src/io/landxml.rs
@@ -84,19 +84,19 @@ pub fn write_landxml_surface(path: &str, tin: &Tin, extras: Option<&LandxmlExtra
     writeln!(&mut xml, "<LandXML>").unwrap();
     if let Some(ex) = extras {
         if let Some(u) = &ex.units {
-            writeln!(&mut xml, "  <Units linearUnit=\"{}\"/>", u).unwrap();
+            writeln!(&mut xml, "  <Units linearUnit=\"{u}\"/>").unwrap();
         }
     }
     writeln!(&mut xml, "  <Surfaces>").unwrap();
     let style_attr = extras
         .and_then(|e| e.style.as_deref())
-        .map(|s| format!(" style=\"{}\"", s))
+        .map(|s| format!(" style=\"{s}\""))
         .unwrap_or_default();
     let desc_attr = extras
         .and_then(|e| e.description.as_deref())
-        .map(|s| format!(" desc=\"{}\"", s))
+        .map(|s| format!(" desc=\"{s}\""))
         .unwrap_or_default();
-    writeln!(&mut xml, "    <Surface name=\"TIN\"{}{}>", style_attr, desc_attr).unwrap();
+    writeln!(&mut xml, "    <Surface name=\"TIN\"{style_attr}{desc_attr}>").unwrap();
     writeln!(&mut xml, "      <Definition surfType=\"TIN\">").unwrap();
     writeln!(&mut xml, "        <Pnts>").unwrap();
     for (i, v) in tin.vertices.iter().enumerate() {
@@ -340,19 +340,19 @@ pub fn write_landxml_alignment(
     writeln!(&mut xml, "<LandXML>").unwrap();
     if let Some(ex) = extras {
         if let Some(u) = &ex.units {
-            writeln!(&mut xml, "  <Units linearUnit=\"{}\"/>", u).unwrap();
+            writeln!(&mut xml, "  <Units linearUnit=\"{u}\"/>").unwrap();
         }
     }
     writeln!(&mut xml, "  <Alignments>").unwrap();
     let style_attr = extras
         .and_then(|e| e.style.as_deref())
-        .map(|s| format!(" style=\"{}\"", s))
+        .map(|s| format!(" style=\"{s}\""))
         .unwrap_or_default();
     let desc_attr = extras
         .and_then(|e| e.description.as_deref())
-        .map(|s| format!(" desc=\"{}\"", s))
+        .map(|s| format!(" desc=\"{s}\""))
         .unwrap_or_default();
-    writeln!(&mut xml, "    <Alignment name=\"HAL\"{}{}>", style_attr, desc_attr).unwrap();
+    writeln!(&mut xml, "    <Alignment name=\"HAL\"{style_attr}{desc_attr}>").unwrap();
     writeln!(&mut xml, "      <CoordGeom>").unwrap();
     for elem in &alignment.elements {
         match elem {
@@ -561,7 +561,7 @@ pub fn write_landxml_cross_sections(
     writeln!(&mut xml, "<LandXML>").unwrap();
     if let Some(ex) = extras {
         if let Some(u) = &ex.units {
-            writeln!(&mut xml, "  <Units linearUnit=\"{}\"/>", u).unwrap();
+            writeln!(&mut xml, "  <Units linearUnit=\"{u}\"/>").unwrap();
         }
     }
     writeln!(&mut xml, "  <CrossSections>").unwrap();
@@ -570,7 +570,7 @@ pub fn write_landxml_cross_sections(
         let coords: Vec<String> = sec
             .points
             .iter()
-            .map(|p| format!("{} {} {}", p.x, p.y, p.z))
+            .map(|p| format!("{x} {y} {z}", x = p.x, y = p.y, z = p.z))
             .collect();
         writeln!(
             &mut xml,

--- a/survey_cad/src/io/mod.rs
+++ b/survey_cad/src/io/mod.rs
@@ -58,23 +58,24 @@ pub fn read_points_csv(
         .enumerate()
         .filter(|(_, line)| !line.trim().is_empty())
         .map(|(idx, line)| {
+            let line_no = idx + 1;
             let parts: Vec<&str> = line.split(',').collect();
             if parts.len() != 2 {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("line {}: expected two comma-separated values", idx + 1),
+                    format!("line {line_no}: expected two comma-separated values"),
                 ));
             }
             let x = parts[0].trim().parse::<f64>().map_err(|e| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("line {}: {}", idx + 1, e),
+                    format!("line {line_no}: {e}"),
                 )
             })?;
             let y = parts[1].trim().parse::<f64>().map_err(|e| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("line {}: {}", idx + 1, e),
+                    format!("line {line_no}: {e}"),
                 )
             })?;
             Ok(Point::new(x, y))

--- a/survey_cad/src/reporting.rs
+++ b/survey_cad/src/reporting.rs
@@ -38,7 +38,10 @@ pub fn points_report_pdf(path: &str, points: &[Point]) -> std::io::Result<()> {
     let rows: Vec<String> = points
         .iter()
         .enumerate()
-        .map(|(i, p)| format!("{}: {}, {}", i + 1, p.x, p.y))
+        .map(|(i, p)| {
+            let idx = i + 1;
+            format!("{idx}: {x}, {y}", x = p.x, y = p.y)
+        })
         .collect();
     write_pdf(path, "Points Report", &rows)
 }


### PR DESCRIPTION
## Summary
- inline format args in LandXML writer helpers
- inline format args in CSV parser helper
- inline format args in reporting helper

## Testing
- `cargo clippy -p survey_cad -- -D warnings`
- `cargo test -p survey_cad`

------
https://chatgpt.com/codex/tasks/task_e_6867f96fb5a48328bfdc3cb0121fa565