### PR TITLE
Add plugin panel and scripting hooks

### DIFF
--- a/survey_cad_python/README.md
+++ b/survey_cad_python/README.md
@@ -22,3 +22,10 @@ a = Point(0.0, 0.0)
 b = Point(3.0, 4.0)
 print(station_distance(a, b))
 ```
+
+## Using in GUI Plugins
+
+The `survey_cad_truck_gui` application exposes this module to Python scripts
+loaded from the `macros/` folder. Scripts can access geometry through the
+`Point` class and call functions like `station_distance` while operating on the
+entities and view parameters provided by the GUI.

--- a/survey_cad_truck_gui/README.md
+++ b/survey_cad_truck_gui/README.md
@@ -26,6 +26,29 @@ The main window now contains a simple command line interface below the
 workspace. Type commands such as `point`, `line`, `undo` or `redo` and press
 Enter to execute them. Entered commands are kept in a history list.
 
+## Scripts and Plugins
+
+Python scripts located in the `macros/` directory can be executed from the
+**Plugins Panel** available through the `Macro` menu. When a script runs the
+following variables are provided:
+
+- `survey_cad_python` &ndash; bindings to the core library.
+- `points`, `lines`, `surfaces` &ndash; all entities in the current project.
+- `selected_points`, `selected_lines` &ndash; the current selection.
+- `view` &ndash; a dictionary with `offset` and `zoom` describing the active view.
+
+Scripts can use these values to query or modify the project. An example script:
+
+```python
+from survey_cad_python import Point
+
+for idx in selected_points:
+    p = points[idx]
+    print("Selected:", p.x, p.y)
+
+print("Zoom:", view["zoom"])
+```
+
 ## Fonts
 
 This application bundles the `DejaVuSans.ttf` font located in the `assets/`

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -645,6 +645,10 @@ fn run_python_file(
     point_db: &Rc<RefCell<PointDatabase>>,
     lines_ref: &Rc<RefCell<Vec<(Point, Point)>>>,
     surfaces_ref: &Rc<RefCell<Vec<Tin>>>,
+    selected_points: &Rc<RefCell<Vec<usize>>>,
+    selected_lines: &Rc<RefCell<Vec<(Point, Point)>>>,
+    offset: &Rc<RefCell<Vec2>>,
+    zoom: &Rc<RefCell<f32>>,
 ) {
     match std::fs::read_to_string(path) {
         Ok(code) => {
@@ -685,11 +689,32 @@ fn run_python_file(
                     })
                     .collect::<PyResult<_>>()?;
 
+                let selected_pts: Vec<usize> = selected_points.borrow().clone();
+                let selected_lines_py: Vec<(Py<survey_cad_python::Point>, Py<survey_cad_python::Point>)> =
+                    selected_lines
+                        .borrow()
+                        .iter()
+                        .map(|(a, b)| {
+                            Ok((
+                                Py::new(py, survey_cad_python::Point::new(a.x, a.y))?,
+                                Py::new(py, survey_cad_python::Point::new(b.x, b.y))?,
+                            ))
+                        })
+                        .collect::<PyResult<_>>()?;
+
+                let view = PyDict::new_bound(py);
+                let off = offset.borrow();
+                view.set_item("offset", (off.x, off.y))?;
+                view.set_item("zoom", *zoom.borrow())?;
+
                 let globals = PyDict::new_bound(py);
                 globals.set_item("survey_cad_python", module)?;
                 globals.set_item("points", pts)?;
                 globals.set_item("lines", lines_py)?;
                 globals.set_item("surfaces", surfs)?;
+                globals.set_item("selected_points", selected_pts)?;
+                globals.set_item("selected_lines", selected_lines_py)?;
+                globals.set_item("view", view)?;
 
                 py.run_bound(&code, Some(&globals), None)
             });
@@ -2794,6 +2819,10 @@ fn main() -> Result<(), slint::PlatformError> {
         let backend_render = backend.clone();
         let render_image = render_image.clone();
         let cfg = config.clone();
+        let selected_indices_ml = selected_indices.clone();
+        let selected_lines_ml = selected_lines.clone();
+        let offset_ml = offset.clone();
+        let zoom_ml = zoom.clone();
         app.on_show_macro_list(move || {
             let mut items = Vec::new();
             if let Ok(rd) = fs::read_dir(MACRO_DIR) {
@@ -2823,11 +2852,25 @@ fn main() -> Result<(), slint::PlatformError> {
             let backend_run = backend_render.clone();
             let render_image_run = render_image.clone();
             let items_run = items.clone();
+            let selected_indices = selected_indices_ml.clone();
+            let selected_lines = selected_lines_ml.clone();
+            let offset = offset_ml.clone();
+            let zoom = zoom_ml.clone();
             dlg.on_run(move |idx| {
                 if let Some(name) = items_run.get(idx as usize) {
                     let path = Path::new(MACRO_DIR).join(name.as_str());
                     if name.ends_with(".py") {
-                        run_python_file(&path, &weak_run, &point_db_run, &lines_run, &surfaces_run);
+                        run_python_file(
+                            &path,
+                            &weak_run,
+                            &point_db_run,
+                            &lines_run,
+                            &surfaces_run,
+                            &selected_indices.clone(),
+                            &selected_lines.clone(),
+                            &offset.clone(),
+                            &zoom.clone(),
+                        );
                     } else {
                         let ctx = MacroContext {
                             playing: playing_run.clone(),
@@ -2870,6 +2913,69 @@ fn main() -> Result<(), slint::PlatformError> {
 
     {
         let weak = app.as_weak();
+        let point_db = point_db.clone();
+        let lines_ref = lines.clone();
+        let surfaces_ref = surfaces.clone();
+        let selected_indices_ref = selected_indices.clone();
+        let selected_lines_ref = selected_lines.clone();
+        let offset_ref = offset.clone();
+        let zoom_ref = zoom.clone();
+        app.on_open_script_panel(move || {
+            let mut items = Vec::new();
+            if let Ok(rd) = fs::read_dir(MACRO_DIR) {
+                for ent in rd.flatten() {
+                    if let Some(ext) = ent.path().extension().and_then(|e| e.to_str()) {
+                        if ext == "py" {
+                            if let Some(n) = ent.file_name().to_str() {
+                                items.push(SharedString::from(n.to_string()));
+                            }
+                        }
+                    }
+                }
+            }
+
+            let panel = ScriptPanel::new().unwrap();
+            panel.set_files(Rc::new(VecModel::from(items.clone())).into());
+            panel.set_selected_index(0);
+            let weak_run = weak.clone();
+            let point_db_run = point_db.clone();
+            let lines_run = lines_ref.clone();
+            let surfaces_run = surfaces_ref.clone();
+            let panel_weak = panel.as_weak();
+            let items_run = items.clone();
+            let selected_indices_run = selected_indices_ref.clone();
+            let selected_lines_run = selected_lines_ref.clone();
+            let offset_run = offset_ref.clone();
+            let zoom_run = zoom_ref.clone();
+            panel.on_run(move |idx| {
+                if let Some(name) = items_run.get(idx as usize) {
+                    let path = Path::new(MACRO_DIR).join(name.as_str());
+                    run_python_file(
+                        &path,
+                        &weak_run,
+                        &point_db_run,
+                        &lines_run,
+                        &surfaces_run,
+                        &selected_indices_run,
+                        &selected_lines_run,
+                        &offset_run,
+                        &zoom_run,
+                    );
+                }
+            });
+
+            panel.on_close(move || {
+                if let Some(p) = panel_weak.upgrade() {
+                    let _ = p.hide();
+                }
+            });
+
+            panel.show().unwrap();
+        });
+    }
+
+    {
+        let weak = app.as_weak();
         let cfg = config.clone();
         let point_db = point_db.clone();
         let lines_ref = lines.clone();
@@ -2880,6 +2986,10 @@ fn main() -> Result<(), slint::PlatformError> {
         let line_styles = line_style_indices.clone();
         let backend_render = backend.clone();
         let render_image = render_image.clone();
+        let selected_indices = selected_indices.clone();
+        let selected_lines = selected_lines.clone();
+        let offset = offset.clone();
+        let zoom = zoom.clone();
         app.on_run_quick_script(move |slot| {
             let scripts = &cfg.borrow().quick_scripts;
             if let Some(name) = scripts.get(slot as usize) {
@@ -2888,7 +2998,17 @@ fn main() -> Result<(), slint::PlatformError> {
                 }
                 let path = Path::new(MACRO_DIR).join(name);
                 if name.ends_with(".py") {
-                    run_python_file(&path, &weak, &point_db, &lines_ref, &surfaces_ref);
+                    run_python_file(
+                        &path,
+                        &weak,
+                        &point_db,
+                        &lines_ref,
+                        &surfaces_ref,
+                        &selected_indices,
+                        &selected_lines,
+                        &offset,
+                        &zoom,
+                    );
                 } else {
                     let ctx = MacroContext {
                         playing: playing.clone(),

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -5,6 +5,7 @@ export { CrossSectionViewer } from "cross_section_viewer.slint";
 export { SuperelevationEditor } from "superelevation_editor.slint";
 export { EntityInspector } from "entity_inspector.slint";
 export { ImportProgressDialog } from "import_progress.slint";
+export { ScriptPanel } from "script_panel.slint";
 
 component Ribbon inherits TabWidget {
     in property <[string]> crs_list;
@@ -931,6 +932,7 @@ export component MainWindow inherits Window {
     callback macro_play();
     callback run_python_script();
     callback show_macro_list();
+    callback open_script_panel();
     callback run_quick_script(int);
     callback undo();
     callback redo();
@@ -1046,6 +1048,7 @@ export component MainWindow inherits Window {
             MenuItem { title: "Play"; activated => { root.macro_play(); } }
             MenuItem { title: "Run Python Script"; activated => { root.run_python_script(); } }
             MenuItem { title: "Scripts..."; activated => { root.show_macro_list(); } }
+            MenuItem { title: "Plugins Panel"; activated => { root.open_script_panel(); } }
         }
     }
 

--- a/survey_cad_truck_gui/ui/script_panel.slint
+++ b/survey_cad_truck_gui/ui/script_panel.slint
@@ -1,0 +1,29 @@
+import { Button, VerticalBox, HorizontalBox, ListView } from "std-widgets.slint";
+
+export component ScriptPanel inherits Window {
+    in-out property <[string]> files;
+    in-out property <int> selected_index;
+    callback run(int);
+    callback close();
+    title: "Scripts";
+    preferred-width: 300px;
+    preferred-height: 300px;
+    VerticalBox {
+        spacing: 4px;
+        ListView {
+            vertical-stretch: 1;
+            for f[i] in root.files : Rectangle {
+                property <bool> selected: root.selected_index == i;
+                background: selected ? #404040 : transparent;
+                height: 24px;
+                Text { color: #FFFFFF; text: f; }
+                TouchArea { width: 100%; height: 100%; clicked => { root.selected_index = i; } }
+            }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "Run"; clicked => { root.run(root.selected_index); } }
+            Button { text: "Close"; clicked => { root.close(); } }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ScriptPanel UI and callback hooks
- expose selections and view to Python scripts
- describe plugin scripting in READMEs

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_686d0630b20c832893c2c9583b1ae2f6