### PR TITLE
Add streaming point cloud import with progress

### DIFF
--- a/survey_cad/src/io/e57.rs
+++ b/survey_cad/src/io/e57.rs
@@ -22,6 +22,37 @@ pub fn read_points_e57(path: &str) -> io::Result<Vec<Point3>> {
     Ok(pts)
 }
 
+/// Reads an E57 file while reporting progress. The callback receives a fraction
+/// between 0.0 and 1.0 and should return `true` to continue or `false` to cancel.
+pub fn read_points_e57_progress<F>(path: &str, mut progress: F) -> io::Result<Vec<Point3>>
+where
+    F: FnMut(f32) -> bool,
+{
+    let mut reader =
+        E57Reader::from_file(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let pcs = reader.pointclouds();
+    let total: u64 = pcs.iter().map(|pc| pc.records).sum();
+    let mut pts = Vec::with_capacity(total as usize);
+    let mut read = 0u64;
+    for pc in pcs {
+        let mut iter = reader
+            .pointcloud_simple(&pc)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        for p in &mut iter {
+            let p = p.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            if let e57::CartesianCoordinate::Valid { x, y, z } = p.cartesian {
+                pts.push(Point3::new(x, y, z));
+            }
+            read += 1;
+            if read % 1000 == 0 && !progress(read as f32 / total as f32) {
+                return Ok(pts);
+            }
+        }
+    }
+    progress(1.0);
+    Ok(pts)
+}
+
 /// Writes a list of 3D points to an E57 file.
 pub fn write_points_e57(path: &str, points: &[Point3]) -> io::Result<()> {
     let guid = Uuid::new_v4().to_string();

--- a/survey_cad/src/io/las.rs
+++ b/survey_cad/src/io/las.rs
@@ -14,6 +14,27 @@ pub fn read_points_las(path: &str) -> io::Result<Vec<Point3>> {
     Ok(pts)
 }
 
+/// Reads a LAS file reporting progress. The callback receives values in the
+/// range 0.0..=1.0 and should return `true` to continue or `false` to cancel.
+pub fn read_points_las_progress<F>(path: &str, mut progress: F) -> io::Result<Vec<Point3>>
+where
+    F: FnMut(f32) -> bool,
+{
+    let mut reader =
+        Reader::from_path(path).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let total = reader.header().number_of_points();
+    let mut pts = Vec::with_capacity(total as usize);
+    for (i, wrapped) in reader.points().enumerate() {
+        let p: LasPoint = wrapped.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        pts.push(Point3::new(p.x, p.y, p.z));
+        if i % 1000 == 0 && !progress(i as f32 / total as f32) {
+            break;
+        }
+    }
+    progress(1.0);
+    Ok(pts)
+}
+
 /// Writes points to a LAS or LAZ file. Compression is inferred from the
 /// file extension when the `laz` feature of the `las` crate is enabled.
 pub fn write_points_las(path: &str, points: &[Point3]) -> io::Result<()> {

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -123,6 +123,7 @@ struct Config {
     window_height: u32,
     last_open_dir: Option<String>,
     snap: SnapPrefs,
+    auto_tin: bool,
     #[serde(default)]
     quick_scripts: [String; 3],
 }
@@ -134,6 +135,7 @@ impl Default for Config {
             window_height: 600,
             last_open_dir: None,
             snap: SnapPrefs::default(),
+            auto_tin: false,
             quick_scripts: Default::default(),
         }
     }
@@ -6240,6 +6242,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let point_db = point_db.clone();
         let render_image = render_image.clone();
         let backend_render = backend.clone();
+        let config_ref = config.clone();
+        let surfaces_ref = surfaces.clone();
         app.on_import_las(move || {
             if let Some(path) = rfd::FileDialog::new()
                 .add_filter("LAS", &["las", "laz"])
@@ -6247,34 +6251,67 @@ fn main() -> Result<(), slint::PlatformError> {
             {
                 if let Some(p) = path.to_str() {
                     #[cfg(feature = "las")]
-                    match survey_cad::io::las::read_points_las(p) {
-                        Ok(pts3) => {
-                            let len = {
-                                let mut db = point_db.borrow_mut();
-                                db.clear();
-                                db.extend(pts3.into_iter().map(|p3| Point::new(p3.x, p3.y)));
-                                db.len()
-                            };
-                            if let Some(app) = weak.upgrade() {
-                                app.set_status(SharedString::from(format!(
-                                    "Imported {len} points"
-                                )));
-                                if app.get_workspace_mode() == 0 {
-                                    app.set_workspace_image(render_image());
-                                } else {
-                                    let image = backend_render.borrow_mut().render();
-                                    app.set_workspace_texture(image);
+                    {
+                        use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+                        let dlg = ImportProgressDialog::new().unwrap();
+                        dlg.set_message(SharedString::from("Importing LAS"));
+                        dlg.set_progress(0.0);
+                        let cancel = Arc::new(AtomicBool::new(false));
+                        let cancel_dlg = cancel.clone();
+                        let dlg_weak = dlg.as_weak();
+                        dlg.on_cancel(move || { cancel_dlg.store(true, Ordering::SeqCst); });
+                        dlg.show().unwrap();
+                        let weak_app = weak.clone();
+                        let point_db = point_db.clone();
+                        let render_image = render_image.clone();
+                        let backend_render = backend_render.clone();
+                        let config = config_ref.clone();
+                        let surfaces = surfaces_ref.clone();
+                        std::thread::spawn(move || {
+                            let res = survey_cad::io::las::read_points_las_progress(p, |prog| {
+                                let dweak = dlg_weak.clone();
+                                let _ = slint::invoke_from_event_loop(move || {
+                                    if let Some(d) = dweak.upgrade() {
+                                        d.set_progress(prog.into());
+                                    }
+                                });
+                                !cancel.load(Ordering::SeqCst)
+                            });
+                            slint::invoke_from_event_loop(move || {
+                                if let Some(d) = dlg_weak.upgrade() { let _ = d.hide(); }
+                            }).unwrap();
+                            match res {
+                                Ok(pts3) => {
+                                    let len = {
+                                        let mut db = point_db.borrow_mut();
+                                        db.clear();
+                                        db.extend(pts3.iter().map(|p3| Point::new(p3.x, p3.y)));
+                                        db.len()
+                                    };
+                                    if config.borrow().auto_tin && len >= 3 {
+                                        let verts: Vec<ScPoint3> = pts3.iter().map(|p| ScPoint3::new(p.x, p.y, p.z)).collect();
+                                        let tin = survey_cad::dtm::Tin::from_points(verts.clone());
+                                        backend_render.borrow_mut().add_surface(&verts, &tin.triangles);
+                                        surfaces.borrow_mut().push(tin);
+                                    }
+                                    if let Some(app) = weak_app.upgrade() {
+                                        app.set_status(SharedString::from(format!("Imported {len} points")));
+                                        if app.get_workspace_mode() == 0 {
+                                            app.set_workspace_image(render_image());
+                                        } else {
+                                            let image = backend_render.borrow_mut().render();
+                                            app.set_workspace_texture(image);
+                                        }
+                                        app.window().request_redraw();
+                                    }
                                 }
-                                app.window().request_redraw();
+                                Err(e) => {
+                                    if let Some(app) = weak_app.upgrade() {
+                                        app.set_status(SharedString::from(format!("Failed to import: {e}")));
+                                    }
+                                }
                             }
-                        }
-                        Err(e) => {
-                            if let Some(app) = weak.upgrade() {
-                                app.set_status(SharedString::from(format!(
-                                    "Failed to import: {e}"
-                                )));
-                            }
-                        }
+                        });
                     }
                     #[cfg(not(feature = "las"))]
                     if let Some(app) = weak.upgrade() {
@@ -6290,6 +6327,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let point_db = point_db.clone();
         let render_image = render_image.clone();
         let backend_render = backend.clone();
+        let config_ref = config.clone();
+        let surfaces_ref = surfaces.clone();
         app.on_import_e57(move || {
             if let Some(path) = rfd::FileDialog::new()
                 .add_filter("E57", &["e57"])
@@ -6297,34 +6336,67 @@ fn main() -> Result<(), slint::PlatformError> {
             {
                 if let Some(p) = path.to_str() {
                     #[cfg(feature = "e57")]
-                    match survey_cad::io::e57::read_points_e57(p) {
-                        Ok(pts3) => {
-                            let len = {
-                                let mut db = point_db.borrow_mut();
-                                db.clear();
-                                db.extend(pts3.into_iter().map(|p3| Point::new(p3.x, p3.y)));
-                                db.len()
-                            };
-                            if let Some(app) = weak.upgrade() {
-                                app.set_status(SharedString::from(format!(
-                                    "Imported {len} points"
-                                )));
-                                if app.get_workspace_mode() == 0 {
-                                    app.set_workspace_image(render_image());
-                                } else {
-                                    let image = backend_render.borrow_mut().render();
-                                    app.set_workspace_texture(image);
+                    {
+                        use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+                        let dlg = ImportProgressDialog::new().unwrap();
+                        dlg.set_message(SharedString::from("Importing E57"));
+                        dlg.set_progress(0.0);
+                        let cancel = Arc::new(AtomicBool::new(false));
+                        let cancel_dlg = cancel.clone();
+                        let dlg_weak = dlg.as_weak();
+                        dlg.on_cancel(move || { cancel_dlg.store(true, Ordering::SeqCst); });
+                        dlg.show().unwrap();
+                        let weak_app = weak.clone();
+                        let point_db = point_db.clone();
+                        let render_image = render_image.clone();
+                        let backend_render = backend_render.clone();
+                        let config = config_ref.clone();
+                        let surfaces = surfaces_ref.clone();
+                        std::thread::spawn(move || {
+                            let res = survey_cad::io::e57::read_points_e57_progress(p, |prog| {
+                                let dweak = dlg_weak.clone();
+                                let _ = slint::invoke_from_event_loop(move || {
+                                    if let Some(d) = dweak.upgrade() {
+                                        d.set_progress(prog.into());
+                                    }
+                                });
+                                !cancel.load(Ordering::SeqCst)
+                            });
+                            slint::invoke_from_event_loop(move || {
+                                if let Some(d) = dlg_weak.upgrade() { let _ = d.hide(); }
+                            }).unwrap();
+                            match res {
+                                Ok(pts3) => {
+                                    let len = {
+                                        let mut db = point_db.borrow_mut();
+                                        db.clear();
+                                        db.extend(pts3.iter().map(|p3| Point::new(p3.x, p3.y)));
+                                        db.len()
+                                    };
+                                    if config.borrow().auto_tin && len >= 3 {
+                                        let verts: Vec<ScPoint3> = pts3.iter().map(|p| ScPoint3::new(p.x, p.y, p.z)).collect();
+                                        let tin = survey_cad::dtm::Tin::from_points(verts.clone());
+                                        backend_render.borrow_mut().add_surface(&verts, &tin.triangles);
+                                        surfaces.borrow_mut().push(tin);
+                                    }
+                                    if let Some(app) = weak_app.upgrade() {
+                                        app.set_status(SharedString::from(format!("Imported {len} points")));
+                                        if app.get_workspace_mode() == 0 {
+                                            app.set_workspace_image(render_image());
+                                        } else {
+                                            let image = backend_render.borrow_mut().render();
+                                            app.set_workspace_texture(image);
+                                        }
+                                        app.window().request_redraw();
+                                    }
                                 }
-                                app.window().request_redraw();
+                                Err(e) => {
+                                    if let Some(app) = weak_app.upgrade() {
+                                        app.set_status(SharedString::from(format!("Failed to import: {e}")));
+                                    }
+                                }
                             }
-                        }
-                        Err(e) => {
-                            if let Some(app) = weak.upgrade() {
-                                app.set_status(SharedString::from(format!(
-                                    "Failed to import: {e}"
-                                )));
-                            }
-                        }
+                        });
                     }
                     #[cfg(not(feature = "e57"))]
                     if let Some(app) = weak.upgrade() {
@@ -7585,6 +7657,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let render_image = render_image.clone();
         let backend_render = backend.clone();
         let workspace_crs = workspace_crs.clone();
+        let config_ref = config.clone();
         app.on_settings(move || {
             let dlg = SettingsDialog::new().unwrap();
             let gs = grid_settings.borrow();
@@ -7593,6 +7666,7 @@ fn main() -> Result<(), slint::PlatformError> {
             dlg.set_color_g(SharedString::from(gs.color[1].to_string()));
             dlg.set_color_b(SharedString::from(gs.color[2].to_string()));
             dlg.set_show_grid(gs.visible);
+            dlg.set_auto_tin(config_ref.borrow().auto_tin);
             dlg.set_crs_epsg(SharedString::from(workspace_crs.borrow().to_string()));
             drop(gs);
             let dlg_weak = dlg.as_weak();
@@ -7601,6 +7675,7 @@ fn main() -> Result<(), slint::PlatformError> {
             let render_image = render_image.clone();
             let backend_render = backend_render.clone();
             let crs_ref = workspace_crs.clone();
+            let config_acc = config_ref.clone();
             dlg.on_accept(move || {
                 if let Some(d) = dlg_weak.upgrade() {
                     if let Ok(v) = d.get_spacing_value().parse::<f32>() {
@@ -7611,6 +7686,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let b = d.get_color_b().parse::<u8>().unwrap_or(60);
                     gs_ref.borrow_mut().color = [r, g, b];
                     gs_ref.borrow_mut().visible = d.get_show_grid();
+                    config_acc.borrow_mut().auto_tin = d.get_auto_tin();
                     if let Ok(epsg) = d.get_crs_epsg().parse::<u32>() {
                         *crs_ref.borrow_mut() = epsg;
                     }

--- a/survey_cad_truck_gui/ui/import_progress.slint
+++ b/survey_cad_truck_gui/ui/import_progress.slint
@@ -1,0 +1,18 @@
+import { Button, VerticalBox, ProgressIndicator } from "std-widgets.slint";
+
+export component ImportProgressDialog inherits Window {
+    in-out property <string> message;
+    in-out property <percent> progress;
+    callback cancel();
+    title: "Importing";
+    preferred-width: 300px;
+    VerticalBox {
+        spacing: 6px;
+        Text { color: #FFFFFF; text: root.message; }
+        ProgressIndicator {
+            indeterminate: root.progress <= 0%;
+            progress: root.progress;
+        }
+        Button { text: "Cancel"; clicked => { root.cancel(); } }
+    }
+}

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -4,6 +4,7 @@ export { LayerManager } from "layer_manager.slint";
 export { CrossSectionViewer } from "cross_section_viewer.slint";
 export { SuperelevationEditor } from "superelevation_editor.slint";
 export { EntityInspector } from "entity_inspector.slint";
+export { ImportProgressDialog } from "import_progress.slint";
 
 component Workspace2D inherits Rectangle {
     in-out property <image> image;
@@ -552,6 +553,7 @@ export component SettingsDialog inherits Window {
     in-out property <string> color_b;
     in-out property <string> crs_epsg;
     in-out property <bool> show_grid;
+    in-out property <bool> auto_tin;
     callback accept();
     callback cancel();
     title: "Workspace Settings";
@@ -568,6 +570,7 @@ export component SettingsDialog inherits Window {
             LineEdit { text <=> root.color_b; width: 40px; }
         }
         CheckBox { text: "Show Grid"; checked <=> root.show_grid; }
+        CheckBox { text: "Create TIN after Import"; checked <=> root.auto_tin; }
         HorizontalBox {
             Text { color: #FFFFFF; text: "EPSG:"; }
             LineEdit { text <=> root.crs_epsg; width: 80px; }


### PR DESCRIPTION
## Summary
- allow streaming LAS and E57 files with progress callback
- add option to create TIN automatically in settings
- display import progress dialog with cancel support

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo test -p survey_cad_truck_gui --no-run`


------
https://chatgpt.com/codex/tasks/task_e_686bd2679a008328a19d154e703f487f