### PR TITLE
Add alignment and label style management

### DIFF
--- a/survey_cad/src/styles.rs
+++ b/survey_cad/src/styles.rs
@@ -68,7 +68,7 @@ pub struct DimensionStyleOverride {
 }
 
 /// Style definition for point labels.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PointLabelStyle {
     pub text_style: TextStyle,
     pub color: [u8; 3],
@@ -94,7 +94,7 @@ pub enum LineLabelPosition {
 }
 
 /// Style definition for line labels.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct LineLabelStyle {
     pub text_style: TextStyle,
     pub color: [u8; 3],
@@ -243,6 +243,15 @@ pub fn default_line_label_styles() -> Vec<(String, LineLabelStyle)> {
             ),
         ),
     ]
+}
+
+/// Returns a basic set of default alignment styles.
+pub fn default_alignment_styles() -> Vec<(String, crate::geometry::line::LineStyle)> {
+    use crate::geometry::line::{LineStyle, LineType};
+    vec![(
+        "Default".to_string(),
+        LineStyle::new(LineType::Solid, [0, 200, 255], LineWeight(1.0)),
+    )]
 }
 
 /// Returns a basic set of default polygon styles.

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -22,7 +22,7 @@ use survey_cad::layers::{Layer, LayerManager as ScLayerManager};
 use survey_cad::point_database::PointDatabase;
 use survey_cad::styles::{
     format_dms, HatchPattern, LineLabelPosition, LineLabelStyle, LineWeight, PointLabelStyle,
-    TextStyle as ScTextStyle,
+    TextStyle as ScTextStyle, default_alignment_styles,
 };
 use survey_cad::subassembly;
 use survey_cad::superelevation::SuperelevationPoint;
@@ -410,6 +410,7 @@ struct RenderStyles<'a> {
     line_style_indices: &'a Rc<RefCell<Vec<usize>>>,
     polygon_styles: &'a [survey_cad::styles::PolygonStyle],
     polygon_style_indices: &'a Rc<RefCell<Vec<usize>>>,
+    alignment_style: &'a LineStyle,
     show_labels: bool,
     label_style: &'a LineLabelStyle,
     point_label_style: &'a PointLabelStyle,
@@ -1211,7 +1212,12 @@ fn render_workspace(
         }
     }
 
