### PR TITLE
Fix path lifetime for background imports

### DIFF
--- a/survey_cad/Cargo.toml
+++ b/survey_cad/Cargo.toml
@@ -34,7 +34,7 @@ gdal = { version = "0.18", optional = true }
 nalgebra = { version = "0.32", default-features = false, features = ["std"] }
 tempfile = "3.10"
 fresnel = "0.1"
-uuid = { version = "1", optional = true }
+uuid = { version = "1", features = ["v4"], optional = true }
 genpdf = { version = "0.2", optional = true }
 umya-spreadsheet = { version = "1.1", optional = true }
 geo-types = "0.7"

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -4145,7 +4145,8 @@ fn main() -> Result<(), slint::PlatformError> {
                 config_rc.borrow_mut().last_open_dir = last_dir.borrow().clone();
                 save_config(&config_rc.borrow());
                 if let Some(p) = path.to_str() {
-                    match read_project_json(p) {
+                    let p = p.to_string();
+                    match read_project_json(&p) {
                         Ok(proj) => {
                             *workspace_crs.borrow_mut() = proj.crs_epsg;
                             if let Some(idx) = crs_entries_rc
@@ -6545,6 +6546,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 .pick_file()
             {
                 if let Some(p) = path.to_str() {
+                    let p = p.to_string();
                     #[cfg(feature = "las")]
                     {
                         use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
@@ -6561,7 +6563,7 @@ fn main() -> Result<(), slint::PlatformError> {
 
                         let (tx, rx) = mpsc::channel();
                         std::thread::spawn(move || {
-                            let res = survey_cad::io::las::read_points_las_progress(p, |prog| {
+                            let res = survey_cad::io::las::read_points_las_progress(&p, |prog| {
                                 let dweak = dlg_weak.clone();
                                 let _ = slint::invoke_from_event_loop(move || {
                                     if let Some(d) = dweak.upgrade() {
@@ -6655,6 +6657,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 .pick_file()
             {
                 if let Some(p) = path.to_str() {
+                    let p = p.to_string();
                     #[cfg(feature = "e57")]
                     {
                         use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
@@ -6671,7 +6674,7 @@ fn main() -> Result<(), slint::PlatformError> {
 
                         let (tx, rx) = mpsc::channel();
                         std::thread::spawn(move || {
-                            let res = survey_cad::io::e57::read_points_e57_progress(p, |prog| {
+                            let res = survey_cad::io::e57::read_points_e57_progress(&p, |prog| {
                                 let dweak = dlg_weak.clone();
                                 let _ = slint::invoke_from_event_loop(move || {
                                     if let Some(d) = dweak.upgrade() {


### PR DESCRIPTION
## Summary
- own the dialog path before spawning threads so it outlives the closure
- enable uuid `v4` feature for e57 support

## Testing
- `cargo check -p survey_cad_truck_gui --features las,e57`

------
https://chatgpt.com/codex/tasks/task_e_686bf4345cec83288a2d90af7804fa61