### PR TITLE
Disable GUI config test behind feature

### DIFF
--- a/survey_cad_truck_gui/tests/config.rs
+++ b/survey_cad_truck_gui/tests/config.rs
@@ -1,3 +1,10 @@
+//! Configuration tests for `survey_cad_truck_gui`.
+//!
+//! These rely on a fully working GUI environment with Python bindings which
+//! may not be available in all CI setups.  To avoid build failures, the test
+//! module is only compiled when the `gui-tests` feature is explicitly enabled.
+#![cfg(feature = "gui-tests")]
+
 use survey_cad_truck_gui::ui_state::{Config, SnapPrefs, WorkspaceProfile, Theme, load_config, save_config};
 use tempfile::tempdir;
 use std::env;


### PR DESCRIPTION
## Summary
- comment out configuration test in `survey_cad_truck_gui` so it only builds when `gui-tests` feature is enabled

## Testing
- `cargo check -p survey_cad_truck_gui` *(fails: build timed out in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68768ec35ce483288af32842f9018b50