### PR TITLE
Fix font load error handling

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -1677,7 +1677,7 @@ fn main() -> Result<(), slint::PlatformError> {
     // provide our bundled DejaVuSans.
     sharedfontdb::FONT_DB.with_borrow_mut(|db| db.make_mut().load_system_fonts());
     if let Some(path) = config.borrow().font_path.as_ref() {
-        if let Err(_) = sharedfontdb::register_font_from_path(Path::new(path)) {
+        if sharedfontdb::register_font_from_path(Path::new(path)).is_err() {
             sharedfontdb::register_font_from_memory(FONT_DATA)
                 .expect("failed to register embedded font");
         }


### PR DESCRIPTION
## Summary
- simplify redundant pattern matching using `is_err`

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo clippy -p survey_cad_truck_gui -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_686ff98bae4083289b7a080683d7ab76