### PR TITLE
Fix CI Python dev package error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,6 @@ jobs:
         id: python
         with:
           python-version: '3.11'
-      - name: Install Python 3.11 headers
-        run: sudo apt-get update && sudo apt-get install -y python3.11-dev
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
         id: python
         with:
           python-version: '3.11'
-      - name: Install Python 3.11 headers
-        run: sudo apt-get update && sudo apt-get install -y python3.11-dev
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
## Summary
- remove python3.11-dev install in build & ci workflows

## Testing
- `cargo test --quiet` *(fails: build takes too long)*
- `cargo test -p survey_cad_cli --no-run --quiet` *(fails: build takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_687543d99e988328b276d57f53de120c