### PR TITLE
Switch quick scripts to Vec

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -2284,8 +2284,14 @@ fn main() -> Result<(), slint::PlatformError> {
             let items_assign = items.clone();
             dlg.on_assign(move |idx, slot| {
                 if let Some(name) = items_assign.get(idx as usize) {
-                    cfg_assign.borrow_mut().quick_scripts[slot as usize] = name.to_string();
-                    save_config(&cfg_assign.borrow());
+                    let mut cfg_borrow = cfg_assign.borrow_mut();
+                    if slot as usize >= cfg_borrow.quick_scripts.len() {
+                        cfg_borrow
+                            .quick_scripts
+                            .resize(slot as usize + 1, String::new());
+                    }
+                    cfg_borrow.quick_scripts[slot as usize] = name.to_string();
+                    save_config(&cfg_borrow);
                 }
             });
 

--- a/survey_cad_truck_gui/src/ui_state.rs
+++ b/survey_cad_truck_gui/src/ui_state.rs
@@ -91,7 +91,7 @@ pub struct Config {
     pub snap: SnapPrefs,
     pub auto_tin: bool,
     #[serde(default)]
-    pub quick_scripts: [String; 3],
+    pub quick_scripts: Vec<String>,
     #[serde(default)]
     pub profile: WorkspaceProfile,
     #[serde(default)]
@@ -106,7 +106,7 @@ impl Default for Config {
             last_open_dir: None,
             snap: SnapPrefs::default(),
             auto_tin: false,
-            quick_scripts: Default::default(),
+            quick_scripts: Vec::new(),
             profile: WorkspaceProfile::default(),
             theme: Theme::default(),
         }


### PR DESCRIPTION
## Summary
- store quick scripts in a `Vec<String>` instead of a fixed array
- resize the vector when assigning scripts

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_686eb94d95488328ae57a46157d3e5f4