### PR TITLE
Fix warnings and add default impls

### DIFF
--- a/survey_cad_truck_gui/src/commands.rs
+++ b/survey_cad_truck_gui/src/commands.rs
@@ -25,6 +25,12 @@ pub struct CommandStack {
     redo: Vec<Command>,
 }
 
+impl Default for CommandStack {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Default)]
 pub struct MacroRecorder {
     pub file: Option<std::fs::File>,

--- a/survey_cad_truck_gui/src/geometry.rs
+++ b/survey_cad_truck_gui/src/geometry.rs
@@ -30,6 +30,12 @@ pub struct GeometryStore {
     pub solids: Vec<Vec<Point3>>, // triangulated positions for snapping
 }
 
+impl Default for GeometryStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GeometryStore {
     pub fn new() -> Self {
         Self {

--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -277,7 +277,9 @@ impl TruckBackend {
     pub fn add_vertex(&mut self, surface: usize, p: Point3) -> Option<usize> {
         let res = self.engine.add_surface_vertex(surface, p);
         if let Some(idx) = res {
-            let _ = self.geometry.add_vertex(surface, p);
+            if let Some(g_idx) = self.geometry.add_vertex(surface, p) {
+                debug_assert_eq!(idx, g_idx);
+            }
         }
         self.rebuild_index();
         res


### PR DESCRIPTION
## Summary
- implement `Default` for `CommandStack` and `GeometryStore`
- use returned vertex index in `TruckBackend::add_vertex`

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo clippy -p survey_cad_truck_gui -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_6871464b17b483289b8ebd120827029c