### PR TITLE
Fix Clippy warning in truck gui

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -1082,8 +1082,8 @@ fn calc_section_params(
     if section.points.len() < 2 {
         return None;
     }
-    let Some(first) = section.points.first() else { return None };
-    let Some(last) = section.points.last() else { return None };
+    let first = section.points.first()?;
+    let last = section.points.last()?;
     let dx = last.x - first.x;
     let dy = last.y - first.y;
     let len = (dx * dx + dy * dy).sqrt();


### PR DESCRIPTION
## Summary
- fix clippy::question_mark warnings by using `?` in `calc_section_params`

## Testing
- `cargo check -p survey_cad_truck_gui --locked`
- `cargo test --workspace --no-run` *(fails to finish due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_686fb443f4748328a5f088099e4154e1