### PR TITLE
Fix unused imports and variant

### DIFF
--- a/survey_cad_truck_gui/src/cross_section.rs
+++ b/survey_cad_truck_gui/src/cross_section.rs
@@ -4,7 +4,7 @@ use tiny_skia::{Color, Paint, PathBuilder, Pixmap, Stroke, Transform};
 
 use survey_cad::alignment::{VerticalAlignment, VerticalElement};
 use survey_cad::corridor;
-use survey_cad::geometry::{Line, LineAnnotation, Point, Point3 as ScPoint3};
+use survey_cad::geometry::Point3 as ScPoint3;
 
 /// Parameters for mapping section coordinates to screen coordinates.
 pub struct SectionParams {
@@ -30,12 +30,20 @@ pub fn render_cross_section(
     paint.anti_alias = true;
 
     if section.points.len() >= 2 {
-        let Some(first) = section.points.first() else { return Ok(Image::default()); };
-        let Some(last) = section.points.last() else { return Ok(Image::default()); };
+        let Some(first) = section.points.first() else {
+            return Ok(Image::default());
+        };
+        let Some(last) = section.points.last() else {
+            return Ok(Image::default());
+        };
         let dx = last.x - first.x;
         let dy = last.y - first.y;
         let len = (dx * dx + dy * dy).sqrt();
-        let dir = if len.abs() < f64::EPSILON { (1.0, 0.0) } else { (dx / len, dy / len) };
+        let dir = if len.abs() < f64::EPSILON {
+            (1.0, 0.0)
+        } else {
+            (dx / len, dy / len)
+        };
         let center = section.points[section.points.len() / 2];
         let mut pts = Vec::new();
         let mut min_x = f32::MAX;
@@ -57,7 +65,8 @@ pub fn render_cross_section(
         if (max_y - min_y).abs() < f32::EPSILON {
             max_y += 1.0;
         }
-        let scale = ((width as f32 * 0.8) / (max_x - min_x)).min((height as f32 * 0.8) / (max_y - min_y));
+        let scale =
+            ((width as f32 * 0.8) / (max_x - min_x)).min((height as f32 * 0.8) / (max_y - min_y));
         let ox = width as f32 / 2.0 - scale * (min_x + max_x) / 2.0;
         let oy = height as f32 / 2.0 + scale * (min_y + max_y) / 2.0;
         let mut pb = PathBuilder::new();
@@ -71,7 +80,10 @@ pub fn render_cross_section(
             }
         }
         if let Some(path) = pb.finish() {
-            let stroke = Stroke { width: 2.0, ..Stroke::default() };
+            let stroke = Stroke {
+                width: 2.0,
+                ..Stroke::default()
+            };
             pixmap.stroke_path(&path, &paint, &stroke, Transform::identity(), None);
         }
     }
@@ -97,7 +109,11 @@ pub fn calc_section_params(
     let dx = last.x - first.x;
     let dy = last.y - first.y;
     let len = (dx * dx + dy * dy).sqrt();
-    let dir = if len.abs() < f64::EPSILON { (1.0, 0.0) } else { (dx / len, dy / len) };
+    let dir = if len.abs() < f64::EPSILON {
+        (1.0, 0.0)
+    } else {
+        (dx / len, dy / len)
+    };
     let center = section.points[section.points.len() / 2];
     let mut min_x = f32::MAX;
     let mut max_x = f32::MIN;
@@ -120,7 +136,13 @@ pub fn calc_section_params(
     let scale = ((width * 0.8) / (max_x - min_x)).min((height * 0.8) / (max_y - min_y));
     let ox = width / 2.0 - scale * (min_x + max_x) / 2.0;
     let oy = height / 2.0 + scale * (min_y + max_y) / 2.0;
-    Some(SectionParams { dir, center, scale, ox, oy })
+    Some(SectionParams {
+        dir,
+        center,
+        scale,
+        ox,
+        oy,
+    })
 }
 
 pub fn screen_to_world(
@@ -151,7 +173,8 @@ pub fn nearest_point(
     let mut best = None;
     let mut best_dist = f32::MAX;
     for (i, p) in section.points.iter().enumerate() {
-        let off = ((p.x - params.center.x) * params.dir.0 + (p.y - params.center.y) * params.dir.1) as f32;
+        let off = ((p.x - params.center.x) * params.dir.0 + (p.y - params.center.y) * params.dir.1)
+            as f32;
         let elev = (p.z - params.center.z) as f32;
         let sx = params.ox + off * params.scale;
         let sy = params.oy - elev * params.scale;
@@ -163,13 +186,22 @@ pub fn nearest_point(
             best = Some(i);
         }
     }
-    if best_dist.sqrt() <= 10.0 { best } else { None }
+    if best_dist.sqrt() <= 10.0 {
+        best
+    } else {
+        None
+    }
 }
 
 pub fn grade_at(profile: &VerticalAlignment, station: f64) -> Option<f64> {
     for elem in &profile.elements {
         match *elem {
-            VerticalElement::Grade { start_station, end_station, start_elev, end_elev } => {
+            VerticalElement::Grade {
+                start_station,
+                end_station,
+                start_elev,
+                end_elev,
+            } => {
                 if station >= start_station && station <= end_station {
                     if (end_station - start_station).abs() < f64::EPSILON {
                         return Some(0.0);
@@ -177,7 +209,13 @@ pub fn grade_at(profile: &VerticalAlignment, station: f64) -> Option<f64> {
                     return Some((end_elev - start_elev) / (end_station - start_station));
                 }
             }
-            VerticalElement::Parabola { start_station, end_station, start_grade, end_grade, .. } => {
+            VerticalElement::Parabola {
+                start_station,
+                end_station,
+                start_grade,
+                end_grade,
+                ..
+            } => {
                 if station >= start_station && station <= end_station {
                     let t = (station - start_station) / (end_station - start_station);
                     return Some(start_grade + (end_grade - start_grade) * t);

--- a/survey_cad_truck_gui/src/inspector.rs
+++ b/survey_cad_truck_gui/src/inspector.rs
@@ -7,9 +7,8 @@ use slint::{ComponentHandle, Image, SharedString, VecModel};
 use survey_cad::geometry::Point;
 
 use crate::truck_backend::TruckBackend;
-use crate::{ContextMenu, EntityInspector, MainWindow};
-use crate::ui_state::DrawingMode; // maybe not used? Wait show_inspector functions use render_image etc
 use crate::workspace::refresh_workspace;
+use crate::{ContextMenu, EntityInspector, MainWindow};
 
 pub fn show_context_menu(
     app: &MainWindow,

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -2,28 +2,24 @@
 
 use i_slint_common::sharedfontdb;
 use slint::platform::PointerEventButton;
-use slint::{Image, Model, PhysicalSize, SharedString, VecModel};
+use slint::{Model, PhysicalSize, SharedString, VecModel};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Instant;
-use std::error::Error;
 
-use survey_cad::alignment::{Alignment, AlignmentGroup, VerticalAlignment, VerticalElement};
+use survey_cad::alignment::{Alignment, AlignmentGroup, VerticalAlignment};
 use survey_cad::corridor;
 use survey_cad::crs::list_known_crs;
-use survey_cad::dtm::{Tin, SurfaceGroup};
+use survey_cad::dtm::{SurfaceGroup, Tin};
 use survey_cad::geometry::point::PointStyle;
 use survey_cad::geometry::{
-    convex_hull, Arc, Line, LineAnnotation, LineStyle, LineType, LinearDimension, Point,
-    Point3 as ScPoint3, PointSymbol, Polyline,
+    convex_hull, Arc, Line, LineStyle, LineType, LinearDimension, Point, Point3 as ScPoint3,
+    Polyline,
 };
 use survey_cad::io::project::{read_project_json, write_project_json, GridSettings, Project};
 use survey_cad::layers::{Layer, LayerManager as ScLayerManager};
 use survey_cad::point_database::PointDatabase;
-use survey_cad::styles::{
-    format_dms, HatchPattern, LineLabelPosition, LineWeight,
-    TextStyle as ScTextStyle, default_alignment_styles,
-};
+use survey_cad::styles::{default_alignment_styles, LineWeight, TextStyle as ScTextStyle};
 use survey_cad::subassembly;
 use survey_cad::superelevation::SuperelevationPoint;
 mod snap;
@@ -39,34 +35,42 @@ mod truck_backend;
 use truck_backend::{HitObject, TruckBackend};
 mod persistence;
 use persistence::{load_layers, load_styles, save_layers, save_styles, StyleSettings};
-mod ui_state;
 mod commands;
+mod cross_section;
+mod inspector;
+mod io_utils;
 mod python;
 mod render;
+mod ui_state;
 mod workspace;
-mod cross_section;
-mod io_utils;
-mod inspector;
 
+use commands::{
+    record_macro, spawn_line, spawn_point, Command, CommandStack, Context, MacroPlaying,
+    MacroRecorder,
+};
+pub use cross_section::{
+    calc_section_params, grade_at, nearest_point, render_cross_section, screen_to_world,
+    SectionParams,
+};
+pub use inspector::{
+    has_selection, show_context_menu, show_inspector_for_point, show_inspector_for_polygon,
+};
+pub use io_utils::{read_arc_csv, read_line_csv, read_points_list};
 use once_cell::sync::Lazy;
-pub use workspace::{render_workspace, refresh_workspace, set_workspace_image_result};
-pub use cross_section::{render_cross_section, calc_section_params, screen_to_world, nearest_point, grade_at, SectionParams};
-pub use io_utils::{read_line_csv, read_points_list, read_arc_csv};
-pub use inspector::{show_context_menu, has_selection, show_inspector_for_point, show_inspector_for_polygon};
-use commands::{Command, CommandStack, Context, MacroPlaying, MacroRecorder, record_macro, spawn_line, spawn_point};
-use python::{MacroContext, PythonContext, play_macro_file, run_python_file};
-use render::{
-    WorkspaceRenderData, RenderState, RenderStyles, draw_text, screen_to_workspace,
-    workspace_to_screen, arc_from_three_points, arc_from_start_end_radius, polyline_to_solid,
-};
-use ui_state::{
-    CursorFeedback, DragSelect, Vec2, DrawingMode, Theme,
-    WorkspaceProfile, load_config, save_config,
-};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use python::{play_macro_file, run_python_file, MacroContext, PythonContext};
+use render::{
+    arc_from_start_end_radius, arc_from_three_points, polyline_to_solid, screen_to_workspace,
+    workspace_to_screen, RenderState, RenderStyles, WorkspaceRenderData,
+};
 use rusttype::Font;
-use tiny_skia::{Color, FillRule, Paint, PathBuilder, Pixmap, Stroke, Transform};
+use tiny_skia::Pixmap;
+use ui_state::{
+    load_config, save_config, CursorFeedback, DragSelect, DrawingMode, Theme, Vec2,
+    WorkspaceProfile,
+};
+pub use workspace::{refresh_workspace, render_workspace, set_workspace_image_result};
 
 slint::include_modules!();
 
@@ -74,9 +78,7 @@ slint::include_modules!();
 // the `DEFAULT_FONT_PATH` environment variable, which can be overridden with
 // `SURVEY_CAD_FONT` when building.
 static FONT_DATA: &[u8] = include_bytes!(env!("DEFAULT_FONT_PATH"));
-static FONT: Lazy<Font<'static>> =
-    Lazy::new(|| Font::try_from_bytes(FONT_DATA).unwrap());
-
+static FONT: Lazy<Font<'static>> = Lazy::new(|| Font::try_from_bytes(FONT_DATA).unwrap());
 
 fn main() -> Result<(), slint::PlatformError> {
     let mut cmd_font: Option<String> = None;
@@ -2275,7 +2277,9 @@ fn main() -> Result<(), slint::PlatformError> {
                             surfaces.borrow_mut().clear();
                             surfaces.borrow_mut().extend(proj.surfaces.clone());
                             surface_groups.borrow_mut().clear();
-                            surface_groups.borrow_mut().extend(proj.surface_groups.clone());
+                            surface_groups
+                                .borrow_mut()
+                                .extend(proj.surface_groups.clone());
                             surface_units_ref.borrow_mut().clear();
                             surface_units_ref
                                 .borrow_mut()
@@ -2291,7 +2295,9 @@ fn main() -> Result<(), slint::PlatformError> {
                             alignments.borrow_mut().clear();
                             alignments.borrow_mut().extend(proj.alignments.clone());
                             alignment_groups.borrow_mut().clear();
-                            alignment_groups.borrow_mut().extend(proj.alignment_groups.clone());
+                            alignment_groups
+                                .borrow_mut()
+                                .extend(proj.alignment_groups.clone());
                             *line_style_indices.borrow_mut() = proj.line_style_indices.clone();
                             *point_style_indices.borrow_mut() = proj.point_style_indices.clone();
                             *polygon_style_indices.borrow_mut() =
@@ -2820,7 +2826,10 @@ fn main() -> Result<(), slint::PlatformError> {
                                                 polygons.borrow().len()
                                             )));
                                             if app.get_workspace_mode() == 0 {
-                                                crate::set_workspace_image_result(&app, &render_image);
+                                                crate::set_workspace_image_result(
+                                                    &app,
+                                                    &render_image,
+                                                );
                                                 app.window().request_redraw();
                                             }
                                         }
@@ -2944,7 +2953,10 @@ fn main() -> Result<(), slint::PlatformError> {
                                                 polylines.borrow().len()
                                             )));
                                             if app.get_workspace_mode() == 0 {
-                                                crate::set_workspace_image_result(&app, &render_image);
+                                                crate::set_workspace_image_result(
+                                                    &app,
+                                                    &render_image,
+                                                );
                                                 app.window().request_redraw();
                                             }
                                         }
@@ -3974,11 +3986,20 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_y_val().parse::<f64>(),
                         d.get_z_val().parse::<f64>(),
                     ) {
-                        let targets = if let Some(g) = surface_groups_inner.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                        let targets = if let Some(g) = surface_groups_inner
+                            .borrow()
+                            .iter()
+                            .find(|g| g.surface_ids.contains(&surf))
+                        {
                             g.surface_ids.clone()
-                        } else { vec![surf] };
+                        } else {
+                            vec![surf]
+                        };
                         for sidx in targets {
-                            if let Some(idx) = backend_inner.borrow_mut().add_vertex(sidx, Point3::new(x, y, z)) {
+                            if let Some(idx) = backend_inner
+                                .borrow_mut()
+                                .add_vertex(sidx, Point3::new(x, y, z))
+                            {
                                 command_stack.borrow_mut().push(Command::TinDeleteVertex {
                                     surface: sidx,
                                     index: idx,
@@ -4024,9 +4045,15 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_y_val().parse::<f64>(),
                         d.get_z_val().parse::<f64>(),
                     ) {
-                        let targets = if let Some(g) = surface_groups_inner.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                        let targets = if let Some(g) = surface_groups_inner
+                            .borrow()
+                            .iter()
+                            .find(|g| g.surface_ids.contains(&surf))
+                        {
                             g.surface_ids.clone()
-                        } else { vec![surf] };
+                        } else {
+                            vec![surf]
+                        };
                         for sidx in targets {
                             backend_inner
                                 .borrow_mut()
@@ -4070,9 +4097,15 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_surface_index().parse::<usize>(),
                         d.get_vertex_index().parse::<usize>(),
                     ) {
-                        let targets = if let Some(g) = surface_groups_inner.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                        let targets = if let Some(g) = surface_groups_inner
+                            .borrow()
+                            .iter()
+                            .find(|g| g.surface_ids.contains(&surf))
+                        {
                             g.surface_ids.clone()
-                        } else { vec![surf] };
+                        } else {
+                            vec![surf]
+                        };
                         for sidx in targets {
                             backend_inner.borrow_mut().delete_vertex(sidx, idx);
                         }
@@ -4113,9 +4146,15 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_v2().parse::<usize>(),
                         d.get_v3().parse::<usize>(),
                     ) {
-                        let targets = if let Some(g) = surface_groups_inner.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                        let targets = if let Some(g) = surface_groups_inner
+                            .borrow()
+                            .iter()
+                            .find(|g| g.surface_ids.contains(&surf))
+                        {
                             g.surface_ids.clone()
-                        } else { vec![surf] };
+                        } else {
+                            vec![surf]
+                        };
                         for sidx in targets {
                             backend_inner.borrow_mut().add_triangle(sidx, [a, b, c]);
                         }
@@ -4157,9 +4196,15 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_surface_index().parse::<usize>(),
                         d.get_tri_index().parse::<usize>(),
                     ) {
-                        let targets = if let Some(g) = surface_groups_inner.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                        let targets = if let Some(g) = surface_groups_inner
+                            .borrow()
+                            .iter()
+                            .find(|g| g.surface_ids.contains(&surf))
+                        {
                             g.surface_ids.clone()
-                        } else { vec![surf] };
+                        } else {
+                            vec![surf]
+                        };
                         for sidx in targets {
                             backend_inner.borrow_mut().delete_triangle(sidx, idx);
                         }
@@ -4199,9 +4244,15 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_v1().parse::<usize>(),
                         d.get_v2().parse::<usize>(),
                     ) {
-                        let targets = if let Some(g) = surface_groups_inner.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                        let targets = if let Some(g) = surface_groups_inner
+                            .borrow()
+                            .iter()
+                            .find(|g| g.surface_ids.contains(&surf))
+                        {
                             g.surface_ids.clone()
-                        } else { vec![surf] };
+                        } else {
+                            vec![surf]
+                        };
                         for sidx in targets {
                             backend_inner.borrow_mut().add_breakline(sidx, a, b);
                         }
@@ -4241,9 +4292,15 @@ fn main() -> Result<(), slint::PlatformError> {
                         d.get_v1().parse::<usize>(),
                         d.get_v2().parse::<usize>(),
                     ) {
-                        let targets = if let Some(g) = surface_groups_inner.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                        let targets = if let Some(g) = surface_groups_inner
+                            .borrow()
+                            .iter()
+                            .find(|g| g.surface_ids.contains(&surf))
+                        {
                             g.surface_ids.clone()
-                        } else { vec![surf] };
+                        } else {
+                            vec![surf]
+                        };
                         for sidx in targets {
                             backend_inner.borrow_mut().remove_breakline(sidx, a, b);
                         }
@@ -4284,9 +4341,15 @@ fn main() -> Result<(), slint::PlatformError> {
                             .split(|c: char| c == ',' || c.is_whitespace())
                             .filter_map(|s| s.parse().ok())
                             .collect();
-                        let targets = if let Some(g) = surface_groups_inner.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                        let targets = if let Some(g) = surface_groups_inner
+                            .borrow()
+                            .iter()
+                            .find(|g| g.surface_ids.contains(&surf))
+                        {
                             g.surface_ids.clone()
-                        } else { vec![surf] };
+                        } else {
+                            vec![surf]
+                        };
                         for sidx in targets {
                             backend_inner.borrow_mut().set_boundary(sidx, verts.clone());
                         }
@@ -4323,9 +4386,15 @@ fn main() -> Result<(), slint::PlatformError> {
             dlg.on_accept(move || {
                 if let Some(d) = dlg_weak.upgrade() {
                     if let Ok(surf) = d.get_surface_index().parse::<usize>() {
-                        let targets = if let Some(g) = surface_groups_inner.borrow().iter().find(|g| g.surface_ids.contains(&surf)) {
+                        let targets = if let Some(g) = surface_groups_inner
+                            .borrow()
+                            .iter()
+                            .find(|g| g.surface_ids.contains(&surf))
+                        {
                             g.surface_ids.clone()
-                        } else { vec![surf] };
+                        } else {
+                            vec![surf]
+                        };
                         for sidx in targets {
                             backend_inner.borrow_mut().clear_boundary(sidx);
                         }
@@ -4816,7 +4885,10 @@ fn main() -> Result<(), slint::PlatformError> {
                                                     "Imported {len} points"
                                                 )));
                                                 if app.get_workspace_mode() == 0 {
-                                                    crate::set_workspace_image_result(&app, &render_image);
+                                                    crate::set_workspace_image_result(
+                                                        &app,
+                                                        &render_image,
+                                                    );
                                                 } else {
                                                     let image =
                                                         backend_render.borrow_mut().render();
@@ -4946,7 +5018,10 @@ fn main() -> Result<(), slint::PlatformError> {
                                                     "Imported {len} points"
                                                 )));
                                                 if app.get_workspace_mode() == 0 {
-                                                    crate::set_workspace_image_result(&app, &render_image);
+                                                    crate::set_workspace_image_result(
+                                                        &app,
+                                                        &render_image,
+                                                    );
                                                 } else {
                                                     let image =
                                                         backend_render.borrow_mut().render();
@@ -6050,7 +6125,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     .borrow()
                     .iter()
                     .map(|g| SharedString::from(g.name.clone()))
-                    .collect::<Vec<_>>()
+                    .collect::<Vec<_>>(),
             ));
             dlg.set_groups_model(model.clone().into());
             dlg.set_selected_index(-1);
@@ -6059,7 +6134,10 @@ fn main() -> Result<(), slint::PlatformError> {
                 let model = model.clone();
                 dlg.on_create_group(move || {
                     let name = format!("Group {}", surface_groups.borrow().len() + 1);
-                    surface_groups.borrow_mut().push(SurfaceGroup { name: name.clone(), surface_ids: Vec::new() });
+                    surface_groups.borrow_mut().push(SurfaceGroup {
+                        name: name.clone(),
+                        surface_ids: Vec::new(),
+                    });
                     model.push(SharedString::from(name));
                 });
             }
@@ -6067,11 +6145,13 @@ fn main() -> Result<(), slint::PlatformError> {
                 let surface_groups = surface_groups.clone();
                 let model = model.clone();
                 dlg.on_rename_group(move |idx| {
-                    if idx >= 0 { if let Some(g) = surface_groups.borrow_mut().get_mut(idx as usize) {
-                        let new_name = format!("Group {}", idx + 1);
-                        g.name = new_name.clone();
-                        model.set_row_data(idx as usize, SharedString::from(new_name));
-                    } }
+                    if idx >= 0 {
+                        if let Some(g) = surface_groups.borrow_mut().get_mut(idx as usize) {
+                            let new_name = format!("Group {}", idx + 1);
+                            g.name = new_name.clone();
+                            model.set_row_data(idx as usize, SharedString::from(new_name));
+                        }
+                    }
                 });
             }
             dlg.show().unwrap();
@@ -6088,7 +6168,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     .borrow()
                     .iter()
                     .map(|g| SharedString::from(g.name.clone()))
-                    .collect::<Vec<_>>()
+                    .collect::<Vec<_>>(),
             ));
             dlg.set_groups_model(model.clone().into());
             dlg.set_selected_index(-1);
@@ -6097,7 +6177,10 @@ fn main() -> Result<(), slint::PlatformError> {
                 let model = model.clone();
                 dlg.on_create_group(move || {
                     let name = format!("Group {}", alignment_groups.borrow().len() + 1);
-                    alignment_groups.borrow_mut().push(AlignmentGroup { name: name.clone(), alignment_ids: Vec::new() });
+                    alignment_groups.borrow_mut().push(AlignmentGroup {
+                        name: name.clone(),
+                        alignment_ids: Vec::new(),
+                    });
                     model.push(SharedString::from(name));
                 });
             }
@@ -6105,11 +6188,13 @@ fn main() -> Result<(), slint::PlatformError> {
                 let alignment_groups = alignment_groups.clone();
                 let model = model.clone();
                 dlg.on_rename_group(move |idx| {
-                    if idx >= 0 { if let Some(g) = alignment_groups.borrow_mut().get_mut(idx as usize) {
-                        let new_name = format!("Group {}", idx + 1);
-                        g.name = new_name.clone();
-                        model.set_row_data(idx as usize, SharedString::from(new_name));
-                    } }
+                    if idx >= 0 {
+                        if let Some(g) = alignment_groups.borrow_mut().get_mut(idx as usize) {
+                            let new_name = format!("Group {}", idx + 1);
+                            g.name = new_name.clone();
+                            model.set_row_data(idx as usize, SharedString::from(new_name));
+                        }
+                    }
                 });
             }
             dlg.show().unwrap();
@@ -6370,9 +6455,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         _ => Theme::Dark,
                     };
                     cfg.theme = theme;
-                    cfg.font_path = fonts_cloned
-                        .get(d.get_font_index() as usize)
-                        .cloned();
+                    cfg.font_path = fonts_cloned.get(d.get_font_index() as usize).cloned();
                     drop(cfg);
                     if let Ok(epsg) = d.get_crs_epsg().parse::<u32>() {
                         *crs_ref.borrow_mut() = epsg;

--- a/survey_cad_truck_gui/src/workspace.rs
+++ b/survey_cad_truck_gui/src/workspace.rs
@@ -2,17 +2,17 @@ use std::cell::RefCell;
 use std::error::Error;
 use std::rc::Rc;
 
-use slint::Image;
+use slint::{ComponentHandle, Image};
 use tiny_skia::{Color, FillRule, Paint, PathBuilder, Pixmap, Stroke, Transform};
 
-use survey_cad::geometry::{Line, LineAnnotation, LineType, Point};
+use survey_cad::geometry::{Line, LineAnnotation, LineType};
 use survey_cad::io::project::GridSettings;
 use survey_cad::styles::{format_dms, HatchPattern, LineLabelPosition};
 
 use crate::render::{draw_text, RenderState, RenderStyles, WorkspaceRenderData};
-use crate::ui_state::{CursorFeedback, DragSelect, DrawingMode};
-use crate::{MainWindow, FONT};
 use crate::truck_backend::TruckBackend;
+use crate::ui_state::DrawingMode;
+use crate::{MainWindow, FONT};
 
 pub fn render_workspace(
     data: &WorkspaceRenderData,
@@ -33,9 +33,17 @@ pub fn render_workspace(
         pixmap.fill(Color::from_rgba8(32, 32, 32, 255));
     }
     let mut paint = Paint::default();
-    paint.set_color(Color::from_rgba8(grid.color[0], grid.color[1], grid.color[2], 255));
+    paint.set_color(Color::from_rgba8(
+        grid.color[0],
+        grid.color[1],
+        grid.color[2],
+        255,
+    ));
     paint.anti_alias = true;
-    let grid_stroke = Stroke { width: 1.0, ..Stroke::default() };
+    let grid_stroke = Stroke {
+        width: 1.0,
+        ..Stroke::default()
+    };
     let origin_x = width as f32 / 2.0;
     let origin_y = height as f32 / 2.0;
     let zoom_val = *state.zoom.borrow();
@@ -123,8 +131,16 @@ pub fn render_workspace(
         if selected {
             style.color = [255, 255, 0];
         }
-        paint.set_color(Color::from_rgba8(style.color[0], style.color[1], style.color[2], 255));
-        let mut stroke = Stroke { width: style.weight.0, ..Stroke::default() };
+        paint.set_color(Color::from_rgba8(
+            style.color[0],
+            style.color[1],
+            style.color[2],
+            255,
+        ));
+        let mut stroke = Stroke {
+            width: style.weight.0,
+            ..Stroke::default()
+        };
         use tiny_skia::StrokeDash;
         match style.line_type {
             LineType::Dashed => stroke.dash = StrokeDash::new(vec![10.0, 10.0], 0.0),
@@ -135,7 +151,10 @@ pub fn render_workspace(
         pb.move_to(tx(s.x as f32), ty(s.y as f32));
         pb.line_to(tx(e.x as f32), ty(e.y as f32));
         if let Some(path) = pb.finish() {
-            let stroke = Stroke { width: 1.0, ..Stroke::default() };
+            let stroke = Stroke {
+                width: 1.0,
+                ..Stroke::default()
+            };
             pixmap.stroke_path(&path, &paint, &stroke, Transform::identity(), None);
         }
 
@@ -209,7 +228,13 @@ pub fn render_workspace(
                 pstyle.fill_color[2],
                 255,
             ));
-            pixmap.fill_path(&path, &paint, FillRule::Winding, Transform::identity(), None);
+            pixmap.fill_path(
+                &path,
+                &paint,
+                FillRule::Winding,
+                Transform::identity(),
+                None,
+            );
 
             if pstyle.hatch_pattern != HatchPattern::None {
                 paint.set_color(Color::from_rgba8(
@@ -218,30 +243,53 @@ pub fn render_workspace(
                     pstyle.hatch_color[2],
                     255,
                 ));
-                let stroke = Stroke { width: 1.0, ..Stroke::default() };
+                let stroke = Stroke {
+                    width: 1.0,
+                    ..Stroke::default()
+                };
                 {
                     let bb = path.bounds();
                     let step = 10.0;
-                    if matches!(pstyle.hatch_pattern, HatchPattern::Cross | HatchPattern::Grid) {
+                    if matches!(
+                        pstyle.hatch_pattern,
+                        HatchPattern::Cross | HatchPattern::Grid
+                    ) {
                         let mut x = bb.left();
                         while x <= bb.right() {
                             let mut pb = PathBuilder::new();
                             pb.move_to(x, bb.top());
                             pb.line_to(x, bb.bottom());
                             if let Some(p) = pb.finish() {
-                                pixmap.stroke_path(&p, &paint, &stroke, Transform::identity(), None);
+                                pixmap.stroke_path(
+                                    &p,
+                                    &paint,
+                                    &stroke,
+                                    Transform::identity(),
+                                    None,
+                                );
                             }
                             x += step;
                         }
                     }
-                    if matches!(pstyle.hatch_pattern, HatchPattern::Cross | HatchPattern::DiagonalCross) {
+                    if matches!(
+                        pstyle.hatch_pattern,
+                        HatchPattern::ForwardDiagonal
+                            | HatchPattern::BackwardDiagonal
+                            | HatchPattern::Cross
+                    ) {
                         let mut x = bb.left();
                         while x <= bb.right() {
                             let mut pb = PathBuilder::new();
                             pb.move_to(x, bb.top());
                             pb.line_to(x + bb.height(), bb.bottom());
                             if let Some(p) = pb.finish() {
-                                pixmap.stroke_path(&p, &paint, &stroke, Transform::identity(), None);
+                                pixmap.stroke_path(
+                                    &p,
+                                    &paint,
+                                    &stroke,
+                                    Transform::identity(),
+                                    None,
+                                );
                             }
                             x += step;
                         }
@@ -258,7 +306,10 @@ pub fn render_workspace(
         let x2 = ds.start.0.max(ds.end.0);
         let y2 = ds.start.1.max(ds.end.1);
         paint.set_color(Color::from_rgba8(255, 255, 255, 128));
-        let rect_stroke = Stroke { width: 1.0, ..Stroke::default() };
+        let rect_stroke = Stroke {
+            width: 1.0,
+            ..Stroke::default()
+        };
         let mut pb = PathBuilder::new();
         pb.move_to(x1, y1);
         pb.line_to(x2, y1);
@@ -284,7 +335,16 @@ pub fn render_workspace(
         pb.move_to(cf.pos.0, cf.pos.1 - 5.0);
         pb.line_to(cf.pos.0, cf.pos.1 + 5.0);
         if let Some(path) = pb.finish() {
-            pixmap.stroke_path(&path, &paint, &Stroke { width: 1.0, ..Stroke::default() }, Transform::identity(), None);
+            pixmap.stroke_path(
+                &path,
+                &paint,
+                &Stroke {
+                    width: 1.0,
+                    ..Stroke::default()
+                },
+                Transform::identity(),
+                None,
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- remove unused imports and fix style hints
- import ComponentHandle to access window methods
- replace invalid hatch pattern enum usage
- clean up inspector module import
- remove unused geometry imports in cross_section

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_687011d4d53c8328967c2939483b52c4