-    paint.set_color(Color::from_rgba8(0, 200, 255, 255));
+    paint.set_color(Color::from_rgba8(
+        styles.alignment_style.color[0],
+        styles.alignment_style.color[1],
+        styles.alignment_style.color[2],
+        255,
+    ));
     for al in data.alignments {
         for elem in &al.horizontal.elements {
             match elem {
@@ -1220,10 +1226,20 @@ fn render_workspace(
                     pb.move_to(tx(start.x as f32), ty(start.y as f32));
                     pb.line_to(tx(end.x as f32), ty(end.y as f32));
                     if let Some(path) = pb.finish() {
-                        let stroke = Stroke {
-                            width: 1.0,
+                        let mut stroke = Stroke {
+                            width: styles.alignment_style.weight.0,
                             ..Stroke::default()
                         };
+                        use tiny_skia::StrokeDash;
+                        match styles.alignment_style.line_type {
+                            LineType::Dashed => {
+                                stroke.dash = StrokeDash::new(vec![10.0, 10.0], 0.0);
+                            }
+                            LineType::Dotted => {
+                                stroke.dash = StrokeDash::new(vec![2.0, 6.0], 0.0);
+                            }
+                            _ => {}
+                        }
                         pixmap.stroke_path(&path, &paint, &stroke, Transform::identity(), None);
                     }
                 }
@@ -1244,10 +1260,20 @@ fn render_workspace(
                         }
                     }
                     if let Some(path) = pb.finish() {
-                        let stroke = Stroke {
-                            width: 1.0,
+                        let mut stroke = Stroke {
+                            width: styles.alignment_style.weight.0,
                             ..Stroke::default()
                         };
+                        use tiny_skia::StrokeDash;
+                        match styles.alignment_style.line_type {
+                            LineType::Dashed => {
+                                stroke.dash = StrokeDash::new(vec![10.0, 10.0], 0.0);
+                            }
+                            LineType::Dotted => {
+                                stroke.dash = StrokeDash::new(vec![2.0, 6.0], 0.0);
+                            }
+                            _ => {}
+                        }
                         pixmap.stroke_path(&path, &paint, &stroke, Transform::identity(), None);
                     }
                 }
@@ -1258,10 +1284,20 @@ fn render_workspace(
                     pb.move_to(tx(sp.x as f32), ty(sp.y as f32));
                     pb.line_to(tx(ep.x as f32), ty(ep.y as f32));
                     if let Some(path) = pb.finish() {
-                        let stroke = Stroke {
-                            width: 1.0,
+                        let mut stroke = Stroke {
+                            width: styles.alignment_style.weight.0,
                             ..Stroke::default()
                         };
+                        use tiny_skia::StrokeDash;
+                        match styles.alignment_style.line_type {
+                            LineType::Dashed => {
+                                stroke.dash = StrokeDash::new(vec![10.0, 10.0], 0.0);
+                            }
+                            LineType::Dotted => {
+                                stroke.dash = StrokeDash::new(vec![2.0, 6.0], 0.0);
+                            }
+                            _ => {}
+                        }
                         pixmap.stroke_path(&path, &paint, &stroke, Transform::identity(), None);
                     }
                 }
@@ -2392,6 +2428,9 @@ fn main() -> Result<(), slint::PlatformError> {
         point_styles: survey_cad::styles::default_point_styles(),
         line_styles: survey_cad::styles::default_line_styles(),
         polygon_styles: survey_cad::styles::default_polygon_styles(),
+        alignment_styles: survey_cad::styles::default_alignment_styles(),
+        line_label_styles: survey_cad::styles::default_line_label_styles(),
+        point_label_styles: survey_cad::styles::default_point_label_styles(),
     });
     let point_styles = style_settings.point_styles.clone();
     let point_style_names: Vec<SharedString> = point_styles
@@ -2411,6 +2450,12 @@ fn main() -> Result<(), slint::PlatformError> {
         .collect();
     let polygon_style_values: Vec<survey_cad::styles::PolygonStyle> =
         polygon_styles.iter().map(|(_, s)| *s).collect();
+
+    let alignment_styles = style_settings.alignment_styles.clone();
+    let alignment_style = alignment_styles
+        .get(0)
+        .map(|(_, s)| *s)
+        .unwrap_or_else(|| default_alignment_styles()[0].1);
     let command_stack = Rc::new(RefCell::new(CommandStack::new()));
     let macro_recorder = Rc::new(RefCell::new(MacroRecorder::default()));
     let macro_playing = Rc::new(RefCell::new(MacroPlaying::default()));
@@ -2420,8 +2465,8 @@ fn main() -> Result<(), slint::PlatformError> {
         SharedString::from("Dashed"),
         SharedString::from("Dotted"),
     ]));
-    let line_label_styles = survey_cad::styles::default_line_label_styles();
-    let point_label_styles = survey_cad::styles::default_point_label_styles();
+    let line_label_styles = style_settings.line_label_styles.clone();
+    let point_label_styles = style_settings.point_label_styles.clone();
     let point_label_style = Rc::new(RefCell::new(point_label_styles[0].1.clone()));
     let line_style_names: Rc<Vec<SharedString>> = Rc::new(
         line_styles
@@ -2516,6 +2561,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let drawing_mode = drawing_mode.clone();
         let label_style = line_label_styles[0].1.clone();
         let point_label_style = point_label_style.clone();
+        let alignment_style = alignment_style.clone();
         let grid_settings_ref = grid_settings.clone();
         move || {
             let size = app_weak.upgrade().map(|a| a.window().size()).unwrap();
@@ -2554,6 +2600,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     line_style_indices: &line_style_indices,
                     polygon_styles: &polygon_style_values,
                     polygon_style_indices: &polygon_style_indices,
+                    alignment_style: &alignment_style,
                     show_labels: true,
                     label_style: &label_style,
                     point_label_style: &point_label_style.borrow(),
@@ -4553,6 +4600,9 @@ fn main() -> Result<(), slint::PlatformError> {
                         point_styles: point_styles.clone(),
                         line_styles: line_styles.clone(),
                         polygon_styles: polygon_styles.clone(),
+                        alignment_styles: alignment_styles.clone(),
+                        line_label_styles: line_label_styles.clone(),
+                        point_label_styles: point_label_styles.clone(),
                     };
                     let _ = save_styles(&base.with_extension("styles.json"), &style_settings);
 

--- a/survey_cad_truck_gui/src/persistence.rs
+++ b/survey_cad_truck_gui/src/persistence.rs
@@ -6,13 +6,16 @@ use serde::{Deserialize, Serialize};
 use survey_cad::layers::LayerManager;
 use survey_cad::geometry::line::LineStyle;
 use survey_cad::geometry::point::PointStyle;
-use survey_cad::styles::PolygonStyle;
+use survey_cad::styles::{LineLabelStyle, PointLabelStyle, PolygonStyle};
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct StyleSettings {
     pub point_styles: Vec<(String, PointStyle)>,
     pub line_styles: Vec<(String, LineStyle)>,
     pub polygon_styles: Vec<(String, PolygonStyle)>,
+    pub alignment_styles: Vec<(String, LineStyle)>,
+    pub line_label_styles: Vec<(String, LineLabelStyle)>,
+    pub point_label_styles: Vec<(String, PointLabelStyle)>,
 }
 
 pub fn save_layers(path: &Path, layers: &LayerManager) -> std::io::Result<()> {

--- a/survey_cad_truck_gui/ui/alignment_style_manager.slint
+++ b/survey_cad_truck_gui/ui/alignment_style_manager.slint
@@ -1,0 +1,53 @@
+export struct AlignmentRow {
+    start: string,
+    end: string,
+    style_index: int,
+}
+
+import { VerticalBox, HorizontalBox, ComboBox, ListView } from "std-widgets.slint";
+
+export component AlignmentStyleManager inherits Window {
+    in-out property <[AlignmentRow]> lines_model;
+    in-out property <[string]> styles_model;
+    in-out property <int> selected_index;
+    callback style_changed(int, int);
+    title: "Alignment Style Manager";
+    width: 500px;
+    height: 300px;
+
+    VerticalBox {
+        spacing: 4px;
+        Rectangle {
+            width: 100%;
+            height: 20px;
+            border-width: 1px;
+            border-color: #808080;
+            HorizontalBox {
+                spacing: 8px;
+                Text { color: #FFFFFF; text: "Start"; width: 140px; }
+                Text { color: #FFFFFF; text: "End"; width: 140px; }
+                Text { color: #FFFFFF; text: "Style"; width: 80px; }
+            }
+        }
+        ListView {
+            vertical-stretch: 1;
+            for row[i] in root.lines_model : Rectangle {
+                property <bool> selected: root.selected_index == i;
+                background: selected ? #404040 : transparent;
+                height: 24px;
+                HorizontalBox {
+                    spacing: 8px;
+                    Text { color: #FFFFFF; text: row.start; width: 140px; }
+                    Text { color: #FFFFFF; text: row.end; width: 140px; }
+                    ComboBox {
+                        model: root.styles_model;
+                        current-index: row.style_index;
+                        selected => { root.style_changed(i, self.current-index); }
+                        width: 80px;
+                    }
+                }
+                TouchArea { width: 100%; height: 100%; clicked => { root.selected_index = i; } }
+            }
+        }
+    }
+}

--- a/survey_cad_truck_gui/ui/line_label_style_manager.slint
+++ b/survey_cad_truck_gui/ui/line_label_style_manager.slint
@@ -1,0 +1,53 @@
+export struct LineLabelRow {
+    start: string,
+    end: string,
+    style_index: int,
+}
+
+import { VerticalBox, HorizontalBox, ComboBox, ListView } from "std-widgets.slint";
+
+export component LineLabelStyleManager inherits Window {
+    in-out property <[LineLabelRow]> lines_model;
+    in-out property <[string]> styles_model;
+    in-out property <int> selected_index;
+    callback style_changed(int, int);
+    title: "Line Label Style Manager";
+    width: 500px;
+    height: 300px;
+
+    VerticalBox {
+        spacing: 4px;
+        Rectangle {
+            width: 100%;
+            height: 20px;
+            border-width: 1px;
+            border-color: #808080;
+            HorizontalBox {
+                spacing: 8px;
+                Text { color: #FFFFFF; text: "Start"; width: 140px; }
+                Text { color: #FFFFFF; text: "End"; width: 140px; }
+                Text { color: #FFFFFF; text: "Style"; width: 80px; }
+            }
+        }
+        ListView {
+            vertical-stretch: 1;
+            for row[i] in root.lines_model : Rectangle {
+                property <bool> selected: root.selected_index == i;
+                background: selected ? #404040 : transparent;
+                height: 24px;
+                HorizontalBox {
+                    spacing: 8px;
+                    Text { color: #FFFFFF; text: row.start; width: 140px; }
+                    Text { color: #FFFFFF; text: row.end; width: 140px; }
+                    ComboBox {
+                        model: root.styles_model;
+                        current-index: row.style_index;
+                        selected => { root.style_changed(i, self.current-index); }
+                        width: 80px;
+                    }
+                }
+                TouchArea { width: 100%; height: 100%; clicked => { root.selected_index = i; } }
+            }
+        }
+    }
+}

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -1,5 +1,8 @@
 export { PointManager } from "point_manager.slint";
 export { LineStyleManager } from "line_style_manager.slint";
+export { AlignmentStyleManager } from "alignment_style_manager.slint";
+export { LineLabelStyleManager } from "line_label_style_manager.slint";
+export { PointLabelStyleManager } from "point_label_style_manager.slint";
 export { LayerManager } from "layer_manager.slint";
 export { CrossSectionViewer } from "cross_section_viewer.slint";
 export { SuperelevationEditor } from "superelevation_editor.slint";
@@ -25,6 +28,9 @@ component Ribbon inherits TabWidget {
     callback save_project();
     callback point_manager();
     callback line_style_manager();
+    callback alignment_style_manager();
+    callback line_label_style_manager();
+    callback point_label_style_manager();
     callback layer_manager();
     callback inspector();
     callback add_point();
@@ -902,6 +908,9 @@ export component MainWindow inherits Window {
     callback snap_tolerance_changed(float);
     callback point_manager();
     callback line_style_manager();
+    callback alignment_style_manager();
+    callback line_label_style_manager();
+    callback point_label_style_manager();
     callback layer_manager();
     callback inspector();
     callback import_geojson();
@@ -1085,6 +1094,9 @@ export component MainWindow inherits Window {
             save_project => { root.save_project(); }
             point_manager => { root.point_manager(); }
             line_style_manager => { root.line_style_manager(); }
+            alignment_style_manager => { root.alignment_style_manager(); }
+            line_label_style_manager => { root.line_label_style_manager(); }
+            point_label_style_manager => { root.point_label_style_manager(); }
             layer_manager => { root.layer_manager(); }
             inspector => { root.inspector(); }
             add_point => { root.add_point(); }

--- a/survey_cad_truck_gui/ui/point_label_style_manager.slint
+++ b/survey_cad_truck_gui/ui/point_label_style_manager.slint
@@ -1,0 +1,53 @@
+export struct PointLabelRow {
+    start: string,
+    end: string,
+    style_index: int,
+}
+
+import { VerticalBox, HorizontalBox, ComboBox, ListView } from "std-widgets.slint";
+
+export component PointLabelStyleManager inherits Window {
+    in-out property <[PointLabelRow]> lines_model;
+    in-out property <[string]> styles_model;
+    in-out property <int> selected_index;
+    callback style_changed(int, int);
+    title: "Point Label Style Manager";
+    width: 500px;
+    height: 300px;
+
+    VerticalBox {
+        spacing: 4px;
+        Rectangle {
+            width: 100%;
+            height: 20px;
+            border-width: 1px;
+            border-color: #808080;
+            HorizontalBox {
+                spacing: 8px;
+                Text { color: #FFFFFF; text: "Start"; width: 140px; }
+                Text { color: #FFFFFF; text: "End"; width: 140px; }
+                Text { color: #FFFFFF; text: "Style"; width: 80px; }
+            }
+        }
+        ListView {
+            vertical-stretch: 1;
+            for row[i] in root.lines_model : Rectangle {
+                property <bool> selected: root.selected_index == i;
+                background: selected ? #404040 : transparent;
+                height: 24px;
+                HorizontalBox {
+                    spacing: 8px;
+                    Text { color: #FFFFFF; text: row.start; width: 140px; }
+                    Text { color: #FFFFFF; text: row.end; width: 140px; }
+                    ComboBox {
+                        model: root.styles_model;
+                        current-index: row.style_index;
+                        selected => { root.style_changed(i, self.current-index); }
+                        width: 80px;
+                    }
+                }
+                TouchArea { width: 100%; height: 100%; clicked => { root.selected_index = i; } }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `StyleSettings` with alignment, line label, and point label styles
- save/load the new style lists
- expose default alignment styles in `survey_cad`
- use alignment and label styles in rendering
- add placeholder managers and callbacks in the Slint UI

## Testing
- `cargo test -p survey_cad_truck_gui --no-run` *(fails: use of unresolved module or unlinked crate `truck_meshalgo`)*

------
https://chatgpt.com/codex/tasks/task_e_686d3a757ecc8328bf93dbf8d00edb9a