### PR TITLE
Fix pyo3 linking for truck GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9368,6 +9368,7 @@ dependencies = [
  "once_cell",
  "open",
  "pyo3",
+ "pyo3-build-config",
  "rfd",
  "rstar",
  "rusttype 0.9.3",

--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1"
 
 [build-dependencies]
 slint-build = "1"
+pyo3-build-config = "0.21"
 
 [features]
 default = []

--- a/survey_cad_truck_gui/build.rs
+++ b/survey_cad_truck_gui/build.rs
@@ -1,6 +1,9 @@
 use std::path::Path;
 
 fn main() {
+    // Propagate PyO3's build configuration so the Python interpreter links
+    // correctly when this binary is built.
+    pyo3_build_config::use_pyo3_cfgs();
     // Allow overriding the bundled font at build time via the SURVEY_CAD_FONT
     // environment variable. Otherwise fall back to the default font shipped in
     // the assets directory.


### PR DESCRIPTION
## Summary
- ensure PyO3's build configuration is applied
- add `pyo3-build-config` as a build dependency

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo test -p survey_cad_truck_gui --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68751cef23e0832890e6769a05d94ca3