### PR TITLE
Add batched mesh API and backend bulk ops

### DIFF
--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -13,6 +13,7 @@ tiny-skia = "0.11"
 truck_cad_engine = { path = "../truck_cad_engine" }
 truck-modeling = { path = "../truck-master/truck-modeling" }
 truck-meshalgo = { path = "../truck-master/truck-meshalgo", features = ["tessellation"] }
+truck-rendimpl = { path = "../truck-master/truck-rendimpl" }
 once_cell = "1"
 rusttype = "0.9"
 serde = { version = "1", features = ["derive"] }

--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -2,6 +2,7 @@ use slint::Image;
 use truck_cad_engine::TruckCadEngine;
 use truck_modeling::base::{Point3, Vector4};
 use truck_modeling::topology::Solid;
+use truck_rendimpl::PolygonState;
 
 use crate::geometry::GeometryStore;
 use rstar::{RTree, RTreeObject, AABB};
@@ -154,6 +155,16 @@ impl TruckBackend {
         self.rebuild_index();
     }
 
+    /// Add multiple points in a single operation.
+    pub fn add_points(&mut self, points: &[Point3]) {
+        for p in points {
+            let id = self.engine.add_point_marker(*p);
+            self.point_ids.push(Some(id));
+            self.geometry.add_point(*p);
+        }
+        self.rebuild_index();
+    }
+
     pub fn add_line(
         &mut self,
         a: [f64; 3],
@@ -217,6 +228,27 @@ impl TruckBackend {
         self.rebuild_index();
     }
 
+    /// Add multiple lines at once.
+    pub fn add_lines(&mut self, lines: &[([f64; 3], [f64; 3], [f32; 4], f32)]) {
+        for (a, b, color, weight) in lines {
+            let col = Vector4::new(color[0] as f64, color[1] as f64, color[2] as f64, color[3] as f64);
+            let id = self.engine.add_line(
+                Point3::new(a[0], a[1], a[2]),
+                Point3::new(b[0], b[1], b[2]),
+                col,
+                *weight,
+            );
+            self.line_ids.push(Some(id));
+            self.geometry.add_line(
+                Point3::new(a[0], a[1], a[2]),
+                Point3::new(b[0], b[1], b[2]),
+                col,
+                *weight,
+            );
+        }
+        self.rebuild_index();
+    }
+
     /// Add a dimension represented as a simple line between two points.
     pub fn add_dimension(&mut self, a: [f64; 3], b: [f64; 3], color: [f32; 4], weight: f32) -> usize {
         let id = self.engine.add_line(
@@ -248,6 +280,19 @@ impl TruckBackend {
         let idx = self.geometry.add_surface(vertices, triangles);
         self.rebuild_index();
         idx
+    }
+
+    /// Add many surfaces using the engine's batching API.
+    pub fn add_surfaces(&mut self, surfs: &[(&[Point3], &[[usize; 3]])]) {
+        let mut engine_meshes = Vec::new();
+        for (v, t) in surfs {
+            self.surface_ids.push(None);
+            self.geometry.add_surface(v, t);
+            engine_meshes.push((v.to_vec(), t.to_vec()));
+        }
+        self.engine
+            .add_batched_mesh(&engine_meshes, &PolygonState::default());
+        self.rebuild_index();
     }
 
     pub fn add_solid(&mut self, solid: Solid) {

--- a/truck_cad_engine/src/lib.rs
+++ b/truck_cad_engine/src/lib.rs
@@ -106,6 +106,43 @@ impl TruckCadEngine {
         self.add_solid(cube);
     }
 
+    /// Add multiple triangulated meshes sharing the same [`PolygonState`].
+    pub fn add_batched_mesh(
+        &mut self,
+        meshes: &[(Vec<truck::base::Point3>, Vec<[usize; 3]>)],
+        state: &PolygonState,
+    ) {
+        let mut vertices = Vec::new();
+        let mut triangles = Vec::new();
+        for (verts, tris) in meshes {
+            let offset = vertices.len();
+            vertices.extend_from_slice(verts);
+            triangles.extend(tris.iter().map(|t| [t[0] + offset, t[1] + offset, t[2] + offset]));
+        }
+        if vertices.is_empty() {
+            return;
+        }
+        let attrs = StandardAttributes {
+            positions: vertices,
+            ..Default::default()
+        };
+        let tri_faces: Vec<[StandardVertex; 3]> = triangles
+            .iter()
+            .map(|t| {
+                [
+                    StandardVertex { pos: t[0], uv: None, nor: None },
+                    StandardVertex { pos: t[1], uv: None, nor: None },
+                    StandardVertex { pos: t[2], uv: None, nor: None },
+                ]
+            })
+            .collect();
+        let faces = Faces::from_tri_and_quad_faces(tri_faces, Vec::new());
+        let mesh = PolygonMesh::new(attrs, faces);
+        let instance = self.creator.create_instance(&mesh, state);
+        self.scene.add_object(&instance);
+        self.instances.push(instance);
+    }
+
     /// Add a small cube to visualize a point.
     pub fn add_point_marker(&mut self, p: truck::base::Point3) -> usize {
         let v: truck::topology::Vertex =


### PR DESCRIPTION
## Summary
- implement `add_batched_mesh` in `truck_cad_engine`
- allow importing `PolygonState` for GUI backend
- provide `add_points`, `add_lines`, and `add_surfaces` bulk methods
- integrate batching via engine when adding many surfaces

## Testing
- `cargo check -p truck_cad_engine -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_6877d1210bf08328be8dee3e2479f779