### PR TITLE
Add breakline and boundary tools

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -5176,6 +5176,144 @@ fn main() -> Result<(), slint::PlatformError> {
     }
 
     {
+        let backend = backend.clone();
+        let weak = app.as_weak();
+        app.on_tin_add_breakline(move || {
+            let dlg = TinBreaklineDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            let weak2 = weak.clone();
+            let backend_inner = backend.clone();
+            dlg.on_accept(move || {
+                if let Some(d) = dlg_weak.upgrade() {
+                    if let (Ok(surf), Ok(a), Ok(b)) = (
+                        d.get_surface_index().parse::<usize>(),
+                        d.get_v1().parse::<usize>(),
+                        d.get_v2().parse::<usize>(),
+                    ) {
+                        backend_inner.borrow_mut().add_breakline(surf, a, b);
+                        if let Some(app) = weak2.upgrade() {
+                            let image = backend_inner.borrow_mut().render();
+                            app.set_workspace_texture(image);
+                            app.window().request_redraw();
+                        }
+                    }
+                    let _ = d.hide();
+                }
+            });
+            let dlg_weak2 = dlg.as_weak();
+            dlg.on_cancel(move || {
+                if let Some(d) = dlg_weak2.upgrade() {
+                    let _ = d.hide();
+                }
+            });
+            dlg.show().unwrap();
+        });
+    }
+
+    {
+        let backend = backend.clone();
+        let weak = app.as_weak();
+        app.on_tin_remove_breakline(move || {
+            let dlg = TinBreaklineDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            let weak2 = weak.clone();
+            let backend_inner = backend.clone();
+            dlg.on_accept(move || {
+                if let Some(d) = dlg_weak.upgrade() {
+                    if let (Ok(surf), Ok(a), Ok(b)) = (
+                        d.get_surface_index().parse::<usize>(),
+                        d.get_v1().parse::<usize>(),
+                        d.get_v2().parse::<usize>(),
+                    ) {
+                        backend_inner.borrow_mut().remove_breakline(surf, a, b);
+                        if let Some(app) = weak2.upgrade() {
+                            let image = backend_inner.borrow_mut().render();
+                            app.set_workspace_texture(image);
+                            app.window().request_redraw();
+                        }
+                    }
+                    let _ = d.hide();
+                }
+            });
+            let dlg_weak2 = dlg.as_weak();
+            dlg.on_cancel(move || {
+                if let Some(d) = dlg_weak2.upgrade() {
+                    let _ = d.hide();
+                }
+            });
+            dlg.show().unwrap();
+        });
+    }
+
+    {
+        let backend = backend.clone();
+        let weak = app.as_weak();
+        app.on_tin_set_boundary(move || {
+            let dlg = TinBoundaryDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            let weak2 = weak.clone();
+            let backend_inner = backend.clone();
+            dlg.on_accept(move || {
+                if let Some(d) = dlg_weak.upgrade() {
+                    if let Ok(surf) = d.get_surface_index().parse::<usize>() {
+                        let verts: Vec<usize> = d
+                            .get_verts()
+                            .split(|c: char| c == ',' || c.is_whitespace())
+                            .filter_map(|s| s.parse().ok())
+                            .collect();
+                        backend_inner.borrow_mut().set_boundary(surf, verts);
+                        if let Some(app) = weak2.upgrade() {
+                            let image = backend_inner.borrow_mut().render();
+                            app.set_workspace_texture(image);
+                            app.window().request_redraw();
+                        }
+                    }
+                    let _ = d.hide();
+                }
+            });
+            let dlg_weak2 = dlg.as_weak();
+            dlg.on_cancel(move || {
+                if let Some(d) = dlg_weak2.upgrade() {
+                    let _ = d.hide();
+                }
+            });
+            dlg.show().unwrap();
+        });
+    }
+
+    {
+        let backend = backend.clone();
+        let weak = app.as_weak();
+        app.on_tin_clear_boundary(move || {
+            let dlg = TinBoundaryDialog::new().unwrap();
+            dlg.set_verts("".into());
+            let dlg_weak = dlg.as_weak();
+            let weak2 = weak.clone();
+            let backend_inner = backend.clone();
+            dlg.on_accept(move || {
+                if let Some(d) = dlg_weak.upgrade() {
+                    if let Ok(surf) = d.get_surface_index().parse::<usize>() {
+                        backend_inner.borrow_mut().clear_boundary(surf);
+                        if let Some(app) = weak2.upgrade() {
+                            let image = backend_inner.borrow_mut().render();
+                            app.set_workspace_texture(image);
+                            app.window().request_redraw();
+                        }
+                    }
+                    let _ = d.hide();
+                }
+            });
+            let dlg_weak2 = dlg.as_weak();
+            dlg.on_cancel(move || {
+                if let Some(d) = dlg_weak2.upgrade() {
+                    let _ = d.hide();
+                }
+            });
+            dlg.show().unwrap();
+        });
+    }
+
+    {
         let weak = app.as_weak();
         let point_db = point_db.clone();
         let render_image = render_image.clone();

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -292,6 +292,44 @@ export component TinTriangleDialog inherits Window {
     }
 }
 
