### PR TITLE
Fix PyO3 linking for GUI

### DIFF
--- a/survey_cad_python/Cargo.toml
+++ b/survey_cad_python/Cargo.toml
@@ -9,4 +9,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 survey_cad = { path = "../survey_cad", default-features = false }
-pyo3 = { version = "0.21", features = ["extension-module"] }
+pyo3 = { version = "0.21", default-features = false }
+
+[features]
+extension-module = ["pyo3/extension-module"]
+default = ["extension-module"]

--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -19,8 +19,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 shell-words = "1.1"
 dirs = "6"
-pyo3 = { version = "0.21", features = ["auto-initialize", "extension-module"] }
-survey_cad_python = { path = "../survey_cad_python" }
+pyo3 = { version = "0.21", features = ["auto-initialize"] }
+survey_cad_python = { path = "../survey_cad_python", default-features = false }
 open = "5"
 rstar = "0.9"
 thiserror = "1"


### PR DESCRIPTION
## Summary
- disable `extension-module` when building `survey_cad_python` as a dependency
- link Python for the GUI binary

## Testing
- `cargo build -p survey_cad_truck_gui --release`

------
https://chatgpt.com/codex/tasks/task_e_68750ff32b4c8328a3468be76caea9a6