### PR TITLE
Fix clippy let-and-return lint

### DIFF
--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -226,11 +226,10 @@ impl TruckBackend {
             weight,
         );
         self.dimension_ids.push(Some(id));
-        let idx = self.geometry.add_dimension(
+        self.geometry.add_dimension(
             Point3::new(a[0], a[1], a[2]),
             Point3::new(b[0], b[1], b[2]),
-        );
-        idx
+        )
     }
 
     /// Remove an existing dimension.


### PR DESCRIPTION
## Summary
- fix `let_and_return` clippy lint in truck_backend

## Testing
- `cargo clippy -p survey_cad_truck_gui -- -D clippy::let_and_return`
- `cargo test -p survey_cad_truck_gui --no-run`

------
https://chatgpt.com/codex/tasks/task_e_687125b0c86083288309f8bf0662ba0d