### PR TITLE
Implement bulk scene clearing

### DIFF
--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -411,18 +411,11 @@ impl TruckBackend {
     }
 
     pub fn clear(&mut self) {
-        for _ in 0..self.point_ids.len() {
-            self.remove_point(0);
-        }
-        for _ in 0..self.line_ids.len() {
-            self.remove_line(0);
-        }
-        for _ in 0..self.dimension_ids.len() {
-            self.remove_dimension(0);
-        }
-        for _ in 0..self.surface_ids.len() {
-            self.remove_surface(0);
-        }
+        self.engine.clear_scene();
+        self.point_ids.clear();
+        self.line_ids.clear();
+        self.dimension_ids.clear();
+        self.surface_ids.clear();
         self.points.clear();
         self.lines.clear();
         self.dimensions.clear();

--- a/truck_cad_engine/src/lib.rs
+++ b/truck_cad_engine/src/lib.rs
@@ -293,6 +293,15 @@ impl TruckCadEngine {
         }
     }
 
+    /// Remove all objects from the scene.
+    pub fn clear_scene(&mut self) {
+        self.scene.clear_objects();
+        self.instances.clear();
+        self.point_markers.clear();
+        self.lines.clear();
+        self.surfaces.clear();
+    }
+
     /// Add a vertex to an existing surface and return its index.
     pub fn add_surface_vertex(
         &mut self,


### PR DESCRIPTION
## Summary
- add `clear_scene` method to `TruckCadEngine`
- use new call in `TruckBackend::clear` to wipe vectors without looping

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68710160d694832881316b2a8e1cb817