### PR TITLE
Fix deprecated rng.gen usages

### DIFF
--- a/truck-master/truck-geotrait/src/traits/curve.rs
+++ b/truck-master/truck-geotrait/src/traits/curve.rs
@@ -358,14 +358,14 @@ where
     C::Point: Debug + Tolerance,
     C::Vector: Debug + Tolerance + std::ops::Mul<f64, Output = C::Vector>, {
     let mut rng = seeded_rng();
-    let a = rng.gen::<f64>() + 0.5;
-    let b = rng.gen::<f64>() * 2.0;
+    let a = rng.random::<f64>() + 0.5;
+    let b = rng.random::<f64>() * 2.0;
     let transformed = curve.parameter_transformed(a, b);
 
     let (t0, t1) = curve.range_tuple();
     assert_near!(transformed.range_tuple().0, t0 * a + b);
     assert_near!(transformed.range_tuple().1, t1 * a + b);
-    let p = rng.gen::<f64>();
+    let p = rng.random::<f64>();
     let t = (1.0 - p) * t0 + p * t1;
     assert_near!(transformed.subs(t * a + b), curve.subs(t));
     assert_near!(transformed.der(t * a + b) * a, curve.der(t));
@@ -401,14 +401,14 @@ where
     assert_near!(concatted.range_tuple().0, t0);
     assert_near!(concatted.range_tuple().1, t2);
 
-    let p = rng.gen::<f64>();
+    let p = rng.random::<f64>();
     let t = t0 * (1.0 - p) + t1 * p;
     assert_near!(concatted.subs(t), curve0.subs(t));
     assert_near!(concatted.der(t), curve0.der(t));
     assert_near!(concatted.der2(t), curve0.der2(t));
     assert_near!(concatted.front(), curve0.front());
 
-    let p = rng.gen::<f64>();
+    let p = rng.random::<f64>();
     let t = t1 * (1.0 - p) + t2 * p;
     assert_near!(concatted.subs(t), curve1.subs(t));
     assert_near!(concatted.der(t), curve1.der(t));
@@ -435,7 +435,7 @@ where
     let mut rng = seeded_rng();
     let mut part0 = curve.clone();
     let (t0, t1) = curve.range_tuple();
-    let p = rng.gen::<f64>();
+    let p = rng.random::<f64>();
     let t = t0 * (1.0 - p) + t1 * p;
     let part1 = part0.cut(t);
     assert_near!(part0.range_tuple().0, t0);
@@ -443,7 +443,7 @@ where
     assert_near!(part1.range_tuple().0, t);
     assert_near!(part1.range_tuple().1, t1);
 
-    let p = rng.gen::<f64>();
+    let p = rng.random::<f64>();
     let s = t0 * (1.0 - p) + t * p;
     assert_near!(part0.subs(s), curve.subs(s));
     assert_near!(part0.der(s), curve.der(s));
@@ -451,7 +451,7 @@ where
     assert_near!(part0.front(), curve.front());
     assert_near!(part0.back(), curve.subs(t));
 
-    let p = rng.gen::<f64>();
+    let p = rng.random::<f64>();
     let s = t * (1.0 - p) + t1 * p;
     assert_near!(part1.subs(s), curve.subs(s));
     assert_near!(part1.der(s), curve.der(s));

--- a/truck-master/truck-geotrait/tests/curve.rs
+++ b/truck-master/truck-geotrait/tests/curve.rs
@@ -48,16 +48,16 @@ fn exec_polycurve_snp_on_curve() -> bool {
     let coef: Vec<Vector3> = (0..5)
         .map(|_| {
             Vector3::new(
-                20.0 * rng.gen::<f64>() - 10.0,
-                20.0 * rng.gen::<f64>() - 10.0,
-                20.0 * rng.gen::<f64>() - 10.0,
+                20.0 * rng.random::<f64>() - 10.0,
+                20.0 * rng.random::<f64>() - 10.0,
+                20.0 * rng.random::<f64>() - 10.0,
             )
         })
         .collect();
     let poly = PolyCurve::<Point3>(coef);
-    let t = 20.0 * rng.gen::<f64>() - 10.0;
+    let t = 20.0 * rng.random::<f64>() - 10.0;
     let pt = poly.subs(t);
-    let hint = t + 1.0 * rng.gen::<f64>() - 0.5;
+    let hint = t + 1.0 * rng.random::<f64>() - 0.5;
     match algo::curve::search_nearest_parameter(&poly, pt, hint, 100) {
         Some(res) => match poly.subs(res).near(&pt) {
             true => true,
@@ -86,9 +86,9 @@ fn exec_polycurve_division() -> bool {
     let coef: Vec<Vector3> = (0..5)
         .map(|_| {
             Vector3::new(
-                20.0 * rng.gen::<f64>() - 10.0,
-                20.0 * rng.gen::<f64>() - 10.0,
-                20.0 * rng.gen::<f64>() - 10.0,
+                20.0 * rng.random::<f64>() - 10.0,
+                20.0 * rng.random::<f64>() - 10.0,
+                20.0 * rng.random::<f64>() - 10.0,
             )
         })
         .collect();
@@ -118,10 +118,10 @@ fn polycurve_division() {
 fn exec_polycurve_closest_point() -> bool {
     let mut rng = seeded_rng();
     let a = [
-        rng.gen::<f64>() - 0.5,
-        rng.gen::<f64>() - 0.5,
-        rng.gen::<f64>() - 0.5,
-        rng.gen::<f64>() - 0.5,
+        rng.random::<f64>() - 0.5,
+        rng.random::<f64>() - 0.5,
+        rng.random::<f64>() - 0.5,
+        rng.random::<f64>() - 0.5,
     ];
     let coef0 = vec![
         Vector3::new(0.0, 0.0, 0.0),
@@ -164,9 +164,9 @@ fn polycurve_closest_point() {
 fn exec_polycurve_intersection_point() -> bool {
     let mut rng = seeded_rng();
     let a = [
-        0.5 * rng.gen::<f64>() + 0.1,
-        0.5 * rng.gen::<f64>() + 0.1,
-        rng.gen::<f64>() - 0.5,
+        0.5 * rng.random::<f64>() + 0.1,
+        0.5 * rng.random::<f64>() + 0.1,
+        rng.random::<f64>() - 0.5,
     ];
     let (x, y) = (-1.0 + a[0], 1.0 - a[1]);
     let coef0 = vec![

--- a/truck-master/truck-geotrait/tests/surface.rs
+++ b/truck-master/truck-geotrait/tests/surface.rs
@@ -71,21 +71,21 @@ fn polysurface_presearch() {
 fn exec_polysurface_snp_on_surface() -> bool {
     let mut rng = seeded_rng();
     let coef0 = vec![
-        Vector3::new(0.0, 1.0, 3.0 * rng.gen::<f64>() - 1.5),
-        Vector3::new(1.0, 0.0, 3.0 * rng.gen::<f64>() - 1.5),
-        Vector3::new(0.0, 0.0, 3.0 * rng.gen::<f64>() - 1.5),
+        Vector3::new(0.0, 1.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(1.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
     ];
     let coef1 = vec![
-        Vector3::new(1.0, 0.0, 3.0 * rng.gen::<f64>() - 1.5),
-        Vector3::new(0.0, 1.0, 3.0 * rng.gen::<f64>() - 1.5),
-        Vector3::new(0.0, 0.0, 3.0 * rng.gen::<f64>() - 1.5),
+        Vector3::new(1.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 1.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
     ];
     let poly = PolySurface(PolyCurve(coef0), PolyCurve(coef1));
-    let u = 10.0 * rng.gen::<f64>() - 5.0;
-    let v = 10.0 * rng.gen::<f64>() - 5.0;
+    let u = 10.0 * rng.random::<f64>() - 5.0;
+    let v = 10.0 * rng.random::<f64>() - 5.0;
     let pt = poly.subs(u, v);
-    let u0 = u + 0.2 * rng.gen::<f64>() - 0.1;
-    let v0 = v + 0.2 * rng.gen::<f64>() - 0.1;
+    let u0 = u + 0.2 * rng.random::<f64>() - 0.1;
+    let v0 = v + 0.2 * rng.random::<f64>() - 0.1;
     match algo::surface::search_nearest_parameter(&poly, pt, (u0, v0), 100) {
         Some(res) => match poly.subs(res.0, res.1).near(&pt) {
             true => true,
@@ -129,23 +129,23 @@ fn polysurface_snp_on_surface() {
 fn exec_polysurface_sp_on_surface() -> bool {
     let mut rng = seeded_rng();
     let coef0 = vec![
-        Vector3::new(0.0, 1.0, 3.0 * rng.gen::<f64>() - 1.5),
-        Vector3::new(1.0, 0.0, 3.0 * rng.gen::<f64>() - 1.5),
-        Vector3::new(0.0, 0.0, 3.0 * rng.gen::<f64>() - 1.5),
-        Vector3::new(0.0, 0.0, 3.0 * rng.gen::<f64>() - 1.5),
+        Vector3::new(0.0, 1.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(1.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
     ];
     let coef1 = vec![
-        Vector3::new(1.0, 0.0, 3.0 * rng.gen::<f64>() - 1.5),
-        Vector3::new(0.0, 1.0, 3.0 * rng.gen::<f64>() - 1.5),
-        Vector3::new(0.0, 0.0, 3.0 * rng.gen::<f64>() - 1.5),
-        Vector3::new(0.0, 0.0, 3.0 * rng.gen::<f64>() - 1.5),
+        Vector3::new(1.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 1.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
     ];
     let poly = PolySurface(PolyCurve(coef0), PolyCurve(coef1));
-    let u = 10.0 * rng.gen::<f64>() - 5.0;
-    let v = 10.0 * rng.gen::<f64>() - 5.0;
+    let u = 10.0 * rng.random::<f64>() - 5.0;
+    let v = 10.0 * rng.random::<f64>() - 5.0;
     let pt = poly.subs(u, v);
-    let u0 = u + 2.0 * rng.gen::<f64>() - 1.0;
-    let v0 = v + 2.0 * rng.gen::<f64>() - 1.0;
+    let u0 = u + 2.0 * rng.random::<f64>() - 1.0;
+    let v0 = v + 2.0 * rng.random::<f64>() - 1.0;
     match algo::surface::search_parameter(&poly, pt, (u0, v0), 100) {
         Some(res) => match poly.subs(res.0, res.1).near(&pt) {
             true => true,
@@ -188,7 +188,7 @@ fn polysurface_sp_on_surface() {
 
 fn exec_polysurface_intersection_point() -> bool {
     let mut rng = seeded_rng();
-    let (a, b) = (rng.gen::<f64>(), rng.gen::<f64>());
+    let (a, b) = (rng.random::<f64>(), rng.random::<f64>());
     let coef0 = vec![
         Vector3::new(0.0, 1.0, 0.0),
         Vector3::new(1.0, 0.0, 0.0),
@@ -223,14 +223,14 @@ fn polysurface_intersection_point() {
 fn exec_polysurface_division() -> bool {
     let mut rng = seeded_rng();
     let coef0 = vec![
-        Vector3::new(0.0, 1.0, 10.0 * rng.gen::<f64>() - 5.0),
-        Vector3::new(1.0, 0.0, 10.0 * rng.gen::<f64>() - 5.0),
-        Vector3::new(0.0, 0.0, 10.0 * rng.gen::<f64>() - 5.0),
+        Vector3::new(0.0, 1.0, 10.0 * rng.random::<f64>() - 5.0),
+        Vector3::new(1.0, 0.0, 10.0 * rng.random::<f64>() - 5.0),
+        Vector3::new(0.0, 0.0, 10.0 * rng.random::<f64>() - 5.0),
     ];
     let coef1 = vec![
-        Vector3::new(1.0, 0.0, 10.0 * rng.gen::<f64>() - 5.0),
-        Vector3::new(0.0, 1.0, 10.0 * rng.gen::<f64>() - 5.0),
-        Vector3::new(0.0, 0.0, 10.0 * rng.gen::<f64>() - 5.0),
+        Vector3::new(1.0, 0.0, 10.0 * rng.random::<f64>() - 5.0),
+        Vector3::new(0.0, 1.0, 10.0 * rng.random::<f64>() - 5.0),
+        Vector3::new(0.0, 0.0, 10.0 * rng.random::<f64>() - 5.0),
     ];
     let poly = PolySurface(PolyCurve(coef0), PolyCurve(coef1));
     let (udiv, vdiv) = algo::surface::parameter_division(&poly, ((-1.0, 1.0), (-1.0, 1.0)), 0.1);

--- a/truck-master/truck-meshalgo/src/analyzers/point_cloud/hashed_point_cloud.rs
+++ b/truck-master/truck-meshalgo/src/analyzers/point_cloud/hashed_point_cloud.rs
@@ -247,30 +247,30 @@ fn exec_space_division_distance() {
     let points = (0..NUM_POINTS)
         .map(|_| {
             Point3::new(
-                SPACE_SIZE * rng.gen::<f64>() - SPACE_SIZE / 2.0,
-                SPACE_SIZE * rng.gen::<f64>() - SPACE_SIZE / 2.0,
-                SPACE_SIZE * rng.gen::<f64>() - SPACE_SIZE / 2.0,
+                SPACE_SIZE * rng.random::<f64>() - SPACE_SIZE / 2.0,
+                SPACE_SIZE * rng.random::<f64>() - SPACE_SIZE / 2.0,
+                SPACE_SIZE * rng.random::<f64>() - SPACE_SIZE / 2.0,
             )
         })
         .collect::<Vec<_>>();
     let triangles = (0..NUM_TRIANGLES)
         .map(|_| {
             let pt = Point3::new(
-                SPACE_SIZE * rng.gen::<f64>() - SPACE_SIZE / 2.0,
-                SPACE_SIZE * rng.gen::<f64>() - SPACE_SIZE / 2.0,
-                SPACE_SIZE * rng.gen::<f64>() - SPACE_SIZE / 2.0,
+                SPACE_SIZE * rng.random::<f64>() - SPACE_SIZE / 2.0,
+                SPACE_SIZE * rng.random::<f64>() - SPACE_SIZE / 2.0,
+                SPACE_SIZE * rng.random::<f64>() - SPACE_SIZE / 2.0,
             );
             [
                 pt,
                 pt + Vector3::new(
-                    TRIANGLE_DISPLACEMENT * 2.0 * rng.gen::<f64>() - TRIANGLE_DISPLACEMENT,
-                    TRIANGLE_DISPLACEMENT * 2.0 * rng.gen::<f64>() - TRIANGLE_DISPLACEMENT,
-                    TRIANGLE_DISPLACEMENT * 2.0 * rng.gen::<f64>() - TRIANGLE_DISPLACEMENT,
+                    TRIANGLE_DISPLACEMENT * 2.0 * rng.random::<f64>() - TRIANGLE_DISPLACEMENT,
+                    TRIANGLE_DISPLACEMENT * 2.0 * rng.random::<f64>() - TRIANGLE_DISPLACEMENT,
+                    TRIANGLE_DISPLACEMENT * 2.0 * rng.random::<f64>() - TRIANGLE_DISPLACEMENT,
                 ),
                 pt + Vector3::new(
-                    TRIANGLE_DISPLACEMENT * 2.0 * rng.gen::<f64>() - TRIANGLE_DISPLACEMENT,
-                    TRIANGLE_DISPLACEMENT * 2.0 * rng.gen::<f64>() - TRIANGLE_DISPLACEMENT,
-                    TRIANGLE_DISPLACEMENT * 2.0 * rng.gen::<f64>() - TRIANGLE_DISPLACEMENT,
+                    TRIANGLE_DISPLACEMENT * 2.0 * rng.random::<f64>() - TRIANGLE_DISPLACEMENT,
+                    TRIANGLE_DISPLACEMENT * 2.0 * rng.random::<f64>() - TRIANGLE_DISPLACEMENT,
+                    TRIANGLE_DISPLACEMENT * 2.0 * rng.random::<f64>() - TRIANGLE_DISPLACEMENT,
                 ),
             ]
         })

--- a/truck-master/truck-meshalgo/tests/analyzers/collision.rs
+++ b/truck-master/truck-meshalgo/tests/analyzers/collision.rs
@@ -35,7 +35,7 @@ fn sphere_interference() {
 fn in_plane() {
     let mut rng = seeded_rng();
     let positions: Vec<_> = (0..300)
-        .map(|_| Point3::new(rng.gen::<f64>(), 0.0, rng.gen::<f64>()))
+        .map(|_| Point3::new(rng.random::<f64>(), 0.0, rng.random::<f64>()))
         .collect();
     let faces = Faces::from_iter((0..100).map(|i| [i, i + 100, i + 200]));
     let polygon0 = PolygonMesh::new(
@@ -46,7 +46,7 @@ fn in_plane() {
         faces.clone(),
     );
     let positions: Vec<_> = (0..300)
-        .map(|_| Point3::new(rng.gen::<f64>(), 0.0, rng.gen::<f64>()))
+        .map(|_| Point3::new(rng.random::<f64>(), 0.0, rng.random::<f64>()))
         .collect();
     let polygon1 = PolygonMesh::new(
         StandardAttributes {
@@ -62,9 +62,9 @@ fn in_plane() {
 fn collision_sphere() {
     let mut rng = seeded_rng();
     let unit = Vector3::new(
-        rng.gen::<f64>(),
-        rng.gen::<f64>(),
-        rng.gen::<f64>(),
+        rng.random::<f64>(),
+        rng.random::<f64>(),
+        rng.random::<f64>(),
     )
     .normalize();
     let instant = std::time::Instant::now();

--- a/truck-master/truck-shapeops/src/transversal/intersection_curve/tests.rs
+++ b/truck-master/truck-shapeops/src/transversal/intersection_curve/tests.rs
@@ -43,7 +43,7 @@ fn intersection_curve_sphere_case() {
     );
 
     let mut rng = seeded_rng();
-    let theta = 2.0 * PI * rng.gen::<f64>();
+    let theta = 2.0 * PI * rng.random::<f64>();
     let pt = Point3::new(f64::cos(theta), f64::sin(theta), 0.0);
     let t = curve.search_parameter(pt, None, 10).unwrap();
     assert_near!(curve.subs(t), pt);


### PR DESCRIPTION
## Summary
- replace calls to `rng.gen` with `rng.random` to silence deprecation warnings
- update tests and internal sources accordingly

## Testing
- `cargo test -p truck-meshalgo --test analyzers -- --nocapture`
- `cargo test -p truck-geotrait -- --nocapture`
- `cargo test -p truck-shapeops -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_686d2b6da8ac8328bc418e5b8d3c4f7c