### PR TITLE
Fix unused mut variable warnings

### DIFF
--- a/survey_cad_truck_gui/tests/command_stack.rs
+++ b/survey_cad_truck_gui/tests/command_stack.rs
@@ -15,7 +15,7 @@ fn undo_redo_point() {
     let backend = Rc::new(RefCell::new(TruckBackend::new(1,1)));
 
     let mut stack = CommandStack::new();
-    let mut ctx = Context {
+    let ctx = Context {
         points: &points,
         point_styles: &styles,
         lines: &lines,
@@ -44,7 +44,7 @@ fn pushing_clears_redo() {
     let dims = Rc::new(RefCell::new(Vec::new()));
     let backend = Rc::new(RefCell::new(TruckBackend::new(1,1)));
     let mut stack = CommandStack::new();
-    let mut ctx = Context {
+    let ctx = Context {
         points: &points,
         point_styles: &styles,
         lines: &lines,


### PR DESCRIPTION
## Summary
- remove unnecessary `mut` in test context setup

## Testing
- `cargo test -p survey_cad_truck_gui --test command_stack` *(fails: build takes too long in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68714fe62888832892c47aaa5e2d05e5