### PR TITLE
Fix PyO3 linking

### DIFF
--- a/survey_cad_python/Cargo.toml
+++ b/survey_cad_python/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 survey_cad = { path = "../survey_cad", default-features = false }
-pyo3 = { version = "0.21", default-features = false }
+pyo3 = { version = "0.21", default-features = false, features = ["abi3-py311"] }
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 shell-words = "1.1"
 dirs = "6"
-pyo3 = { version = "0.21", features = ["auto-initialize"] }
+pyo3 = { version = "0.21", features = ["auto-initialize", "abi3-py311"] }
 survey_cad_python = { path = "../survey_cad_python", default-features = false }
 open = "5"
 rstar = "0.9"


### PR DESCRIPTION
## Summary
- use abi3 build of PyO3 to avoid linking errors

## Testing
- `cargo check --manifest-path survey_cad_truck_gui/Cargo.toml -q` *(failed: build timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6875279903f8832896f1db08527e22cf