### PR TITLE
Fix clippy warnings in truck backend

### DIFF
--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -8,8 +8,8 @@ pub enum HitObject {
     Line,
     Surface(usize),
     Handle(usize),
-    Breakline(usize, usize),
-    Boundary(usize, usize),
+    Breakline,
+    Boundary,
 }
 
 struct SurfaceData {
@@ -280,14 +280,14 @@ impl TruckBackend {
 
     pub fn add_breakline(&mut self, surface: usize, a: usize, b: usize) {
         if let Some(surf) = self.surfaces.get_mut(surface) {
-            if a < surf.vertices.len() && b < surf.vertices.len() {
-                if !surf
+            if a < surf.vertices.len()
+                && b < surf.vertices.len()
+                && !surf
                     .breaklines
                     .iter()
                     .any(|&(x, y)| (x == a && y == b) || (x == b && y == a))
-                {
-                    surf.breaklines.push((a, b));
-                }
+            {
+                surf.breaklines.push((a, b));
             }
         }
     }
@@ -488,7 +488,8 @@ impl TruckBackend {
                         let d2 = (x - lx).powi(2) + (y - ly).powi(2);
                         if d2 < 36.0 && lz < best_z {
                             best_z = lz;
-                            result = Some(HitObject::Breakline(si, bi));
+                            let _ = (si, bi); // indices currently unused
+                            result = Some(HitObject::Breakline);
                         }
                     }
                 }
@@ -510,7 +511,8 @@ impl TruckBackend {
                             let d2 = (x - lx).powi(2) + (y - ly).powi(2);
                             if d2 < 36.0 && lz < best_z {
                                 best_z = lz;
-                                result = Some(HitObject::Boundary(si, bi));
+                                let _ = (si, bi);
+                                result = Some(HitObject::Boundary);
                             }
                         }
                     }
@@ -532,7 +534,8 @@ impl TruckBackend {
                             let d2 = (x - lx).powi(2) + (y - ly).powi(2);
                             if d2 < 36.0 && lz < best_z {
                                 best_z = lz;
-                                result = Some(HitObject::Boundary(si, bound.len() - 1));
+                                let _ = (si, bound.len() - 1);
+                                result = Some(HitObject::Boundary);
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- remove unused fields from `HitObject` variants
- collapse nested `if` in `add_breakline`
- update hit test logic to match new `HitObject` types

## Testing
- `cargo clippy -p survey_cad_truck_gui --all-targets -- --no-deps -D warnings`
- `cargo test -p survey_cad_truck_gui --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68680ae88f548328b8147b0056de402b