### PR TITLE
Improve error handling in truck GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9708,6 +9708,7 @@ dependencies = [
  "survey_cad",
  "survey_cad_python",
  "tempfile",
+ "thiserror 1.0.69",
  "tiny-skia",
  "truck-meshalgo",
  "truck-modeling",

--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -23,6 +23,7 @@ pyo3 = { version = "0.21", features = ["auto-initialize"] }
 survey_cad_python = { path = "../survey_cad_python" }
 open = "5"
 rstar = "0.9"
+thiserror = "1"
 
 [build-dependencies]
 slint-build = "1"

--- a/survey_cad_truck_gui/src/error.rs
+++ b/survey_cad_truck_gui/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GuiError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("UI error: {0}")]
+    Slint(#[from] slint::PlatformError),
+    #[error("Python error: {0}")]
+    Python(#[from] pyo3::PyErr),
+    #[error("{0}")]
+    Msg(String),
+}

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -36,6 +36,7 @@ use truck_backend::{HitObject, TruckBackend};
 mod persistence;
 use persistence::{load_layers, load_styles, save_layers, save_styles, StyleSettings};
 mod commands;
+mod error;
 mod cross_section;
 mod inspector;
 mod io_utils;
@@ -744,7 +745,11 @@ fn main() -> Result<(), slint::PlatformError> {
                             offset: offset.clone(),
                             zoom: zoom.clone(),
                         };
-                        run_python_file(&path, &ctx_py);
+                        if let Err(e) = run_python_file(&path, &ctx_py) {
+                            if let Some(app) = weak_run.upgrade() {
+                                app.set_status(SharedString::from(format!("Python error: {e}")));
+                            }
+                        }
                     } else {
                         let ctx = MacroContext {
                             playing: playing_run.clone(),
@@ -840,7 +845,11 @@ fn main() -> Result<(), slint::PlatformError> {
                         offset: offset_run.clone(),
                         zoom: zoom_run.clone(),
                     };
-                    run_python_file(&path, &ctx_py);
+                    if let Err(e) = run_python_file(&path, &ctx_py) {
+                        if let Some(app) = weak_run.upgrade() {
+                            app.set_status(SharedString::from(format!("Python error: {e}")));
+                        }
+                    }
                 }
             });
 
@@ -888,7 +897,11 @@ fn main() -> Result<(), slint::PlatformError> {
                         offset: offset.clone(),
                         zoom: zoom.clone(),
                     };
-                    run_python_file(&path, &ctx_py);
+                    if let Err(e) = run_python_file(&path, &ctx_py) {
+                        if let Some(app) = weak.upgrade() {
+                            app.set_status(SharedString::from(format!("Python error: {e}")));
+                        }
+                    }
                 } else {
                     let ctx = MacroContext {
                         playing: playing.clone(),
@@ -4802,7 +4815,15 @@ fn main() -> Result<(), slint::PlatformError> {
                             atomic::{AtomicBool, Ordering},
                             Arc,
                         };
-                        let dlg = ImportProgressDialog::new().unwrap();
+                        let dlg = match ImportProgressDialog::new() {
+                            Ok(d) => d,
+                            Err(e) => {
+                                if let Some(app) = weak.upgrade() {
+                                    app.set_status(SharedString::from(format!("UI error: {e}")));
+                                }
+                                return;
+                            }
+                        };
                         dlg.set_message(SharedString::from("Importing LAS"));
                         dlg.set_progress(0.0);
                         let cancel = Arc::new(AtomicBool::new(false));
@@ -4811,7 +4832,12 @@ fn main() -> Result<(), slint::PlatformError> {
                         dlg.on_cancel(move || {
                             cancel_dlg.store(true, Ordering::SeqCst);
                         });
-                        dlg.show().unwrap();
+                        if let Err(e) = dlg.show() {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!("UI error: {e}")));
+                            }
+                            return;
+                        }
                         use slint::{Timer, TimerMode};
                         use std::sync::mpsc;
 
@@ -4935,7 +4961,15 @@ fn main() -> Result<(), slint::PlatformError> {
                             atomic::{AtomicBool, Ordering},
                             Arc,
                         };
-                        let dlg = ImportProgressDialog::new().unwrap();
+                        let dlg = match ImportProgressDialog::new() {
+                            Ok(d) => d,
+                            Err(e) => {
+                                if let Some(app) = weak.upgrade() {
+                                    app.set_status(SharedString::from(format!("UI error: {e}")));
+                                }
+                                return;
+                            }
+                        };
                         dlg.set_message(SharedString::from("Importing E57"));
                         dlg.set_progress(0.0);
                         let cancel = Arc::new(AtomicBool::new(false));
@@ -4944,7 +4978,12 @@ fn main() -> Result<(), slint::PlatformError> {
                         dlg.on_cancel(move || {
                             cancel_dlg.store(true, Ordering::SeqCst);
                         });
-                        dlg.show().unwrap();
+                        if let Err(e) = dlg.show() {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!("UI error: {e}")));
+                            }
+                            return;
+                        }
                         use slint::{Timer, TimerMode};
                         use std::sync::mpsc;
 

--- a/survey_cad_truck_gui/src/python.rs
+++ b/survey_cad_truck_gui/src/python.rs
@@ -7,6 +7,7 @@ use pyo3::types::PyDict;
 use slint::{Image, SharedString, ComponentHandle};
 use slint::{Timer, TimerMode};
 use crate::ImportProgressDialog;
+use crate::error::GuiError;
 use std::sync::mpsc;
 
 use survey_cad::dtm::Tin;
@@ -88,15 +89,15 @@ pub fn play_macro_file(path: &Path, ctx: &MacroContext) {
     }
 }
 
-pub fn run_python_file(path: &Path, ctx: &PythonContext) {
+pub fn run_python_file(path: &Path, ctx: &PythonContext) -> Result<(), GuiError> {
     match std::fs::read_to_string(path) {
         Ok(code) => {
             use std::thread;
-            let dlg = ImportProgressDialog::new().unwrap();
+            let dlg = ImportProgressDialog::new()?;
             dlg.set_message(SharedString::from("Running Python script"));
             dlg.set_progress(0.0);
             let dlg_weak = dlg.as_weak();
-            dlg.show().unwrap();
+            dlg.show()?;
 
             let points: Vec<Point> = ctx.point_db.borrow().iter().copied().collect();
             let lines_vec: Vec<(Point, Point)> = ctx.lines.borrow().clone();
@@ -170,7 +171,7 @@ pub fn run_python_file(path: &Path, ctx: &PythonContext) {
 
                     py.run_bound(&code, Some(&globals), None)
                 });
-                let _ = tx.send(result.map_err(|e| e.to_string()));
+                let _ = tx.send(result.map_err(GuiError::from));
             });
 
             let timer = Rc::new(Timer::default());
@@ -202,6 +203,8 @@ pub fn run_python_file(path: &Path, ctx: &PythonContext) {
             if let Some(app) = ctx.weak.upgrade() {
                 app.set_status(SharedString::from(format!("Failed to read: {e}")));
             }
+            return Err(GuiError::from(e));
         }
     }
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add custom `GuiError` type for truck GUI
- propagate errors in `run_python_file`
- handle dialog creation failures and show messages
- update call sites to surface Python errors

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo test -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_687111f0cd548328ae0d1382d3dac135