### PR TITLE
Add integration tests for truck GUI

### DIFF
--- a/survey_cad_truck_gui/src/lib.rs
+++ b/survey_cad_truck_gui/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod commands;
+pub mod truck_backend;
+pub mod ui_state;
+pub mod geometry;
+pub mod snap;

--- a/survey_cad_truck_gui/tests/command_stack.rs
+++ b/survey_cad_truck_gui/tests/command_stack.rs
@@ -1,0 +1,75 @@
+use survey_cad_truck_gui::commands::{CommandStack, Command, Context, spawn_point};
+use survey_cad_truck_gui::truck_backend::TruckBackend;
+use survey_cad::point_database::PointDatabase;
+use survey_cad::geometry::Point;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[test]
+fn undo_redo_point() {
+    let points = Rc::new(RefCell::new(PointDatabase::new()));
+    let styles = Rc::new(RefCell::new(Vec::new()));
+    let lines = Rc::new(RefCell::new(Vec::new()));
+    let line_styles = Rc::new(RefCell::new(Vec::new()));
+    let dims = Rc::new(RefCell::new(Vec::new()));
+    let backend = Rc::new(RefCell::new(TruckBackend::new(1,1)));
+
+    let mut stack = CommandStack::new();
+    let mut ctx = Context {
+        points: &points,
+        point_styles: &styles,
+        lines: &lines,
+        line_styles: &line_styles,
+        dimensions: &dims,
+        backend: &backend,
+    };
+
+    let p = Point::new(1.0, 2.0);
+    spawn_point(&points, &styles, &backend, p);
+    stack.push(Command::RemovePoint { index: 0, point: p });
+
+    assert_eq!(points.borrow().len(), 1);
+    stack.undo(&ctx);
+    assert_eq!(points.borrow().len(), 0);
+    stack.redo(&ctx);
+    assert_eq!(points.borrow().len(), 1);
+}
+
+#[test]
+fn pushing_clears_redo() {
+    let points = Rc::new(RefCell::new(PointDatabase::new()));
+    let styles = Rc::new(RefCell::new(Vec::new()));
+    let lines = Rc::new(RefCell::new(Vec::new()));
+    let line_styles = Rc::new(RefCell::new(Vec::new()));
+    let dims = Rc::new(RefCell::new(Vec::new()));
+    let backend = Rc::new(RefCell::new(TruckBackend::new(1,1)));
+    let mut stack = CommandStack::new();
+    let mut ctx = Context {
+        points: &points,
+        point_styles: &styles,
+        lines: &lines,
+        line_styles: &line_styles,
+        dimensions: &dims,
+        backend: &backend,
+    };
+
+    let p1 = Point::new(0.0,0.0);
+    spawn_point(&points, &styles, &backend, p1);
+    stack.push(Command::RemovePoint { index: 0, point: p1 });
+
+    let p2 = Point::new(1.0,1.0);
+    spawn_point(&points, &styles, &backend, p2);
+    stack.push(Command::RemovePoint { index: 1, point: p2 });
+
+    assert_eq!(points.borrow().len(), 2);
+    stack.undo(&ctx); // removes p2
+    assert_eq!(points.borrow().len(), 1);
+
+    let p3 = Point::new(2.0,2.0);
+    spawn_point(&points, &styles, &backend, p3);
+    stack.push(Command::RemovePoint { index: 1, point: p3 });
+    assert_eq!(points.borrow().len(), 2);
+
+    stack.redo(&ctx); // should do nothing
+    assert_eq!(points.borrow().len(), 2);
+}

--- a/survey_cad_truck_gui/tests/config.rs
+++ b/survey_cad_truck_gui/tests/config.rs
@@ -1,0 +1,45 @@
+use survey_cad_truck_gui::ui_state::{load_config, save_config, Config, Theme};
+use tempfile::tempdir;
+use std::env;
+
+fn set_temp_config_dir(dir: &std::path::Path) {
+    env::set_var("XDG_CONFIG_HOME", dir);
+}
+
+#[test]
+fn load_default_when_missing() {
+    let dir = tempdir().unwrap();
+    set_temp_config_dir(dir.path());
+    let cfg = load_config();
+    assert_eq!(cfg.window_width, 800);
+    assert_eq!(cfg.window_height, 600);
+    assert!(cfg.last_open_dir.is_none());
+    assert!(cfg.auto_tin == false);
+}
+
+#[test]
+fn config_round_trip() {
+    let dir = tempdir().unwrap();
+    set_temp_config_dir(dir.path());
+    let cfg = Config {
+        window_width: 1024,
+        window_height: 768,
+        last_open_dir: Some("dir".into()),
+        snap: Default::default(),
+        auto_tin: true,
+        quick_scripts: vec!["q".into()],
+        profile: Default::default(),
+        theme: Theme::Light,
+        font_path: Some("font".into()),
+    };
+    save_config(&cfg);
+    let loaded = load_config();
+    assert_eq!(loaded.window_width, 1024);
+    assert_eq!(loaded.window_height, 768);
+    assert_eq!(loaded.last_open_dir.as_deref(), Some("dir"));
+    assert_eq!(loaded.auto_tin, true);
+    assert_eq!(loaded.quick_scripts, vec!["q".to_string()]);
+    assert_eq!(loaded.profile as u8, cfg.profile as u8);
+    assert_eq!(loaded.theme as u8, cfg.theme as u8);
+    assert_eq!(loaded.font_path.as_deref(), Some("font"));
+}


### PR DESCRIPTION
## Summary
- expose modules in new `survey_cad_truck_gui` library
- add integration tests for config load/save
- add integration tests for undo/redo command stack logic

## Testing
- `cargo test -p survey_cad_truck_gui --no-run` *(fails: build takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_68713b8658488328a29c79b4453b6c12