### PR TITLE
Fix clone of selected points in python context

### DIFF
--- a/survey_cad_truck_gui/src/python.rs
+++ b/survey_cad_truck_gui/src/python.rs
@@ -127,7 +127,7 @@ pub fn run_python_file(path: &Path, ctx: &PythonContext) {
                     })
                     .collect::<PyResult<_>>()?;
 
-                let selected_pts: Vec<usize> = ctx.selected_points.borrow().clone();
+                let selected_pts: Vec<usize> = ctx.selected_points.borrow().to_vec();
                 let selected_lines_py: Vec<(Py<survey_cad_python::Point>, Py<survey_cad_python::Point>)> = ctx
                     .selected_lines
                     .borrow()


### PR DESCRIPTION
## Summary
- avoid cloning selected_points vec when running python scripts

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_686fea53293c8328ab95d087b0f605ff