### PR TITLE
Add config persistence test

### DIFF
--- a/survey_cad_truck_gui/src/ui_state.rs
+++ b/survey_cad_truck_gui/src/ui_state.rs
@@ -37,7 +37,7 @@ pub enum DrawingMode {
     Dimension { start: Option<Point> },
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct SnapPrefs {
     pub snap_to_grid: bool,
     pub snap_to_entities: bool,
@@ -68,7 +68,7 @@ impl Default for SnapPrefs {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Default)]
+#[derive(Serialize, Deserialize, Clone, Copy, Default, PartialEq, Debug)]
 pub enum WorkspaceProfile {
     #[default]
     Surveyor,
@@ -76,14 +76,14 @@ pub enum WorkspaceProfile {
     Gis,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Default)]
+#[derive(Serialize, Deserialize, Clone, Copy, Default, PartialEq, Debug)]
 pub enum Theme {
     #[default]
     Dark,
     Light,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct Config {
     pub window_width: u32,
     pub window_height: u32,

--- a/survey_cad_truck_gui/tests/config.rs
+++ b/survey_cad_truck_gui/tests/config.rs
@@ -1,0 +1,28 @@
+use survey_cad_truck_gui::ui_state::{Config, SnapPrefs, WorkspaceProfile, Theme, load_config, save_config};
+use tempfile::tempdir;
+use std::env;
+
+#[test]
+fn save_and_load_config() {
+    let dir = tempdir().unwrap();
+    // Redirect configuration directory to the temporary path
+    env::set_var("XDG_CONFIG_HOME", dir.path());
+    env::set_var("APPDATA", dir.path());
+    env::set_var("HOME", dir.path());
+
+    let cfg = Config {
+        window_width: 1024,
+        window_height: 768,
+        last_open_dir: Some("/tmp".into()),
+        snap: SnapPrefs::default(),
+        auto_tin: true,
+        quick_scripts: vec!["one".into(), "two".into()],
+        profile: WorkspaceProfile::default(),
+        theme: Theme::default(),
+        font_path: Some("font/path".into()),
+    };
+
+    save_config(&cfg);
+    let loaded = load_config();
+    assert_eq!(cfg, loaded);
+}


### PR DESCRIPTION
## Summary
- derive `PartialEq` and `Debug` on `Config` and related types
- add integration test for saving and loading `Config`

## Testing
- `cargo test -p survey_cad_truck_gui --test config --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68765268acc88328b26a623804c0147e