### PR TITLE
Fix build errors by configuring Python path

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+PYO3_PYTHON = "/usr/bin/python3.12"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 **/*.rs.bk
+.venv/
+**/.venv/


### PR DESCRIPTION
## Summary
- configure cargo to use Python 3.12 for PyO3
- ignore virtual environment directories

## Testing
- `cargo test -p survey_cad_truck_gui --no-run` *(fails: environment limitation)*

------
https://chatgpt.com/codex/tasks/task_e_68767e9cd81c83288114df70d8beab17