+export component TinBreaklineDialog inherits Window {
+    in-out property <string> surface_index;
+    in-out property <string> v1;
+    in-out property <string> v2;
+    callback accept();
+    callback cancel();
+    title: "TIN Breakline";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox { Text { color: #FFFFFF; text: "Surface:"; } LineEdit { text <=> root.surface_index; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "V1:"; } LineEdit { text <=> root.v1; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "V2:"; } LineEdit { text <=> root.v2; } }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "OK"; clicked => { root.accept(); } }
+            Button { text: "Cancel"; clicked => { root.cancel(); } }
+        }
+    }
+}
+
+export component TinBoundaryDialog inherits Window {
+    in-out property <string> surface_index;
+    in-out property <string> verts;
+    callback accept();
+    callback cancel();
+    title: "TIN Boundary";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox { Text { color: #FFFFFF; text: "Surface:"; } LineEdit { text <=> root.surface_index; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Vertices:"; } LineEdit { text <=> root.verts; } }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "OK"; clicked => { root.accept(); } }
+            Button { text: "Cancel"; clicked => { root.cancel(); } }
+        }
+    }
+}
+
 export component AddLineDialog inherits Window {
     callback from_file();
     callback manual();
@@ -669,6 +707,10 @@ export component MainWindow inherits Window {
     callback tin_delete_vertex();
     callback tin_add_triangle();
     callback tin_delete_triangle();
+    callback tin_add_breakline();
+    callback tin_remove_breakline();
+    callback tin_set_boundary();
+    callback tin_clear_boundary();
     callback macro_record();
     callback macro_play();
     callback run_python_script();
@@ -764,6 +806,10 @@ export component MainWindow inherits Window {
             MenuItem { title: "Delete Vertex"; activated => { root.tin_delete_vertex(); } }
             MenuItem { title: "Add Triangle"; activated => { root.tin_add_triangle(); } }
             MenuItem { title: "Delete Triangle"; activated => { root.tin_delete_triangle(); } }
+            MenuItem { title: "Add Breakline"; activated => { root.tin_add_breakline(); } }
+            MenuItem { title: "Remove Breakline"; activated => { root.tin_remove_breakline(); } }
+            MenuItem { title: "Set Boundary"; activated => { root.tin_set_boundary(); } }
+            MenuItem { title: "Clear Boundary"; activated => { root.tin_clear_boundary(); } }
         }
         Menu {
             title: "View";


### PR DESCRIPTION
## Summary
- extend TruckBackend with breakline and boundary data
- add hit-test logic for breaklines and boundaries
- expose dialogs and menu entries for editing breaklines and boundaries

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_6867fc1691388328b034df180c1ff94d