### PR TITLE
Fix clippy warnings

### DIFF
--- a/survey_cad_truck_gui/src/cross_section.rs
+++ b/survey_cad_truck_gui/src/cross_section.rs
@@ -10,38 +10,44 @@ use survey_cad::subassembly;
 use survey_cad::geometry::Point3 as ScPoint3;
 
 #[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
 pub struct Lane {
     pub width: f64,
     pub slope: f64,
 }
 
+#[allow(dead_code)]
 impl Lane {
-    pub fn to_subassembly(&self) -> corridor::Subassembly {
+    pub fn to_subassembly(self) -> corridor::Subassembly {
         subassembly::lane(self.width, self.slope)
     }
 }
 
 #[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
 pub struct Shoulder {
     pub width: f64,
     pub slope: f64,
 }
 
+#[allow(dead_code)]
 impl Shoulder {
-    pub fn to_subassembly(&self) -> corridor::Subassembly {
+    pub fn to_subassembly(self) -> corridor::Subassembly {
         subassembly::shoulder(self.width, self.slope)
     }
 }
 
 #[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
 pub struct Ditch {
     pub depth: f64,
     pub bottom_width: f64,
     pub side_slope: f64,
 }
 
+#[allow(dead_code)]
 impl Ditch {
-    pub fn to_subassembly(&self) -> corridor::Subassembly {
+    pub fn to_subassembly(self) -> corridor::Subassembly {
         subassembly::ditch(self.depth, self.bottom_width, self.side_slope)
     }
 }

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -3933,7 +3933,7 @@ fn main() -> Result<(), slint::PlatformError> {
             }
             let handles0: Vec<HandlePoint> = handle_positions(&sections[0], 600.0, 300.0)
                 .into_iter()
-                .map(|(x, y)| HandlePoint { x: x.into(), y: y.into() })
+                .map(|(x, y)| HandlePoint { x, y })
                 .collect();
             viewer.set_handles_model(Rc::new(VecModel::from(handles0)).into());
             let viewer_weak = viewer.as_weak();
@@ -3963,7 +3963,7 @@ fn main() -> Result<(), slint::PlatformError> {
                             }
                             let handles: Vec<HandlePoint> = handle_positions(&secs_b[i], 600.0, 300.0)
                                 .into_iter()
-                                .map(|(x, y)| HandlePoint { x: x.into(), y: y.into() })
+                                .map(|(x, y)| HandlePoint { x, y })
                                 .collect();
                             v.set_handles_model(Rc::new(VecModel::from(handles)).into());
                         }
@@ -4039,7 +4039,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                     300.0,
                                 )
                                 .into_iter()
-                                .map(|(hx, hy)| HandlePoint { x: hx.into(), y: hy.into() })
+                                .map(|(hx, hy)| HandlePoint { x: hx, y: hy })
                                 .collect();
                                 v.set_handles_model(Rc::new(VecModel::from(handles)).into());
                             }
@@ -4093,7 +4093,7 @@ fn main() -> Result<(), slint::PlatformError> {
                                 300.0,
                             )
                             .into_iter()
-                            .map(|(hx, hy)| HandlePoint { x: hx.into(), y: hy.into() })
+                            .map(|(hx, hy)| HandlePoint { x: hx, y: hy })
                             .collect();
                             v.set_handles_model(Rc::new(VecModel::from(handles)).into());
                         }


### PR DESCRIPTION
## Summary
- suppress dead-code warnings in `cross_section` helpers
- remove unnecessary conversions when building `HandlePoint`

## Testing
- `cargo check -p survey_cad_truck_gui`


------
https://chatgpt.com/codex/tasks/task_e_6878e573ec008328b6e6d2499374b144