### PR TITLE
Add persistence round-trip tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5987,6 +5987,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5995,6 +6004,16 @@ dependencies = [
  "hermit-abi 0.5.1",
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -7381,6 +7400,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "open"
+version = "5.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7550,6 +7580,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -9616,6 +9652,7 @@ dependencies = [
  "dirs",
  "i-slint-common 1.12.0 (git+https://github.com/slint-ui/slint?rev=939d605e0688b7ea4cb6e3a5b3f40d918a60a5db)",
  "once_cell",
+ "open",
  "pyo3",
  "rfd",
  "rusttype 0.9.3",
@@ -9626,7 +9663,9 @@ dependencies = [
  "slint-build",
  "survey_cad",
  "survey_cad_python",
+ "tempfile",
  "tiny-skia",
+ "truck-meshalgo",
  "truck-modeling",
  "truck_cad_engine",
 ]

--- a/survey_cad/src/layers.rs
+++ b/survey_cad/src/layers.rs
@@ -4,7 +4,7 @@ use crate::geometry::LineType;
 use crate::styles::{LineWeight, TextStyle};
 
 /// Representation of a drawing layer.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Layer {
     pub name: String,
     pub is_on: bool,
@@ -33,7 +33,7 @@ impl Layer {
 }
 
 /// Manager for an arbitrary number of layers.
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct LayerManager {
     layers: HashMap<String, Layer>,
 }

--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -33,3 +33,6 @@ las = ["survey_cad/las"]
 kml = ["survey_cad/kml"]
 fgdb = ["survey_cad/fgdb"]
 e57 = ["survey_cad/e57"]
+
+[dev-dependencies]
+tempfile = "3"

--- a/survey_cad_truck_gui/src/persistence.rs
+++ b/survey_cad_truck_gui/src/persistence.rs
@@ -8,7 +8,7 @@ use survey_cad::geometry::line::LineStyle;
 use survey_cad::geometry::point::PointStyle;
 use survey_cad::styles::{LineLabelStyle, PointLabelStyle, PolygonStyle};
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub struct StyleSettings {
     pub point_styles: Vec<(String, PointStyle)>,
     pub line_styles: Vec<(String, LineStyle)>,
@@ -36,4 +36,65 @@ pub fn save_styles(path: &Path, styles: &StyleSettings) -> std::io::Result<()> {
 pub fn load_styles(path: &Path) -> Option<StyleSettings> {
     let data = fs::read_to_string(path).ok()?;
     serde_json::from_str(&data).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+    use survey_cad::layers::{Layer, LayerManager};
+    use survey_cad::geometry::{line::LineType, point::PointSymbol};
+    use survey_cad::styles::{LineLabelPosition, LineWeight, TextStyle};
+
+    #[test]
+    fn layer_manager_round_trip() {
+        let mut mgr = LayerManager::new();
+        mgr.add_layer(Layer::new("layer1"));
+        mgr.add_layer(Layer::new("layer2"));
+
+        let file = NamedTempFile::new().unwrap();
+        save_layers(file.path(), &mgr).unwrap();
+        let loaded = load_layers(file.path()).unwrap();
+        assert_eq!(mgr, loaded);
+    }
+
+    #[test]
+    fn style_settings_round_trip() {
+        let styles = StyleSettings {
+            point_styles: vec![(
+                "p".into(),
+                PointStyle::new(PointSymbol::Circle, [1, 2, 3], 1.0),
+            )],
+            line_styles: vec![(
+                "l".into(),
+                LineStyle::new(LineType::Solid, [4, 5, 6], LineWeight(0.5)),
+            )],
+            polygon_styles: vec![("poly".into(), PolygonStyle::default())],
+            alignment_styles: vec![(
+                "align".into(),
+                LineStyle::new(LineType::Dashed, [7, 8, 9], LineWeight(0.7)),
+            )],
+            line_label_styles: vec![(
+                "ll".into(),
+                LineLabelStyle::new(
+                    TextStyle::new("txt", "Arial", 10.0),
+                    [10, 11, 12],
+                    LineLabelPosition::Above,
+                ),
+            )],
+            point_label_styles: vec![(
+                "pl".into(),
+                PointLabelStyle::new(
+                    TextStyle::new("txt", "Arial", 10.0),
+                    [13, 14, 15],
+                    [1.0, 2.0],
+                ),
+            )],
+        };
+
+        let file = NamedTempFile::new().unwrap();
+        save_styles(file.path(), &styles).unwrap();
+        let loaded = load_styles(file.path()).unwrap();
+        assert_eq!(styles, loaded);
+    }
 }


### PR DESCRIPTION
## Summary
- derive `Debug` and `PartialEq` for `StyleSettings`
- derive `PartialEq` for layer types
- use `tempfile` as a dev dependency
- add round‑trip tests for layer and style persistence

## Testing
- `cargo test -p survey_cad_truck_gui --no-run` *(fails to complete due to heavy dependency compilation)*

------
https://chatgpt.com/codex/tasks/task_e_686fa5c6ee74832883a946a019bbee81