### PR TITLE
Add gui-tests feature to fix cfg check

### DIFF
--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -37,6 +37,7 @@ las = ["survey_cad/las"]
 kml = ["survey_cad/kml"]
 fgdb = ["survey_cad/fgdb"]
 e57 = ["survey_cad/e57"]
+gui-tests = []
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- add missing `gui-tests` feature to `survey_cad_truck_gui` crate

## Testing
- `cargo check -p survey_cad_truck_gui --tests --features gui-tests`

------
https://chatgpt.com/codex/tasks/task_e_6876aea2e088832892e0b1b4c29123bb