### PR TITLE
Fix unused imports in truck-geotrait

### DIFF
--- a/truck-master/truck-geotrait/src/traits/curve.rs
+++ b/truck-master/truck-geotrait/src/traits/curve.rs
@@ -1,11 +1,10 @@
 use super::*;
 use std::fmt::Debug;
 use thiserror::Error;
-use truck_base::{
-    assert_near,
-    cgmath64::{Point2, Point3, Vector2, Vector3},
-    tolerance::Tolerance,
-};
+use truck_base::cgmath64::{Point2, Point3, Vector2, Vector3};
+#[cfg(test)]
+use truck_base::{assert_near, tolerance::Tolerance};
+#[cfg(test)]
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 /// Parametric curves


### PR DESCRIPTION
## Summary
- avoid unused imports in `truck-geotrait`

## Testing
- `cargo check --release` in `truck-master`
- `cargo check --release`

------
https://chatgpt.com/codex/tasks/task_e_686d161a2ff08328831153e3823ccf0c