### PR TITLE
Improve Truck GUI error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9365,6 +9365,7 @@ version = "0.1.0"
 dependencies = [
  "dirs",
  "i-slint-common",
+ "log",
  "once_cell",
  "open",
  "pyo3",

--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -24,6 +24,7 @@ survey_cad_python = { path = "../survey_cad_python", default-features = false }
 open = "5"
 rstar = "0.9"
 thiserror = "1"
+log = "0.4"
 
 [build-dependencies]
 slint-build = "1"

--- a/survey_cad_truck_gui/src/cross_section.rs
+++ b/survey_cad_truck_gui/src/cross_section.rs
@@ -1,5 +1,7 @@
 use slint::Image;
-use std::error::Error;
+use log::error;
+
+use crate::error::GuiError;
 use tiny_skia::{Color, Paint, PathBuilder, Pixmap, Stroke, Transform};
 
 use survey_cad::alignment::{VerticalAlignment, VerticalElement};
@@ -19,11 +21,14 @@ pub fn render_cross_section(
     section: &corridor::CrossSection,
     width: u32,
     height: u32,
-) -> Result<Image, Box<dyn Error>> {
+) -> Result<Image, GuiError> {
     if width == 0 || height == 0 {
         return Ok(Image::default());
     }
-    let mut pixmap = Pixmap::new(width, height).ok_or("failed to create pixmap")?;
+    let mut pixmap = Pixmap::new(width, height).ok_or_else(|| {
+        error!("Failed to create pixmap {width}x{height}");
+        GuiError::from("failed to create pixmap")
+    })?;
     pixmap.fill(Color::from_rgba8(32, 32, 32, 255));
     let mut paint = Paint::default();
     paint.set_color(Color::from_rgba8(0, 255, 0, 255));

--- a/survey_cad_truck_gui/src/inspector.rs
+++ b/survey_cad_truck_gui/src/inspector.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
-use std::error::Error;
 use std::rc::Rc;
+
+use crate::error::GuiError;
 
 use slint::{ComponentHandle, Image, SharedString, VecModel};
 
@@ -88,7 +89,7 @@ pub fn show_inspector_for_point(
     data_sets: &Rc<RefCell<Vec<usize>>>,
     data_set_names: &Rc<RefCell<Vec<String>>>,
     inspector: &Rc<RefCell<Option<slint::Weak<EntityInspector>>>>,
-    render_image: Rc<dyn Fn() -> Result<Image, Box<dyn Error>>>,
+    render_image: Rc<dyn Fn() -> Result<Image, GuiError>>,
     backend: &Rc<RefCell<TruckBackend>>,
 ) {
     while layers.borrow().len() <= idx {
@@ -252,7 +253,7 @@ pub fn show_inspector_for_polygon(
     data_sets: &Rc<RefCell<Vec<usize>>>,
     data_set_names: &Rc<RefCell<Vec<String>>>,
     inspector: &Rc<RefCell<Option<slint::Weak<EntityInspector>>>>,
-    render_image: Rc<dyn Fn() -> Result<Image, Box<dyn Error>>>,
+    render_image: Rc<dyn Fn() -> Result<Image, GuiError>>,
     backend: &Rc<RefCell<TruckBackend>>,
 ) {
     while layers.borrow().len() <= idx {

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -2,7 +2,7 @@
 
 use i_slint_common::sharedfontdb;
 use slint::platform::PointerEventButton;
-use slint::{Model, PhysicalSize, SharedString, VecModel};
+use slint::{Model, PhysicalSize, SharedString, VecModel, Image};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Instant;
@@ -67,6 +67,7 @@ use render::{
     arc_from_start_end_radius, arc_from_three_points, polyline_to_solid, screen_to_workspace,
     workspace_to_screen, RenderState, RenderStyles, WorkspaceRenderData,
 };
+use error::GuiError;
 use rusttype::Font;
 use tiny_skia::Pixmap;
 use ui_state::{
@@ -356,7 +357,13 @@ fn main() -> Result<(), slint::PlatformError> {
         let point_label_style = point_label_style.clone();
         let grid_settings_ref = grid_settings.clone();
         move || {
-            let size = app_weak.upgrade().map(|a| a.window().size()).unwrap();
+            let Some(app) = app_weak.upgrade() else {
+                return Err(GuiError::Msg("window closed".into()));
+            };
+            let size = app.window().size();
+            if size.width == 0 || size.height == 0 {
+                return Ok(Image::default());
+            }
             let show_numbers = app_weak
                 .upgrade()
                 .map(|a| a.get_show_point_numbers())

--- a/survey_cad_truck_gui/src/python.rs
+++ b/survey_cad_truck_gui/src/python.rs
@@ -27,7 +27,7 @@ pub struct MacroContext {
     pub lines: Rc<RefCell<Vec<(Point, Point)>>>,
     pub line_styles: Rc<RefCell<Vec<usize>>>,
     pub backend: Rc<RefCell<TruckBackend>>,
-    pub render_image: Rc<dyn Fn() -> Result<Image, Box<dyn std::error::Error>>>,
+    pub render_image: Rc<dyn Fn() -> Result<Image, GuiError>>,
     pub weak: slint::Weak<MainWindow>,
 }
 

--- a/survey_cad_truck_gui/src/workspace.rs
+++ b/survey_cad_truck_gui/src/workspace.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
-use std::error::Error;
 use std::rc::Rc;
+
+use log::error;
 
 use slint::{ComponentHandle, Image};
 use tiny_skia::{Color, FillRule, Paint, PathBuilder, Pixmap, Stroke, Transform};
@@ -13,6 +14,7 @@ use crate::render::{draw_text, RenderState, RenderStyles, WorkspaceRenderData};
 use crate::truck_backend::TruckBackend;
 use crate::ui_state::DrawingMode;
 use crate::{MainWindow, FONT};
+use crate::error::GuiError;
 
 pub fn render_workspace(
     data: &WorkspaceRenderData,
@@ -22,13 +24,16 @@ pub fn render_workspace(
     grid: &GridSettings,
     width: u32,
     height: u32,
-) -> Result<Image, Box<dyn Error>> {
+) -> Result<Image, GuiError> {
     if width == 0 || height == 0 {
         return Ok(Image::default());
     }
     let mut pixmap = state.pixmap.borrow_mut();
     if pixmap.width() != width || pixmap.height() != height {
-        *pixmap = Pixmap::new(width, height).ok_or("failed to create pixmap")?;
+        *pixmap = Pixmap::new(width, height).ok_or_else(|| {
+            error!("Failed to create pixmap {width}x{height}");
+            GuiError::from("failed to create pixmap")
+        })?;
     } else {
         pixmap.fill(Color::from_rgba8(32, 32, 32, 255));
     }
@@ -358,7 +363,7 @@ pub fn render_workspace(
 
 pub fn refresh_workspace(
     app: &MainWindow,
-    render_image: &dyn Fn() -> Result<Image, Box<dyn Error>>,
+    render_image: &dyn Fn() -> Result<Image, GuiError>,
     backend_render: &Rc<RefCell<TruckBackend>>,
 ) {
     if app.get_workspace_mode() == 0 {
@@ -378,7 +383,7 @@ pub fn refresh_workspace(
 
 pub fn set_workspace_image_result(
     app: &MainWindow,
-    render_image: &dyn Fn() -> Result<Image, Box<dyn Error>>,
+    render_image: &dyn Fn() -> Result<Image, GuiError>,
 ) {
     match render_image() {
         Ok(img) => app.set_workspace_image(img),


### PR DESCRIPTION
## Summary
- fix panic when pixmap size is zero
- propagate rendering failures using `GuiError`
- log pixmap creation errors

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68764b1ba3708328bdbc38cc37d1d621