### PR TITLE
Add group management for surfaces and alignments

### DIFF
--- a/survey_cad/src/alignment.rs
+++ b/survey_cad/src/alignment.rs
@@ -503,6 +503,71 @@ pub struct Alignment {
     pub vertical: VerticalAlignment,
 }
 
+/// Group of alignment indices.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct AlignmentGroup {
+    pub name: String,
+    pub alignment_ids: Vec<usize>,
+}
+
+/// Collection of alignments with optional grouping.
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AlignmentManager {
+    pub alignments: Vec<Alignment>,
+    #[serde(default)]
+    pub groups: Vec<AlignmentGroup>,
+}
+
+impl AlignmentManager {
+    pub fn add(&mut self, al: Alignment) { self.alignments.push(al); }
+
+    pub fn remove(&mut self, index: usize) {
+        if index < self.alignments.len() {
+            self.alignments.remove(index);
+            for g in &mut self.groups {
+                g.alignment_ids.retain(|&id| id != index);
+                for id in &mut g.alignment_ids {
+                    if *id > index { *id -= 1; }
+                }
+            }
+        }
+    }
+
+    pub fn add_group<S: Into<String>>(&mut self, name: S) -> usize {
+        self.groups.push(AlignmentGroup { name: name.into(), alignment_ids: Vec::new() });
+        self.groups.len() - 1
+    }
+
+    pub fn rename_group<S: Into<String>>(&mut self, id: usize, name: S) -> bool {
+        if let Some(g) = self.groups.get_mut(id) {
+            g.name = name.into();
+            true
+        } else { false }
+    }
+
+    pub fn assign_alignment(&mut self, align_id: usize, group_id: usize) -> bool {
+        if align_id >= self.alignments.len() || group_id >= self.groups.len() { return false; }
+        let g = &mut self.groups[group_id];
+        if !g.alignment_ids.contains(&align_id) {
+            g.alignment_ids.push(align_id);
+        }
+        true
+    }
+
+    pub fn remove_alignment_from_group(&mut self, align_id: usize, group_id: usize) -> bool {
+        if let Some(g) = self.groups.get_mut(group_id) {
+            let len = g.alignment_ids.len();
+            g.alignment_ids.retain(|&id| id != align_id);
+            return len != g.alignment_ids.len();
+        }
+        false
+    }
+
+    pub fn iter_groups(&self) -> impl Iterator<Item=(usize, &AlignmentGroup)> {
+        self.groups.iter().enumerate()
+    }
+}
+
 impl Alignment {
     pub fn new(horizontal: HorizontalAlignment, vertical: VerticalAlignment) -> Self {
         Self {

--- a/survey_cad/src/dtm.rs
+++ b/survey_cad/src/dtm.rs
@@ -694,10 +694,19 @@ pub struct DynamicTin {
     pub tin: Tin,
 }
 
+/// Group of surfaces referenced by indices.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct SurfaceGroup {
+    pub name: String,
+    pub surface_ids: Vec<usize>,
+}
+
 /// Container for working with multiple TIN surfaces.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TinManager {
     pub tins: Vec<Tin>,
+    #[serde(default)]
+    pub groups: Vec<SurfaceGroup>,
 }
 
 impl TinManager {
@@ -710,6 +719,12 @@ impl TinManager {
     pub fn remove(&mut self, index: usize) {
         if index < self.tins.len() {
             self.tins.remove(index);
+            for g in &mut self.groups {
+                g.surface_ids.retain(|&id| id != index);
+                for id in &mut g.surface_ids {
+                    if *id > index { *id -= 1; }
+                }
+            }
         }
     }
 
@@ -726,6 +741,49 @@ impl TinManager {
     /// Returns `true` if no TINs are managed.
     pub fn is_empty(&self) -> bool {
         self.tins.is_empty()
+    }
+
+    /// Adds a new group and returns its index.
+    pub fn add_group<S: Into<String>>(&mut self, name: S) -> usize {
+        self.groups.push(SurfaceGroup { name: name.into(), surface_ids: Vec::new() });
+        self.groups.len() - 1
+    }
+
+    /// Renames an existing group.
+    pub fn rename_group<S: Into<String>>(&mut self, id: usize, name: S) -> bool {
+        if let Some(g) = self.groups.get_mut(id) {
+            g.name = name.into();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Assigns a surface to a group.
+    pub fn assign_surface(&mut self, surface_id: usize, group_id: usize) -> bool {
+        if surface_id >= self.tins.len() || group_id >= self.groups.len() {
+            return false;
+        }
+        let g = &mut self.groups[group_id];
+        if !g.surface_ids.contains(&surface_id) {
+            g.surface_ids.push(surface_id);
+        }
+        true
+    }
+
+    /// Removes a surface from a group.
+    pub fn remove_surface_from_group(&mut self, surface_id: usize, group_id: usize) -> bool {
+        if let Some(g) = self.groups.get_mut(group_id) {
+            let len = g.surface_ids.len();
+            g.surface_ids.retain(|&id| id != surface_id);
+            return len != g.surface_ids.len();
+        }
+        false
+    }
+
+    /// Iterate over groups.
+    pub fn iter_groups(&self) -> impl Iterator<Item = (usize, &SurfaceGroup)> {
+        self.groups.iter().enumerate()
     }
 }
 

--- a/survey_cad/src/io/project.rs
+++ b/survey_cad/src/io/project.rs
@@ -32,7 +32,11 @@ pub struct Project {
     pub dimensions: Vec<crate::geometry::LinearDimension>,
     #[serde(default)]
     pub alignments: Vec<crate::alignment::Alignment>,
+    #[serde(default)]
+    pub alignment_groups: Vec<crate::alignment::AlignmentGroup>,
     pub surfaces: Vec<Tin>,
+    #[serde(default)]
+    pub surface_groups: Vec<crate::dtm::SurfaceGroup>,
     #[serde(default)]
     pub surface_units: Vec<String>,
     #[serde(default)]
@@ -66,7 +70,9 @@ impl Project {
             arcs: Vec::new(),
             dimensions: Vec::new(),
             alignments: Vec::new(),
+            alignment_groups: Vec::new(),
             surfaces: Vec::new(),
+            surface_groups: Vec::new(),
             surface_units: Vec::new(),
             surface_styles: Vec::new(),
             surface_descriptions: Vec::new(),

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -8,10 +8,10 @@ use std::io::Write;
 use std::rc::Rc;
 use std::time::Instant;
 
-use survey_cad::alignment::{Alignment, VerticalAlignment, VerticalElement};
+use survey_cad::alignment::{Alignment, AlignmentGroup, VerticalAlignment, VerticalElement};
 use survey_cad::corridor;
 use survey_cad::crs::list_known_crs;
-use survey_cad::dtm::Tin;
+use survey_cad::dtm::{Tin, SurfaceGroup};
 use survey_cad::geometry::point::PointStyle;
 use survey_cad::geometry::{
     convex_hull, Arc, Line, LineAnnotation, LineStyle, LineType, LinearDimension, Point,
@@ -2368,10 +2368,12 @@ fn main() -> Result<(), slint::PlatformError> {
     let arcs = Rc::new(RefCell::new(Vec::<Arc>::new()));
     let dimensions = Rc::new(RefCell::new(Vec::<LinearDimension>::new()));
     let surfaces = Rc::new(RefCell::new(Vec::<Tin>::new()));
+    let surface_groups = Rc::new(RefCell::new(Vec::<SurfaceGroup>::new()));
     let surface_units = Rc::new(RefCell::new(Vec::<String>::new()));
     let surface_styles = Rc::new(RefCell::new(Vec::<String>::new()));
     let surface_descriptions = Rc::new(RefCell::new(Vec::<String>::new()));
     let alignments = Rc::new(RefCell::new(Vec::<Alignment>::new()));
+    let alignment_groups = Rc::new(RefCell::new(Vec::<AlignmentGroup>::new()));
     let superelevation = Rc::new(RefCell::new(Vec::<SuperelevationPoint>::new()));
     let layers = Rc::new(RefCell::new(ScLayerManager::new()));
     let layer_names = Rc::new(RefCell::new(Vec::<String>::new()));
@@ -4454,6 +4456,8 @@ fn main() -> Result<(), slint::PlatformError> {
                             dimensions.borrow_mut().extend(proj.dimensions.clone());
                             surfaces.borrow_mut().clear();
                             surfaces.borrow_mut().extend(proj.surfaces.clone());
+                            surface_groups.borrow_mut().clear();
+                            surface_groups.borrow_mut().extend(proj.surface_groups.clone());
                             surface_units_ref.borrow_mut().clear();
                             surface_units_ref
                                 .borrow_mut()
@@ -4468,6 +4472,8 @@ fn main() -> Result<(), slint::PlatformError> {
                                 .extend(proj.surface_descriptions.clone());
                             alignments.borrow_mut().clear();
                             alignments.borrow_mut().extend(proj.alignments.clone());
+                            alignment_groups.borrow_mut().clear();
+                            alignment_groups.borrow_mut().extend(proj.alignment_groups.clone());
                             *line_style_indices.borrow_mut() = proj.line_style_indices.clone();
                             *point_style_indices.borrow_mut() = proj.point_style_indices.clone();
                             *polygon_style_indices.borrow_mut() =
@@ -4556,7 +4562,9 @@ fn main() -> Result<(), slint::PlatformError> {
         let surface_units_ref = surface_units.clone();
         let surface_styles_ref = surface_styles.clone();
         let surface_descriptions_ref = surface_descriptions.clone();
+        let surface_groups_ref = surface_groups.clone();
         let alignments_save = alignments.clone();
+        let alignment_groups_save = alignment_groups.clone();
         let layer_names_save = layer_names.clone();
         app.on_save_project(move || {
             let mut dialog = rfd::FileDialog::new();
@@ -4576,7 +4584,9 @@ fn main() -> Result<(), slint::PlatformError> {
                         arcs: arcs.borrow().clone(),
                         dimensions: dimensions.borrow().clone(),
                         alignments: alignments_save.borrow().clone(),
+                        alignment_groups: alignment_groups_save.borrow().clone(),
                         surfaces: surfaces.borrow().clone(),
+                        surface_groups: surface_groups_ref.borrow().clone(),
                         surface_units: surface_units_ref.borrow().clone(),
                         surface_styles: surface_styles_ref.borrow().clone(),
                         surface_descriptions: surface_descriptions_ref.borrow().clone(),
@@ -6122,6 +6132,7 @@ fn main() -> Result<(), slint::PlatformError> {
         let backend = backend.clone();
         let weak = app.as_weak();
         let cs_outer = command_stack.clone();
+        let surface_groups = surface_groups.clone();
         app.on_tin_add_vertex(move || {
             let dlg = TinVertexDialog::new().unwrap();
             let dlg_weak = dlg.as_weak();
@@ -6136,15 +6147,17 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_y_val().parse::<f64>(),
                         d.get_z_val().parse::<f64>(),
                     ) {
-                        if let Some(idx) = backend_inner
-                            .borrow_mut()
-                            .add_vertex(surf, Point3::new(x, y, z))
-                        {
-                            command_stack.borrow_mut().push(Command::TinDeleteVertex {
-                                surface: surf,
-                                index: idx,
-                                point: Point3::new(x, y, z),
-                            });
+                        let targets = if let Some(g) = surface_groups.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                            g.surface_ids.clone()
+                        } else { vec![surf] };
+                        for sidx in targets {
+                            if let Some(idx) = backend_inner.borrow_mut().add_vertex(sidx, Point3::new(x, y, z)) {
+                                command_stack.borrow_mut().push(Command::TinDeleteVertex {
+                                    surface: sidx,
+                                    index: idx,
+                                    point: Point3::new(x, y, z),
+                                });
+                            }
                         }
                         if let Some(app) = weak2.upgrade() {
                             let image = backend_inner.borrow_mut().render();
@@ -6168,6 +6181,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let backend = backend.clone();
         let weak = app.as_weak();
+        let surface_groups = surface_groups.clone();
         app.on_tin_move_vertex(move || {
             let dlg = TinVertexDialog::new().unwrap();
             let dlg_weak = dlg.as_weak();
@@ -6182,9 +6196,14 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_y_val().parse::<f64>(),
                         d.get_z_val().parse::<f64>(),
                     ) {
-                        backend_inner
-                            .borrow_mut()
-                            .move_vertex(surf, idx, Point3::new(x, y, z));
+                        let targets = if let Some(g) = surface_groups.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                            g.surface_ids.clone()
+                        } else { vec![surf] };
+                        for sidx in targets {
+                            backend_inner
+                                .borrow_mut()
+                                .move_vertex(sidx, idx, Point3::new(x, y, z));
+                        }
                         if let Some(app) = weak2.upgrade() {
                             let image = backend_inner.borrow_mut().render();
                             app.set_workspace_texture(image);
@@ -6207,6 +6226,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let backend = backend.clone();
         let weak = app.as_weak();
+        let surface_groups = surface_groups.clone();
         app.on_tin_delete_vertex(move || {
             let dlg = TinVertexDialog::new().unwrap();
             dlg.set_x_val("0".into());
@@ -6221,7 +6241,12 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_surface_index().parse::<usize>(),
                         d.get_vertex_index().parse::<usize>(),
                     ) {
-                        backend_inner.borrow_mut().delete_vertex(surf, idx);
+                        let targets = if let Some(g) = surface_groups.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                            g.surface_ids.clone()
+                        } else { vec![surf] };
+                        for sidx in targets {
+                            backend_inner.borrow_mut().delete_vertex(sidx, idx);
+                        }
                         if let Some(app) = weak2.upgrade() {
                             let image = backend_inner.borrow_mut().render();
                             app.set_workspace_texture(image);
@@ -6244,6 +6269,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let backend = backend.clone();
         let weak = app.as_weak();
+        let surface_groups = surface_groups.clone();
         app.on_tin_add_triangle(move || {
             let dlg = TinTriangleDialog::new().unwrap();
             let dlg_weak = dlg.as_weak();
@@ -6257,7 +6283,12 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_v2().parse::<usize>(),
                         d.get_v3().parse::<usize>(),
                     ) {
-                        backend_inner.borrow_mut().add_triangle(surf, [a, b, c]);
+                        let targets = if let Some(g) = surface_groups.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                            g.surface_ids.clone()
+                        } else { vec![surf] };
+                        for sidx in targets {
+                            backend_inner.borrow_mut().add_triangle(sidx, [a, b, c]);
+                        }
                         if let Some(app) = weak2.upgrade() {
                             let image = backend_inner.borrow_mut().render();
                             app.set_workspace_texture(image);
@@ -6280,6 +6311,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let backend = backend.clone();
         let weak = app.as_weak();
+        let surface_groups = surface_groups.clone();
         app.on_tin_delete_triangle(move || {
             let dlg = TinTriangleDialog::new().unwrap();
             dlg.set_v1("0".into());
@@ -6294,7 +6326,12 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_surface_index().parse::<usize>(),
                         d.get_tri_index().parse::<usize>(),
                     ) {
-                        backend_inner.borrow_mut().delete_triangle(surf, idx);
+                        let targets = if let Some(g) = surface_groups.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                            g.surface_ids.clone()
+                        } else { vec![surf] };
+                        for sidx in targets {
+                            backend_inner.borrow_mut().delete_triangle(sidx, idx);
+                        }
                         if let Some(app) = weak2.upgrade() {
                             let image = backend_inner.borrow_mut().render();
                             app.set_workspace_texture(image);
@@ -6317,6 +6354,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let backend = backend.clone();
         let weak = app.as_weak();
+        let surface_groups = surface_groups.clone();
         app.on_tin_add_breakline(move || {
             let dlg = TinBreaklineDialog::new().unwrap();
             let dlg_weak = dlg.as_weak();
@@ -6329,7 +6367,12 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_v1().parse::<usize>(),
                         d.get_v2().parse::<usize>(),
                     ) {
-                        backend_inner.borrow_mut().add_breakline(surf, a, b);
+                        let targets = if let Some(g) = surface_groups.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                            g.surface_ids.clone()
+                        } else { vec![surf] };
+                        for sidx in targets {
+                            backend_inner.borrow_mut().add_breakline(sidx, a, b);
+                        }
                         if let Some(app) = weak2.upgrade() {
                             let image = backend_inner.borrow_mut().render();
                             app.set_workspace_texture(image);
@@ -6352,6 +6395,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let backend = backend.clone();
         let weak = app.as_weak();
+        let surface_groups = surface_groups.clone();
         app.on_tin_remove_breakline(move || {
             let dlg = TinBreaklineDialog::new().unwrap();
             let dlg_weak = dlg.as_weak();
@@ -6364,7 +6408,12 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_v1().parse::<usize>(),
                         d.get_v2().parse::<usize>(),
                     ) {
-                        backend_inner.borrow_mut().remove_breakline(surf, a, b);
+                        let targets = if let Some(g) = surface_groups.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                            g.surface_ids.clone()
+                        } else { vec![surf] };
+                        for sidx in targets {
+                            backend_inner.borrow_mut().remove_breakline(sidx, a, b);
+                        }
                         if let Some(app) = weak2.upgrade() {
                             let image = backend_inner.borrow_mut().render();
                             app.set_workspace_texture(image);
@@ -6387,6 +6436,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let backend = backend.clone();
         let weak = app.as_weak();
+        let surface_groups = surface_groups.clone();
         app.on_tin_set_boundary(move || {
             let dlg = TinBoundaryDialog::new().unwrap();
             let dlg_weak = dlg.as_weak();
@@ -6400,7 +6450,12 @@ fn main() -> Result<(), slint::PlatformError> {
                             .split(|c: char| c == ',' || c.is_whitespace())
                             .filter_map(|s| s.parse().ok())
                             .collect();
-                        backend_inner.borrow_mut().set_boundary(surf, verts);
+                        let targets = if let Some(g) = surface_groups.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                            g.surface_ids.clone()
+                        } else { vec![surf] };
+                        for sidx in targets {
+                            backend_inner.borrow_mut().set_boundary(sidx, verts.clone());
+                        }
                         if let Some(app) = weak2.upgrade() {
                             let image = backend_inner.borrow_mut().render();
                             app.set_workspace_texture(image);
@@ -6423,6 +6478,7 @@ fn main() -> Result<(), slint::PlatformError> {
     {
         let backend = backend.clone();
         let weak = app.as_weak();
+        let surface_groups = surface_groups.clone();
         app.on_tin_clear_boundary(move || {
             let dlg = TinBoundaryDialog::new().unwrap();
             dlg.set_verts("".into());
@@ -6432,7 +6488,12 @@ fn main() -> Result<(), slint::PlatformError> {
             dlg.on_accept(move || {
                 if let Some(d) = dlg_weak.upgrade() {
                     if let Ok(surf) = d.get_surface_index().parse::<usize>() {
-                        backend_inner.borrow_mut().clear_boundary(surf);
+                        let targets = if let Some(g) = surface_groups.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                            g.surface_ids.clone()
+                        } else { vec![surf] };
+                        for sidx in targets {
+                            backend_inner.borrow_mut().clear_boundary(sidx);
+                        }
                         if let Some(app) = weak2.upgrade() {
                             let image = backend_inner.borrow_mut().render();
                             app.set_workspace_texture(image);
@@ -8140,6 +8201,82 @@ fn main() -> Result<(), slint::PlatformError> {
                 });
             }
 
+            dlg.show().unwrap();
+        });
+    }
+
+    {
+        let surface_groups = surface_groups.clone();
+        let weak = app.as_weak();
+        app.on_surface_group_manager(move || {
+            let dlg = SurfaceGroupManager::new().unwrap();
+            let model = Rc::new(VecModel::<SharedString>::from(
+                surface_groups
+                    .borrow()
+                    .iter()
+                    .map(|g| SharedString::from(g.name.clone()))
+                    .collect::<Vec<_>>()
+            ));
+            dlg.set_groups_model(model.clone().into());
+            dlg.set_selected_index(-1);
+            {
+                let surface_groups = surface_groups.clone();
+                let model = model.clone();
+                dlg.on_create_group(move || {
+                    let name = format!("Group {}", surface_groups.borrow().len() + 1);
+                    surface_groups.borrow_mut().push(SurfaceGroup { name: name.clone(), surface_ids: Vec::new() });
+                    model.push(SharedString::from(name));
+                });
+            }
+            {
+                let surface_groups = surface_groups.clone();
+                let model = model.clone();
+                dlg.on_rename_group(move |idx| {
+                    if idx >= 0 { if let Some(g) = surface_groups.borrow_mut().get_mut(idx as usize) {
+                        let new_name = format!("Group {}", idx + 1);
+                        g.name = new_name.clone();
+                        model.set_row_data(idx as usize, SharedString::from(new_name));
+                    } }
+                });
+            }
+            dlg.show().unwrap();
+        });
+    }
+
+    {
+        let alignment_groups = alignment_groups.clone();
+        let weak = app.as_weak();
+        app.on_alignment_group_manager(move || {
+            let dlg = AlignmentGroupManager::new().unwrap();
+            let model = Rc::new(VecModel::<SharedString>::from(
+                alignment_groups
+                    .borrow()
+                    .iter()
+                    .map(|g| SharedString::from(g.name.clone()))
+                    .collect::<Vec<_>>()
+            ));
+            dlg.set_groups_model(model.clone().into());
+            dlg.set_selected_index(-1);
+            {
+                let alignment_groups = alignment_groups.clone();
+                let model = model.clone();
+                dlg.on_create_group(move || {
+                    let name = format!("Group {}", alignment_groups.borrow().len() + 1);
+                    alignment_groups.borrow_mut().push(AlignmentGroup { name: name.clone(), alignment_ids: Vec::new() });
+                    model.push(SharedString::from(name));
+                });
+            }
+            {
+                let alignment_groups = alignment_groups.clone();
+                let model = model.clone();
+                dlg.on_rename_group(move |idx| {
+                    if idx >= 0 { if let Some(g) = alignment_groups.borrow_mut().get_mut(idx as usize) {
+                        let new_name = format!("Group {}", idx + 1);
+                        g.name = new_name.clone();
+                        model.set_row_data(idx as usize, SharedString::from(new_name));
+                    } }
+                });
+            }
             dlg.show().unwrap();
         });
     }

--- a/survey_cad_truck_gui/ui/alignment_group_manager.slint
+++ b/survey_cad_truck_gui/ui/alignment_group_manager.slint
@@ -1,0 +1,27 @@
+export component AlignmentGroupManager inherits Window {
+    in-out property <[string]> groups_model;
+    in-out property <int> selected_index;
+    callback create_group();
+    callback rename_group(int);
+    title: "Alignment Groups";
+    preferred-width: 200px;
+    preferred-height: 200px;
+    VerticalBox {
+        spacing: 6px;
+        ListView {
+            vertical-stretch: 1;
+            for g[i] in root.groups_model : Rectangle {
+                property <bool> selected: root.selected_index == i;
+                background: selected ? #404040 : transparent;
+                height: 24px;
+                Text { color: #FFFFFF; text: g; }
+                TouchArea { width: 100%; height: 100%; clicked => { root.selected_index = i; } }
+            }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "New"; clicked => { root.create_group(); } }
+            Button { text: "Rename"; clicked => { root.rename_group(root.selected_index); } }
+        }
+    }
+}

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -1,6 +1,8 @@
 export { PointManager } from "point_manager.slint";
 export { LineStyleManager } from "line_style_manager.slint";
 export { AlignmentStyleManager } from "alignment_style_manager.slint";
+export { SurfaceGroupManager } from "surface_group_manager.slint";
+export { AlignmentGroupManager } from "alignment_group_manager.slint";
 export { LineLabelStyleManager } from "line_label_style_manager.slint";
 export { PointLabelStyleManager } from "point_label_style_manager.slint";
 export { LayerManager } from "layer_manager.slint";
@@ -29,6 +31,8 @@ component Ribbon inherits TabWidget {
     callback point_manager();
     callback line_style_manager();
     callback alignment_style_manager();
+    callback surface_group_manager();
+    callback alignment_group_manager();
     callback line_label_style_manager();
     callback point_label_style_manager();
     callback layer_manager();
@@ -73,6 +77,8 @@ component Ribbon inherits TabWidget {
             Button { icon: @image-url("../assets/icons/save.png"); clicked => { root.save_project(); } }
             Button { icon: @image-url("../assets/icons/point_manager.png"); clicked => { root.point_manager(); } }
             Button { icon: @image-url("../assets/icons/line_styles.png"); clicked => { root.line_style_manager(); } }
+            Button { icon: @image-url("../assets/icons/load_surface.png"); clicked => { root.surface_group_manager(); } }
+            Button { icon: @image-url("../assets/icons/load_alignment.png"); clicked => { root.alignment_group_manager(); } }
             Button { icon: @image-url("../assets/icons/layer_manager.png"); clicked => { root.layer_manager(); } }
             Button { icon: @image-url("../assets/icons/inspector.png"); clicked => { root.inspector(); } }
             Button { icon: @image-url("../assets/icons/move.png"); clicked => { root.move_entity(); } }
@@ -1095,6 +1101,8 @@ export component MainWindow inherits Window {
             point_manager => { root.point_manager(); }
             line_style_manager => { root.line_style_manager(); }
             alignment_style_manager => { root.alignment_style_manager(); }
+            surface_group_manager => { root.surface_group_manager(); }
+            alignment_group_manager => { root.alignment_group_manager(); }
             line_label_style_manager => { root.line_label_style_manager(); }
             point_label_style_manager => { root.point_label_style_manager(); }
             layer_manager => { root.layer_manager(); }

--- a/survey_cad_truck_gui/ui/surface_group_manager.slint
+++ b/survey_cad_truck_gui/ui/surface_group_manager.slint
@@ -1,0 +1,27 @@
+export component SurfaceGroupManager inherits Window {
+    in-out property <[string]> groups_model;
+    in-out property <int> selected_index;
+    callback create_group();
+    callback rename_group(int);
+    title: "Surface Groups";
+    preferred-width: 200px;
+    preferred-height: 200px;
+    VerticalBox {
+        spacing: 6px;
+        ListView {
+            vertical-stretch: 1;
+            for g[i] in root.groups_model : Rectangle {
+                property <bool> selected: root.selected_index == i;
+                background: selected ? #404040 : transparent;
+                height: 24px;
+                Text { color: #FFFFFF; text: g; }
+                TouchArea { width: 100%; height: 100%; clicked => { root.selected_index = i; } }
+            }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "New"; clicked => { root.create_group(); } }
+            Button { text: "Rename"; clicked => { root.rename_group(root.selected_index); } }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support grouping of surfaces and alignments in `survey_cad`
- persist groups in project JSON
- expose simple group manager dialogs in the Slint UI
- hook up callbacks and apply TIN operations to all surfaces in a group

## Testing
- `cargo check` *(fails: compilation requires large dependency build)*

------
https://chatgpt.com/codex/tasks/task_e_686d66dd83948328b93fed5c6e9e0592