### PR TITLE
Add corridor subassembly handles

### DIFF
--- a/survey_cad_truck_gui/src/cross_section.rs
+++ b/survey_cad_truck_gui/src/cross_section.rs
@@ -6,7 +6,45 @@ use tiny_skia::{Color, Paint, PathBuilder, Pixmap, Stroke, Transform};
 
 use survey_cad::alignment::{VerticalAlignment, VerticalElement};
 use survey_cad::corridor;
+use survey_cad::subassembly;
 use survey_cad::geometry::Point3 as ScPoint3;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Lane {
+    pub width: f64,
+    pub slope: f64,
+}
+
+impl Lane {
+    pub fn to_subassembly(&self) -> corridor::Subassembly {
+        subassembly::lane(self.width, self.slope)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Shoulder {
+    pub width: f64,
+    pub slope: f64,
+}
+
+impl Shoulder {
+    pub fn to_subassembly(&self) -> corridor::Subassembly {
+        subassembly::shoulder(self.width, self.slope)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Ditch {
+    pub depth: f64,
+    pub bottom_width: f64,
+    pub side_slope: f64,
+}
+
+impl Ditch {
+    pub fn to_subassembly(&self) -> corridor::Subassembly {
+        subassembly::ditch(self.depth, self.bottom_width, self.side_slope)
+    }
+}
 
 /// Parameters for mapping section coordinates to screen coordinates.
 pub struct SectionParams {
@@ -196,6 +234,29 @@ pub fn nearest_point(
     } else {
         None
     }
+}
+
+pub fn handle_positions(
+    section: &corridor::CrossSection,
+    width: f32,
+    height: f32,
+) -> Vec<(f32, f32)> {
+    let Some(params) = calc_section_params(section, width, height) else {
+        return Vec::new();
+    };
+    section
+        .points
+        .iter()
+        .map(|p| {
+            let off = ((p.x - params.center.x) * params.dir.0
+                + (p.y - params.center.y) * params.dir.1) as f32;
+            let elev = (p.z - params.center.z) as f32;
+            (
+                params.ox + off * params.scale,
+                params.oy - elev * params.scale,
+            )
+        })
+        .collect()
 }
 
 pub fn grade_at(profile: &VerticalAlignment, station: f64) -> Option<f64> {

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -71,8 +71,8 @@ use commands::{
     MacroRecorder,
 };
 pub use cross_section::{
-    calc_section_params, grade_at, nearest_point, render_cross_section, screen_to_world,
-    SectionParams,
+    calc_section_params, grade_at, handle_positions, nearest_point, render_cross_section,
+    screen_to_world, SectionParams,
 };
 pub use inspector::{
     has_selection, show_context_menu, show_inspector_for_point, show_inspector_for_polygon,
@@ -3931,6 +3931,11 @@ fn main() -> Result<(), slint::PlatformError> {
             if let Ok(img) = render_cross_section(&sections[0], 600, 300) {
                 viewer.set_section_image(img);
             }
+            let handles0: Vec<HandlePoint> = handle_positions(&sections[0], 600.0, 300.0)
+                .into_iter()
+                .map(|(x, y)| HandlePoint { x: x.into(), y: y.into() })
+                .collect();
+            viewer.set_handles_model(VecModel::from(handles0).into());
             let viewer_weak = viewer.as_weak();
             let secs = Rc::new(RefCell::new(sections));
             let drag_index = Rc::new(RefCell::new(None::<usize>));
@@ -3956,6 +3961,11 @@ fn main() -> Result<(), slint::PlatformError> {
                             if let Ok(img) = render_cross_section(&secs_b[i], 600, 300) {
                                 v.set_section_image(img);
                             }
+                            let handles: Vec<HandlePoint> = handle_positions(&secs_b[i], 600.0, 300.0)
+                                .into_iter()
+                                .map(|(x, y)| HandlePoint { x: x.into(), y: y.into() })
+                                .collect();
+                            v.set_handles_model(VecModel::from(handles).into());
                         }
                     }
                 });
@@ -4003,6 +4013,8 @@ fn main() -> Result<(), slint::PlatformError> {
                 let current_m = current.clone();
                 let drag_m = drag_index.clone();
                 let viewer_weak_m = viewer_weak.clone();
+                let surfaces_m = surfaces.clone();
+                let backend_m = backend.clone();
                 viewer.on_pointer_moved(move |x, y| {
                     if let Some(idx) = *drag_m.borrow() {
                         if let Some(p) = screen_to_world(
@@ -4021,6 +4033,30 @@ fn main() -> Result<(), slint::PlatformError> {
                                 ) {
                                     v.set_section_image(img);
                                 }
+                                let handles: Vec<HandlePoint> = handle_positions(
+                                    &secs_m.borrow()[*current_m.borrow()],
+                                    600.0,
+                                    300.0,
+                                )
+                                .into_iter()
+                                .map(|(hx, hy)| HandlePoint { x: hx.into(), y: hy.into() })
+                                .collect();
+                                v.set_handles_model(VecModel::from(handles).into());
+                            }
+                            let tin = corridor::surface_from_cross_sections(&secs_m.borrow());
+                            let verts: Vec<Point3> = tin
+                                .vertices
+                                .iter()
+                                .map(|p| Point3::new(p.x, p.y, p.z))
+                                .collect();
+                            if surfaces_m.borrow().is_empty() {
+                                backend_m.borrow_mut().add_surface(&verts, &tin.triangles);
+                                surfaces_m.borrow_mut().push(tin);
+                            } else {
+                                backend_m
+                                    .borrow_mut()
+                                    .update_surface(0, &verts, &tin.triangles);
+                                surfaces_m.borrow_mut()[0] = tin;
                             }
                         }
                     }
@@ -4030,6 +4066,8 @@ fn main() -> Result<(), slint::PlatformError> {
                 let surfaces_r = surfaces.clone();
                 let backend_r = backend.clone();
                 let drag_r = drag_index.clone();
+                let current = current.clone();
+                let viewer_weak = viewer_weak.clone();
                 viewer.on_pointer_released(move || {
                     if drag_r.borrow().is_some() {
                         *drag_r.borrow_mut() = None;
@@ -4047,6 +4085,17 @@ fn main() -> Result<(), slint::PlatformError> {
                                 .borrow_mut()
                                 .update_surface(0, &verts, &tin.triangles);
                             surfaces_r.borrow_mut()[0] = tin;
+                        }
+                        if let Some(v) = viewer_weak.upgrade() {
+                            let handles: Vec<HandlePoint> = handle_positions(
+                                &secs_r.borrow()[*current.borrow()],
+                                600.0,
+                                300.0,
+                            )
+                            .into_iter()
+                            .map(|(hx, hy)| HandlePoint { x: hx.into(), y: hy.into() })
+                            .collect();
+                            v.set_handles_model(VecModel::from(handles).into());
                         }
                     }
                 });

--- a/survey_cad_truck_gui/ui/cross_section_viewer.slint
+++ b/survey_cad_truck_gui/ui/cross_section_viewer.slint
@@ -1,10 +1,16 @@
 import { Button, VerticalBox, HorizontalBox } from "std-widgets.slint";
 
+export struct HandlePoint {
+    x: length,
+    y: length,
+}
+
 export component CrossSectionViewer inherits Window {
     in-out property <image> section_image;
     in-out property <string> station_label;
     in-out property <string> elevation_label;
     in-out property <string> slope_label;
+    in-out property <[HandlePoint]> handles_model;
     callback pointer_pressed(length, length);
     callback pointer_moved(length, length);
     callback pointer_released();
@@ -24,22 +30,33 @@ export component CrossSectionViewer inherits Window {
             Text { color: #FFFFFF; text: root.slope_label; }
             Button { text: "Next"; clicked => { root.next(); } }
         }
-        Image {
-            source: root.section_image;
-            image-fit: fill;
+        Rectangle {
             width: 100%;
             height: 100%;
-        }
-        TouchArea {
-            width: 100%;
-            height: 100%;
-            pointer-event(event) => {
-                if event.kind == PointerEventKind.down {
-                    root.pointer_pressed(self.mouse-x, self.mouse-y);
-                } else if event.kind == PointerEventKind.up {
-                    root.pointer_released();
-                } else if event.kind == PointerEventKind.move {
-                    root.pointer_moved(self.mouse-x, self.mouse-y);
+            Image {
+                source: root.section_image;
+                image-fit: fill;
+                width: 100%;
+                height: 100%;
+            }
+            for h[i] in root.handles_model : Rectangle {
+                x: h.x - 4px;
+                y: h.y - 4px;
+                width: 8px;
+                height: 8px;
+                background: #FF0000;
+            }
+            TouchArea {
+                width: 100%;
+                height: 100%;
+                pointer-event(event) => {
+                    if event.kind == PointerEventKind.down {
+                        root.pointer_pressed(self.mouse-x, self.mouse-y);
+                    } else if event.kind == PointerEventKind.up {
+                        root.pointer_released();
+                    } else if event.kind == PointerEventKind.move {
+                        root.pointer_moved(self.mouse-x, self.mouse-y);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add Lane/Shoulder/Ditch structs to cross_section.rs
- expose handle positions for viewer
- render draggable handles in CrossSectionViewer
- update viewer logic to recalc surfaces while dragging

## Testing
- `cargo fmt -- survey_cad_truck_gui/src/cross_section.rs survey_cad_truck_gui/ui/cross_section_viewer.slint survey_cad_truck_gui/src/main.rs` *(fails: unstable options warnings but formatting succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_6877e2b4e1808328bab3f9b8bb33f24d