### PR TITLE
Fix linking by enabling Python extension feature

### DIFF
--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 shell-words = "1.1"
 dirs = "6"
-pyo3 = { version = "0.21", features = ["auto-initialize"] }
+pyo3 = { version = "0.21", features = ["auto-initialize", "extension-module"] }
 survey_cad_python = { path = "../survey_cad_python" }
 open = "5"
 rstar = "0.9"


### PR DESCRIPTION
## Summary
- enable the `extension-module` feature for pyo3 so `libpython` is linked

## Testing
- `cargo check -p survey_cad_truck_gui --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687501fbf53c8328a814a7c4837c39dd