### PR TITLE
Fix slint component imports and backend helpers

### DIFF
--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -12,6 +12,7 @@ rfd = "0.15"
 tiny-skia = "0.11"
 truck_cad_engine = { path = "../truck_cad_engine" }
 truck-modeling = { path = "../truck-master/truck-modeling" }
+truck-meshalgo = { path = "../truck-master/truck-meshalgo", features = ["tessellation"] }
 once_cell = "1"
 rusttype = "0.9"
 serde = { version = "1", features = ["derive"] }

--- a/survey_cad_truck_gui/src/snap.rs
+++ b/survey_cad_truck_gui/src/snap.rs
@@ -3,6 +3,7 @@ use survey_cad::io::DxfEntity;
 use survey_cad::snap::{snap_point_with_settings, SnapSettings};
 use truck_modeling::base::{Point3, Vector3};
 use truck_modeling::topology::Solid;
+use truck_modeling::cgmath::InnerSpace;
 
 pub struct Scene<'a> {
     pub points: &'a [Point],

--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -3,6 +3,7 @@ use truck_cad_engine::TruckCadEngine;
 use truck_modeling::base::{Point3, Vector4};
 use truck_modeling::topology::Solid;
 use truck_meshalgo::prelude::*;
+use truck_meshalgo::tessellation::MeshableShape;
 
 pub enum HitObject {
     Point(usize),
@@ -92,7 +93,7 @@ impl TruckBackend {
 
     pub fn update_point(&mut self, idx: usize, x: f64, y: f64, z: f64) {
         if let Some(Some(id)) = self.point_ids.get(idx) {
-            self.engine.update_point_marker(*id, Point3::new(x, y, z));
+            self.engine.update_point_marker(id, Point3::new(x, y, z));
         }
         if let Some(p) = self.points.get_mut(idx) {
             *p = Point3::new(x, y, z);
@@ -145,7 +146,7 @@ impl TruckBackend {
     ) {
         if let Some(Some(id)) = self.line_ids.get(idx) {
             self.engine.update_line(
-                *id,
+                id,
                 Point3::new(a[0], a[1], a[2]),
                 Point3::new(b[0], b[1], b[2]),
                 Vector4::new(color[0] as f64, color[1] as f64, color[2] as f64, color[3] as f64),
@@ -222,7 +223,7 @@ impl TruckBackend {
     #[allow(dead_code)]
     pub fn update_surface(&mut self, idx: usize, vertices: &[Point3], triangles: &[[usize; 3]]) {
         if let Some(Some(id)) = self.surface_ids.get(idx) {
-            self.engine.update_surface(*id, vertices, triangles);
+            self.engine.update_surface(id, vertices, triangles);
         }
         if let Some(surf) = self.surfaces.get_mut(idx) {
             surf.vertices = vertices.to_vec();
@@ -383,8 +384,8 @@ impl TruckBackend {
     /// Show handle for a single point.
     pub fn show_point_handles(&mut self, idx: usize) {
         self.hide_handles();
-        if let Some(p) = self.points.get(idx).copied() {
-            let id = self.engine.add_point_marker(p);
+        if let Some(p) = self.points.get(idx) {
+            let id = self.engine.add_point_marker(p.clone());
             self.handles = Some((HandleTarget::Point(idx), vec![id]));
         }
     }
@@ -394,8 +395,8 @@ impl TruckBackend {
         self.hide_handles();
         if let Some((a, b, _, _)) = self.lines.get(idx) {
             let ids = vec![
-                self.engine.add_point_marker(*a),
-                self.engine.add_point_marker(*b),
+                self.engine.add_point_marker(a.clone()),
+                self.engine.add_point_marker(b.clone()),
             ];
             self.handles = Some((HandleTarget::Line(idx), ids));
         }
@@ -414,7 +415,8 @@ impl TruckBackend {
     #[allow(dead_code)]
     pub fn move_handle(&mut self, handle_idx: usize, new_pos: Point3) {
         if let Some((ref target, ref mut handles)) = self.handles {
-            if let Some(id) = handles.get(handle_idx).copied() {
+            if handle_idx < handles.len() {
+                let id = handles[handle_idx];
                 self.engine.update_point_marker(id, new_pos);
             }
             match *target {
@@ -453,7 +455,8 @@ impl TruckBackend {
     /// Highlight or un-highlight a handle.
     pub fn highlight_handle(&mut self, handle_idx: usize, on: bool) {
         if let Some((_, ref handles)) = self.handles {
-            if let Some(id) = handles.get(handle_idx).copied() {
+            if handle_idx < handles.len() {
+                let id = handles[handle_idx];
                 let color = if on {
                     Vector4::new(1.0, 0.0, 0.0, 1.0)
                 } else {
@@ -469,8 +472,7 @@ impl TruckBackend {
         self.handles.as_ref().and_then(|(_, handles)| {
             handles
                 .get(handle_idx)
-                .copied()
-                .and_then(|id| self.engine.point_marker_position(id))
+                .and_then(|id| self.engine.point_marker_position(*id))
         })
     }
 

--- a/survey_cad_truck_gui/ui/alignment_group_manager.slint
+++ b/survey_cad_truck_gui/ui/alignment_group_manager.slint
@@ -1,3 +1,5 @@
+import { Button, VerticalBox, HorizontalBox, ListView } from "std-widgets.slint";
+
 export component AlignmentGroupManager inherits Window {
     in-out property <[string]> groups_model;
     in-out property <int> selected_index;

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -915,6 +915,8 @@ export component MainWindow inherits Window {
     callback point_manager();
     callback line_style_manager();
     callback alignment_style_manager();
+    callback surface_group_manager();
+    callback alignment_group_manager();
     callback line_label_style_manager();
     callback point_label_style_manager();
     callback layer_manager();

--- a/survey_cad_truck_gui/ui/surface_group_manager.slint
+++ b/survey_cad_truck_gui/ui/surface_group_manager.slint
@@ -1,3 +1,5 @@
+import { Button, VerticalBox, HorizontalBox, ListView } from "std-widgets.slint";
+
 export component SurfaceGroupManager inherits Window {
     in-out property <[string]> groups_model;
     in-out property <int> selected_index;


### PR DESCRIPTION
## Summary
- fix missing widget imports for group managers
- expose callbacks in main window
- add truck-meshalgo dependency
- tweak backend handle helpers

## Testing
- `cargo check` *(fails: could not compile `survey_cad_truck_gui`)*

------
https://chatgpt.com/codex/tasks/task_e_686d6e715bfc8328945dbefa1ea5ffa8