### PR TITLE
Fix serde derives for LineLabelPosition

### DIFF
--- a/survey_cad/src/styles.rs
+++ b/survey_cad/src/styles.rs
@@ -86,7 +86,7 @@ impl PointLabelStyle {
 }
 
 /// Position of a line label relative to the line.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum LineLabelPosition {
     Above,
     Below,


### PR DESCRIPTION
## Summary
- derive Serialize/Deserialize for `LineLabelPosition` so that `LineLabelStyle` can serialize/deserialize properly

## Testing
- `cargo check -p survey_cad`

------
https://chatgpt.com/codex/tasks/task_e_686d45900d808328a5395249f6df3d99