### PR TITLE
Fix clippy clone-on-copy errors

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -2455,7 +2455,7 @@ fn main() -> Result<(), slint::PlatformError> {
 
     let alignment_styles = style_settings.alignment_styles.clone();
     let alignment_style = alignment_styles
-        .get(0)
+        .first()
         .map(|(_, s)| *s)
         .unwrap_or_else(|| default_alignment_styles()[0].1);
     let command_stack = Rc::new(RefCell::new(CommandStack::new()));
@@ -2563,7 +2563,6 @@ fn main() -> Result<(), slint::PlatformError> {
         let drawing_mode = drawing_mode.clone();
         let label_style = line_label_styles[0].1.clone();
         let point_label_style = point_label_style.clone();
-        let alignment_style = alignment_style.clone();
         let grid_settings_ref = grid_settings.clone();
         move || {
             let size = app_weak.upgrade().map(|a| a.window().size()).unwrap();

--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -384,8 +384,9 @@ impl TruckBackend {
     /// Show handle for a single point.
     pub fn show_point_handles(&mut self, idx: usize) {
         self.hide_handles();
-        if let Some(p) = self.points.get(idx) {
-            let id = self.engine.add_point_marker(p.clone());
+        if idx < self.points.len() {
+            let p = self.points[idx];
+            let id = self.engine.add_point_marker(p);
             self.handles = Some((HandleTarget::Point(idx), vec![id]));
         }
     }
@@ -393,10 +394,11 @@ impl TruckBackend {
     /// Show handles for a line's endpoints.
     pub fn show_line_handles(&mut self, idx: usize) {
         self.hide_handles();
-        if let Some((a, b, _, _)) = self.lines.get(idx) {
+        if idx < self.lines.len() {
+            let (a, b, _, _) = self.lines[idx];
             let ids = vec![
-                self.engine.add_point_marker(a.clone()),
-                self.engine.add_point_marker(b.clone()),
+                self.engine.add_point_marker(a),
+                self.engine.add_point_marker(b),
             ];
             self.handles = Some((HandleTarget::Line(idx), ids));
         }


### PR DESCRIPTION
## Summary
- avoid clones for point and line handles
- stop redundant local in main and use `.first()`

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo clippy -p survey_cad_truck_gui -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_686e73f106ec8328b9a5de97d1f28bb2