### PR TITLE
Add profile and theme settings to truck GUI

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -121,6 +121,31 @@ impl Default for SnapPrefs {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Copy)]
+enum WorkspaceProfile {
+    Surveyor,
+    Engineer,
+    Gis,
+}
+
+impl Default for WorkspaceProfile {
+    fn default() -> Self {
+        WorkspaceProfile::Surveyor
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy)]
+enum Theme {
+    Dark,
+    Light,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Theme::Dark
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 struct Config {
     window_width: u32,
@@ -130,6 +155,10 @@ struct Config {
     auto_tin: bool,
     #[serde(default)]
     quick_scripts: [String; 3],
+    #[serde(default)]
+    profile: WorkspaceProfile,
+    #[serde(default)]
+    theme: Theme,
 }
 
 impl Default for Config {
@@ -141,6 +170,8 @@ impl Default for Config {
             snap: SnapPrefs::default(),
             auto_tin: false,
             quick_scripts: Default::default(),
+            profile: WorkspaceProfile::default(),
+            theme: Theme::default(),
         }
     }
 }
@@ -2336,6 +2367,10 @@ fn main() -> Result<(), slint::PlatformError> {
     // provide our bundled DejaVuSans.
     sharedfontdb::FONT_DB.with_borrow_mut(|db| db.make_mut().load_system_fonts());
     sharedfontdb::register_font_from_memory(FONT_DATA).expect("failed to register embedded font");
+    match config.borrow().theme {
+        Theme::Dark => std::env::set_var("SLINT_STYLE", "fluent-dark"),
+        Theme::Light => std::env::set_var("SLINT_STYLE", "fluent-light"),
+    }
     let app = MainWindow::new()?;
     app.window().set_size(PhysicalSize::new(
         config.borrow().window_width,
@@ -8512,6 +8547,8 @@ fn main() -> Result<(), slint::PlatformError> {
             dlg.set_show_grid(gs.visible);
             dlg.set_auto_tin(config_ref.borrow().auto_tin);
             dlg.set_crs_epsg(SharedString::from(workspace_crs.borrow().to_string()));
+            dlg.set_profile_index(config_ref.borrow().profile as i32);
+            dlg.set_theme_index(config_ref.borrow().theme as i32);
             drop(gs);
             let dlg_weak = dlg.as_weak();
             let gs_ref = grid_settings.clone();
@@ -8530,15 +8567,32 @@ fn main() -> Result<(), slint::PlatformError> {
                     let b = d.get_color_b().parse::<u8>().unwrap_or(60);
                     gs_ref.borrow_mut().color = [r, g, b];
                     gs_ref.borrow_mut().visible = d.get_show_grid();
-                    config_acc.borrow_mut().auto_tin = d.get_auto_tin();
+                    let mut cfg = config_acc.borrow_mut();
+                    cfg.auto_tin = d.get_auto_tin();
+                    cfg.profile = match d.get_profile_index() {
+                        1 => WorkspaceProfile::Engineer,
+                        2 => WorkspaceProfile::Gis,
+                        _ => WorkspaceProfile::Surveyor,
+                    };
+                    let theme = match d.get_theme_index() {
+                        1 => Theme::Light,
+                        _ => Theme::Dark,
+                    };
+                    cfg.theme = theme;
+                    drop(cfg);
                     if let Ok(epsg) = d.get_crs_epsg().parse::<u32>() {
                         *crs_ref.borrow_mut() = epsg;
                     }
                     d.hide().unwrap();
                 }
                 if let Some(app) = weak_app.upgrade() {
+                    match config_acc.borrow().theme {
+                        Theme::Dark => std::env::set_var("SLINT_STYLE", "fluent-dark"),
+                        Theme::Light => std::env::set_var("SLINT_STYLE", "fluent-light"),
+                    }
                     refresh_workspace(&app, &render_image, &backend_render);
                 }
+                save_config(&config_acc.borrow());
             });
             let cancel_weak = dlg.as_weak();
             dlg.on_cancel(move || {

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -769,6 +769,8 @@ export component SettingsDialog inherits Window {
     in-out property <string> crs_epsg;
     in-out property <bool> show_grid;
     in-out property <bool> auto_tin;
+    in-out property <int> profile_index;
+    in-out property <int> theme_index;
     callback accept();
     callback cancel();
     title: "Workspace Settings";
@@ -789,6 +791,20 @@ export component SettingsDialog inherits Window {
         HorizontalBox {
             Text { color: #FFFFFF; text: "EPSG:"; }
             LineEdit { text <=> root.crs_epsg; width: 80px; }
+        }
+        HorizontalBox {
+            Text { color: #FFFFFF; text: "Profile:"; }
+            ComboBox {
+                model: ["Surveyor", "Engineer", "GIS"];
+                current-index <=> root.profile_index;
+            }
+        }
+        HorizontalBox {
+            Text { color: #FFFFFF; text: "Theme:"; }
+            ComboBox {
+                model: ["Dark", "Light"];
+                current-index <=> root.theme_index;
+            }
         }
         HorizontalBox {
             spacing: 6px;


### PR DESCRIPTION
## Summary
- extend config with workspace profile and theme settings
- persist the new settings to disk
- apply saved theme at startup using `SLINT_STYLE`
- allow users to adjust profile and theme in the settings dialog

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_686e80c6df488328bac480640c4b088b