### PR TITLE
Add 3D snapping support

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -99,6 +99,8 @@ struct SnapPrefs {
     snap_midpoints: bool,
     snap_intersections: bool,
     snap_nearest: bool,
+    snap_surfaces: bool,
+    snap_solids: bool,
     snap_tolerance: f32,
 }
 
@@ -112,6 +114,8 @@ impl Default for SnapPrefs {
             snap_midpoints: true,
             snap_intersections: true,
             snap_nearest: true,
+            snap_surfaces: true,
+            snap_solids: true,
             snap_tolerance: 5.0,
         }
     }
@@ -2312,6 +2316,8 @@ fn main() -> Result<(), slint::PlatformError> {
         app.set_snap_intersections(p.snap_intersections);
         app.set_snap_midpoints(p.snap_midpoints);
         app.set_snap_nearest(p.snap_nearest);
+        app.set_snap_surfaces(p.snap_surfaces);
+        app.set_snap_solids(p.snap_solids);
         app.set_snap_tolerance(p.snap_tolerance);
     }
     let last_folder = Rc::new(RefCell::new(config.borrow().last_open_dir.clone()));
@@ -3714,6 +3720,8 @@ fn main() -> Result<(), slint::PlatformError> {
                                 snap_midpoints: app.get_snap_midpoints(),
                                 snap_intersections: app.get_snap_intersections(),
                                 snap_nearest: app.get_snap_nearest(),
+                                snap_surfaces: app.get_snap_surfaces(),
+                                snap_solids: app.get_snap_solids(),
                             };
                             if let Some(sp) = snap::resolve_snap(
                                 p,
@@ -4081,9 +4089,31 @@ fn main() -> Result<(), slint::PlatformError> {
             *last = (x as f64, y as f64);
             if let Some(i) = *active_handle_ref.borrow() {
                 if let Some(pos) = backend_move.borrow().handle_position(i) {
-                    let new_p = backend_move
+                    let mut new_p = backend_move
                         .borrow()
                         .screen_to_plane(x as f64, y as f64, pos.z);
+                    if let Some(app_ref) = weak.upgrade() {
+                        if app_ref.get_snap_to_entities() {
+                            let scene = backend_move.borrow().snap_scene();
+                            let opts = snap::SnapOptions {
+                                snap_points: app_ref.get_snap_points(),
+                                snap_endpoints: app_ref.get_snap_endpoints(),
+                                snap_midpoints: app_ref.get_snap_midpoints(),
+                                snap_intersections: app_ref.get_snap_intersections(),
+                                snap_nearest: app_ref.get_snap_nearest(),
+                                snap_surfaces: app_ref.get_snap_surfaces(),
+                                snap_solids: app_ref.get_snap_solids(),
+                            };
+                            if let Some(sp) = snap::resolve_snap_3d(
+                                new_p,
+                                &scene,
+                                app_ref.get_snap_tolerance() as f64,
+                                opts,
+                            ) {
+                                new_p = sp;
+                            }
+                        }
+                    }
                     backend_move.borrow_mut().move_handle(i, new_p);
                     if let Some(app) = weak.upgrade() {
                         let image = backend_move.borrow_mut().render();
@@ -4162,6 +4192,8 @@ fn main() -> Result<(), slint::PlatformError> {
                             snap_midpoints: app.get_snap_midpoints(),
                             snap_intersections: app.get_snap_intersections(),
                             snap_nearest: app.get_snap_nearest(),
+                            snap_surfaces: app.get_snap_surfaces(),
+                            snap_solids: app.get_snap_solids(),
                         };
                         if let Some(sp) = snap::resolve_snap(
                             p,
@@ -8310,6 +8342,8 @@ fn main() -> Result<(), slint::PlatformError> {
             dlg.set_snap_midpoints(prefs.snap_midpoints);
             dlg.set_snap_intersections(prefs.snap_intersections);
             dlg.set_snap_nearest(prefs.snap_nearest);
+            dlg.set_snap_surfaces(prefs.snap_surfaces);
+            dlg.set_snap_solids(prefs.snap_solids);
             drop(prefs);
             let dlg_weak = dlg.as_weak();
             let prefs_ref = snap_prefs_ref.clone();
@@ -8331,12 +8365,18 @@ fn main() -> Result<(), slint::PlatformError> {
                     cfg_ref.borrow_mut().snap.snap_intersections = d.get_snap_intersections();
                     prefs_ref.borrow_mut().snap_nearest = d.get_snap_nearest();
                     cfg_ref.borrow_mut().snap.snap_nearest = d.get_snap_nearest();
+                    prefs_ref.borrow_mut().snap_surfaces = d.get_snap_surfaces();
+                    cfg_ref.borrow_mut().snap.snap_surfaces = d.get_snap_surfaces();
+                    prefs_ref.borrow_mut().snap_solids = d.get_snap_solids();
+                    cfg_ref.borrow_mut().snap.snap_solids = d.get_snap_solids();
                     if let Some(a) = app_weak.upgrade() {
                         a.set_snap_points(d.get_snap_points());
                         a.set_snap_endpoints(d.get_snap_endpoints());
                         a.set_snap_midpoints(d.get_snap_midpoints());
                         a.set_snap_intersections(d.get_snap_intersections());
                         a.set_snap_nearest(d.get_snap_nearest());
+                        a.set_snap_surfaces(d.get_snap_surfaces());
+                        a.set_snap_solids(d.get_snap_solids());
                         if let Ok(v) = d.get_tolerance().parse::<f32>() {
                             a.set_snap_tolerance(v);
                         }
@@ -8502,6 +8542,8 @@ fn main() -> Result<(), slint::PlatformError> {
                             snap_midpoints: app.get_snap_midpoints(),
                             snap_intersections: app.get_snap_intersections(),
                             snap_nearest: app.get_snap_nearest(),
+                            snap_surfaces: app.get_snap_surfaces(),
+                            snap_solids: app.get_snap_solids(),
                         };
                         if let Some(sp) = snap::resolve_snap(
                             p,
@@ -8616,6 +8658,8 @@ fn main() -> Result<(), slint::PlatformError> {
                             snap_midpoints: app.get_snap_midpoints(),
                             snap_intersections: app.get_snap_intersections(),
                             snap_nearest: app.get_snap_nearest(),
+                            snap_surfaces: app.get_snap_surfaces(),
+                            snap_solids: app.get_snap_solids(),
                         };
                         if let Some(sp) = snap::resolve_snap(
                             p,

--- a/survey_cad_truck_gui/src/snap.rs
+++ b/survey_cad_truck_gui/src/snap.rs
@@ -1,6 +1,8 @@
 use survey_cad::geometry::{Arc, Line, Point, Polyline};
 use survey_cad::io::DxfEntity;
 use survey_cad::snap::{snap_point_with_settings, SnapSettings};
+use truck_modeling::base::{Point3, Vector3};
+use truck_modeling::topology::Solid;
 
 pub struct Scene<'a> {
     pub points: &'a [Point],
@@ -17,6 +19,8 @@ pub struct SnapOptions {
     pub snap_midpoints: bool,
     pub snap_intersections: bool,
     pub snap_nearest: bool,
+    pub snap_surfaces: bool,
+    pub snap_solids: bool,
 }
 
 pub fn resolve_snap(
@@ -55,4 +59,88 @@ pub fn resolve_snap(
         return None;
     }
     snap_point_with_settings(target, &ents, tol, settings)
+}
+
+pub struct Scene3D {
+    pub points: Vec<Point3>,
+    pub lines: Vec<(Point3, Point3)>,
+    pub surface_vertices: Vec<Point3>,
+    pub solid_vertices: Vec<Point3>,
+}
+
+fn distance3(a: Point3, b: Point3) -> f64 {
+    ((a.x - b.x).powi(2) + (a.y - b.y).powi(2) + (a.z - b.z).powi(2)).sqrt()
+}
+
+pub fn resolve_snap_3d(target: Point3, scene: &Scene3D, tol: f64, opts: SnapOptions) -> Option<Point3> {
+    let mut best = None;
+    let mut best_dist = tol;
+
+    if opts.snap_points {
+        for p in &scene.points {
+            let d = distance3(*p, target);
+            if d < best_dist {
+                best_dist = d;
+                best = Some(*p);
+            }
+        }
+        if opts.snap_surfaces {
+            for p in &scene.surface_vertices {
+                let d = distance3(*p, target);
+                if d < best_dist {
+                    best_dist = d;
+                    best = Some(*p);
+                }
+            }
+        }
+        if opts.snap_solids {
+            for p in &scene.solid_vertices {
+                let d = distance3(*p, target);
+                if d < best_dist {
+                    best_dist = d;
+                    best = Some(*p);
+                }
+            }
+        }
+    }
+
+    if opts.snap_endpoints || opts.snap_midpoints || opts.snap_nearest {
+        for (a, b) in &scene.lines {
+            if opts.snap_endpoints {
+                let da = distance3(*a, target);
+                if da < best_dist {
+                    best_dist = da;
+                    best = Some(*a);
+                }
+                let db = distance3(*b, target);
+                if db < best_dist {
+                    best_dist = db;
+                    best = Some(*b);
+                }
+            }
+            if opts.snap_midpoints {
+                let mid = Point3::new((a.x + b.x) / 2.0, (a.y + b.y) / 2.0, (a.z + b.z) / 2.0);
+                let d = distance3(mid, target);
+                if d < best_dist {
+                    best_dist = d;
+                    best = Some(mid);
+                }
+            }
+            if opts.snap_nearest {
+                let ab = Vector3::new(b.x - a.x, b.y - a.y, b.z - a.z);
+                let ap = Vector3::new(target.x - a.x, target.y - a.y, target.z - a.z);
+                let t = ab.dot(ap) / ab.magnitude2();
+                if (0.0..=1.0).contains(&t) {
+                    let p = Point3::new(a.x + ab.x * t, a.y + ab.y * t, a.z + ab.z * t);
+                    let d = distance3(p, target);
+                    if d < best_dist {
+                        best_dist = d;
+                        best = Some(p);
+                    }
+                }
+            }
+        }
+    }
+
+    best
 }

--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -2,6 +2,7 @@ use slint::Image;
 use truck_cad_engine::TruckCadEngine;
 use truck_modeling::base::{Point3, Vector4};
 use truck_modeling::topology::Solid;
+use truck_meshalgo::prelude::*;
 
 pub enum HitObject {
     Point(usize),
@@ -35,6 +36,7 @@ pub struct TruckBackend {
     lines: Vec<(Point3, Point3, Vector4, f32)>,
     dimensions: Vec<(Point3, Point3)>,
     surfaces: Vec<SurfaceData>,
+    solids: Vec<Vec<Point3>>,
     handles: Option<(HandleTarget, Vec<usize>)>,
     hover_surface: Option<usize>,
     hover_handle: Option<usize>,
@@ -54,6 +56,7 @@ impl TruckBackend {
             lines: Vec::new(),
             dimensions: Vec::new(),
             surfaces: Vec::new(),
+            solids: Vec::new(),
             handles: None,
             hover_surface: None,
             hover_handle: None,
@@ -211,6 +214,8 @@ impl TruckBackend {
     }
 
     pub fn add_solid(&mut self, solid: Solid) {
+        let mesh = solid.triangulation(0.01).to_polygon();
+        self.solids.push(mesh.positions().clone());
         self.engine.add_solid(solid);
     }
 
@@ -345,6 +350,7 @@ impl TruckBackend {
         self.lines.clear();
         self.dimensions.clear();
         self.surfaces.clear();
+        self.solids.clear();
         if let Some((_, handles)) = self.handles.take() {
             for id in handles {
                 self.engine.remove_point_marker(id);
@@ -479,6 +485,29 @@ impl TruckBackend {
             (z - orig.z) / dir.z
         };
         orig + dir * t
+    }
+
+    /// Collect geometry for snapping.
+    pub fn snap_scene(&self) -> crate::snap::Scene3D {
+        let lines = self
+            .lines
+            .iter()
+            .map(|(a, b, _, _)| (*a, *b))
+            .collect();
+        let mut surface_vertices = Vec::new();
+        for s in &self.surfaces {
+            surface_vertices.extend_from_slice(&s.vertices);
+        }
+        let mut solid_vertices = Vec::new();
+        for verts in &self.solids {
+            solid_vertices.extend_from_slice(verts);
+        }
+        crate::snap::Scene3D {
+            points: self.points.clone(),
+            lines,
+            surface_vertices,
+            solid_vertices,
+        }
     }
 
     /// Hit test screen coordinates against existing objects.

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -763,6 +763,8 @@ export component SnapSettingsDialog inherits Window {
     in-out property <bool> snap_midpoints;
     in-out property <bool> snap_intersections;
     in-out property <bool> snap_nearest;
+    in-out property <bool> snap_surfaces;
+    in-out property <bool> snap_solids;
     callback accept();
     callback cancel();
     title: "Snap Settings";
@@ -777,6 +779,8 @@ export component SnapSettingsDialog inherits Window {
         CheckBox { text: "Midpoints"; checked <=> root.snap_midpoints; }
         CheckBox { text: "Intersections"; checked <=> root.snap_intersections; }
         CheckBox { text: "Nearest"; checked <=> root.snap_nearest; }
+        CheckBox { text: "Surfaces"; checked <=> root.snap_surfaces; }
+        CheckBox { text: "Solids"; checked <=> root.snap_solids; }
         HorizontalBox {
             spacing: 6px;
             Button { text: "OK"; clicked => { root.accept(); } }
@@ -838,6 +842,8 @@ export component MainWindow inherits Window {
     in-out property <bool> snap_midpoints;
     in-out property <bool> snap_intersections;
     in-out property <bool> snap_nearest;
+    in-out property <bool> snap_surfaces;
+    in-out property <bool> snap_solids;
     in-out property <float> snap_tolerance;
     in-out property <float> zoom_level;
     in-out property <[string]> command_history;
@@ -891,6 +897,8 @@ export component MainWindow inherits Window {
     callback snap_intersections_changed(bool);
     callback snap_midpoints_changed(bool);
     callback snap_nearest_changed(bool);
+    callback snap_surfaces_changed(bool);
+    callback snap_solids_changed(bool);
     callback snap_tolerance_changed(float);
     callback point_manager();
     callback line_style_manager();


### PR DESCRIPTION
## Summary
- extend snapping options and scene structures to cover 3D entities
- store solid geometry for snapping in `TruckBackend`
- surface and solid snapping preferences added to GUI
- connect new preferences through event handling

## Testing
- `cargo check` *(fails: operation interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_686d1a1831e083289b66433369dc2ced