### PR TITLE
Fix unused GuiError variant

### DIFF
--- a/survey_cad_truck_gui/src/error.rs
+++ b/survey_cad_truck_gui/src/error.rs
@@ -11,3 +11,15 @@ pub enum GuiError {
     #[error("{0}")]
     Msg(String),
 }
+
+impl From<String> for GuiError {
+    fn from(msg: String) -> Self {
+        GuiError::Msg(msg)
+    }
+}
+
+impl From<&str> for GuiError {
+    fn from(msg: &str) -> Self {
+        GuiError::Msg(msg.to_string())
+    }
+}

--- a/survey_cad_truck_gui/src/python.rs
+++ b/survey_cad_truck_gui/src/python.rs
@@ -90,6 +90,13 @@ pub fn play_macro_file(path: &Path, ctx: &MacroContext) {
 }
 
 pub fn run_python_file(path: &Path, ctx: &PythonContext) -> Result<(), GuiError> {
+    if !path.exists() {
+        return Err(GuiError::Msg(format!("File not found: {}", path.display())));
+    }
+    if path.extension().and_then(|e| e.to_str()) != Some("py") {
+        return Err(GuiError::Msg(format!("Not a Python file: {}", path.display())));
+    }
+
     match std::fs::read_to_string(path) {
         Ok(code) => {
             use std::thread;


### PR DESCRIPTION
## Summary
- allow constructing `GuiError` from string types
- use `GuiError::Msg` in `run_python_file` to surface missing/invalid script issues

## Testing
- `cargo check -p survey_cad_truck_gui --bin survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_68711bafec78832886a15444e686e66f