### PR TITLE
Update CI with Python 3.11 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        id: python
+        with:
+          python-version: '3.11'
+      - name: Install Python 3.11 headers
+        run: sudo apt-get update && sudo apt-get install -y python3.11-dev
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -26,6 +32,8 @@ jobs:
           df -h
       - name: Build survey_cad_cli
         run: cargo build -p survey_cad_cli --release
+        env:
+          PYO3_PYTHON: ${{ steps.python.outputs.python-path }}
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        id: python
+        with:
+          python-version: '3.11'
+      - name: Install Python 3.11 headers
+        run: sudo apt-get update && sudo apt-get install -y python3.11-dev
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -27,5 +33,9 @@ jobs:
           df -h
       - name: Run cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+        env:
+          PYO3_PYTHON: ${{ steps.python.outputs.python-path }}
       - name: Run cargo test
         run: cargo test --all
+        env:
+          PYO3_PYTHON: ${{ steps.python.outputs.python-path }}


### PR DESCRIPTION
## Summary
- add Python 3.11 setup in CI and build workflows
- install python3.11 headers for pyo3
- pass `PYO3_PYTHON` to cargo steps

## Testing
- `cargo test --workspace --jobs 1 --no-run` *(failed: cancelled after long compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68753d98b6248328826b7a502b31a0d4