### PR TITLE
Implement LandXML import/export in truck GUI

### DIFF
--- a/survey_cad/src/io/landxml.rs
+++ b/survey_cad/src/io/landxml.rs
@@ -634,3 +634,103 @@ pub fn write_landxml_superelevation(path: &str, table: &[SuperelevationPoint]) -
     writeln!(&mut xml, "</LandXML>").unwrap();
     write_string(path, &xml)
 }
+pub fn write_landxml(
+    path: &str,
+    points: &[crate::geometry::Point],
+    alignments: &[crate::alignment::Alignment],
+    surfaces: &[crate::dtm::Tin],
+) -> io::Result<()> {
+    use crate::alignment::HorizontalElement;
+    let mut xml = String::new();
+    writeln!(&mut xml, "<?xml version=\"1.0\"?>").unwrap();
+    writeln!(&mut xml, "<LandXML>").unwrap();
+    if !points.is_empty() {
+        writeln!(&mut xml, "  <CgPoints>").unwrap();
+        for (i, p) in points.iter().enumerate() {
+            writeln!(&mut xml, "    <P id=\"{}\">{} {}</P>", i + 1, p.x, p.y).unwrap();
+        }
+        writeln!(&mut xml, "  </CgPoints>").unwrap();
+    }
+    if !alignments.is_empty() {
+        writeln!(&mut xml, "  <Alignments>").unwrap();
+        for (i, al) in alignments.iter().enumerate() {
+            writeln!(&mut xml, "    <Alignment name=\"AL{}\">", i + 1).unwrap();
+            writeln!(&mut xml, "      <CoordGeom>").unwrap();
+            for elem in &al.horizontal.elements {
+                match elem {
+                    HorizontalElement::Tangent { start, end } => {
+                        writeln!(&mut xml, "        <Line>").unwrap();
+                        writeln!(&mut xml, "          <Start>{} {}</Start>", start.x, start.y).unwrap();
+                        writeln!(&mut xml, "          <End>{} {}</End>", end.x, end.y).unwrap();
+                        writeln!(&mut xml, "        </Line>").unwrap();
+                    }
+                    HorizontalElement::Curve { arc } => {
+                        writeln!(&mut xml, "        <Curve radius=\"{}\">", arc.radius).unwrap();
+                        let sp = crate::geometry::Point::new(
+                            arc.center.x + arc.radius * arc.start_angle.cos(),
+                            arc.center.y + arc.radius * arc.start_angle.sin(),
+                        );
+                        let ep = crate::geometry::Point::new(
+                            arc.center.x + arc.radius * arc.end_angle.cos(),
+                            arc.center.y + arc.radius * arc.end_angle.sin(),
+                        );
+                        writeln!(&mut xml, "          <Start>{} {}</Start>", sp.x, sp.y).unwrap();
+                        writeln!(&mut xml, "          <End>{} {}</End>", ep.x, ep.y).unwrap();
+                        writeln!(
+                            &mut xml,
+                            "          <Center>{} {}</Center>",
+                            arc.center.x, arc.center.y
+                        ).unwrap();
+                        writeln!(&mut xml, "        </Curve>").unwrap();
+                    }
+                    HorizontalElement::Spiral { spiral } => {
+                        let s = spiral.start_point();
+                        let e = spiral.end_point();
+                        writeln!(&mut xml, "        <Spiral>").unwrap();
+                        writeln!(&mut xml, "          <Start>{} {}</Start>", s.x, s.y).unwrap();
+                        writeln!(&mut xml, "          <End>{} {}</End>", e.x, e.y).unwrap();
+                        writeln!(&mut xml, "        </Spiral>").unwrap();
+                    }
+                }
+            }
+            writeln!(&mut xml, "      </CoordGeom>").unwrap();
+            writeln!(&mut xml, "    </Alignment>").unwrap();
+        }
+        writeln!(&mut xml, "  </Alignments>").unwrap();
+    }
+    if !surfaces.is_empty() {
+        writeln!(&mut xml, "  <Surfaces>").unwrap();
+        for (i, tin) in surfaces.iter().enumerate() {
+            writeln!(&mut xml, "    <Surface name=\"TIN{}\">", i + 1).unwrap();
+            writeln!(&mut xml, "      <Definition surfType=\"TIN\">").unwrap();
+            writeln!(&mut xml, "        <Pnts>").unwrap();
+            for (j, v) in tin.vertices.iter().enumerate() {
+                writeln!(
+                    &mut xml,
+                    "          <P id=\"{}\">{} {} {}</P>",
+                    j + 1,
+                    v.x,
+                    v.y,
+                    v.z
+                ).unwrap();
+            }
+            writeln!(&mut xml, "        </Pnts>").unwrap();
+            writeln!(&mut xml, "        <Faces>").unwrap();
+            for t in &tin.triangles {
+                writeln!(
+                    &mut xml,
+                    "          <F>{} {} {}</F>",
+                    t[0] + 1,
+                    t[1] + 1,
+                    t[2] + 1
+                ).unwrap();
+            }
+            writeln!(&mut xml, "        </Faces>").unwrap();
+            writeln!(&mut xml, "      </Definition>").unwrap();
+            writeln!(&mut xml, "    </Surface>").unwrap();
+        }
+        writeln!(&mut xml, "  </Surfaces>").unwrap();
+    }
+    writeln!(&mut xml, "</LandXML>").unwrap();
+    write_string(path, &xml)
+}

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -5491,6 +5491,34 @@ fn main() -> Result<(), slint::PlatformError> {
 
     {
         let weak = app.as_weak();
+        let point_db = point_db.clone();
+        let alignments = alignments.clone();
+        let surfaces = surfaces.clone();
+        app.on_export_landxml(move || {
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("LandXML", &["xml"])
+                .save_file()
+            {
+                if let Some(p) = path.to_str() {
+                    let pts = point_db.borrow().points().to_vec();
+                    let als = alignments.borrow().clone();
+                    let surfs = surfaces.borrow().clone();
+                    if let Err(e) =
+                        survey_cad::io::landxml::write_landxml(p, &pts, &als, &surfs)
+                    {
+                        if let Some(app) = weak.upgrade() {
+                            app.set_status(SharedString::from(format!("Failed to export: {e}")));
+                        }
+                    } else if let Some(app) = weak.upgrade() {
+                        app.set_status(SharedString::from("Exported"));
+                    }
+                }
+            }
+        });
+    }
+
+    {
+        let weak = app.as_weak();
         let surfaces = surfaces.clone();
         let surface_units_clone = surface_units.clone();
         let surface_styles_clone = surface_styles.clone();
@@ -6719,6 +6747,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let surface_units = surface_units.clone();
         let surface_styles = surface_styles.clone();
         let surface_descriptions = surface_descriptions.clone();
+        let point_db = point_db.clone();
+        let point_style_indices = point_style_indices.clone();
         app.on_import_landxml_surface(move || {
             if let Some(path) = rfd::FileDialog::new()
                 .add_filter("LandXML", &["xml"])
@@ -6736,6 +6766,10 @@ fn main() -> Result<(), slint::PlatformError> {
                                 .borrow_mut()
                                 .add_surface(&verts, &tin.triangles);
                             surfaces.borrow_mut().push(tin);
+                            for v in &verts {
+                                point_db.borrow_mut().push(Point::new(v.x, v.y));
+                                point_style_indices.borrow_mut().push(0);
+                            }
                             surface_units
                                 .borrow_mut()
                                 .push(extras.units.unwrap_or_default());
@@ -6774,6 +6808,8 @@ fn main() -> Result<(), slint::PlatformError> {
         let alignments = alignments.clone();
         let render_image = render_image.clone();
         let backend_render = backend.clone();
+        let point_db = point_db.clone();
+        let point_style_indices = point_style_indices.clone();
         app.on_import_landxml_alignment(move || {
             if let Some(path) = rfd::FileDialog::new()
                 .add_filter("LandXML", &["xml"])
@@ -6786,6 +6822,37 @@ fn main() -> Result<(), slint::PlatformError> {
                                 .unwrap_or_else(|_| {
                                     VerticalAlignment::new(vec![(0.0, 0.0), (hal.length(), 0.0)])
                                 });
+                            for elem in &hal.elements {
+                                use survey_cad::alignment::HorizontalElement::*;
+                                match elem {
+                                    Tangent { start, end } => {
+                                        point_db.borrow_mut().push(*start);
+                                        point_style_indices.borrow_mut().push(0);
+                                        point_db.borrow_mut().push(*end);
+                                        point_style_indices.borrow_mut().push(0);
+                                    }
+                                    Curve { arc } => {
+                                        let s = Point::new(
+                                            arc.center.x + arc.radius * arc.start_angle.cos(),
+                                            arc.center.y + arc.radius * arc.start_angle.sin(),
+                                        );
+                                        let e = Point::new(
+                                            arc.center.x + arc.radius * arc.end_angle.cos(),
+                                            arc.center.y + arc.radius * arc.end_angle.sin(),
+                                        );
+                                        point_db.borrow_mut().push(s);
+                                        point_style_indices.borrow_mut().push(0);
+                                        point_db.borrow_mut().push(e);
+                                        point_style_indices.borrow_mut().push(0);
+                                    }
+                                    Spiral { spiral } => {
+                                        point_db.borrow_mut().push(spiral.start_point());
+                                        point_style_indices.borrow_mut().push(0);
+                                        point_db.borrow_mut().push(spiral.end_point());
+                                        point_style_indices.borrow_mut().push(0);
+                                    }
+                                }
+                            }
                             alignments.borrow_mut().push(Alignment::new(hal, val));
                             if let Some(app) = weak.upgrade() {
                                 app.set_status(SharedString::from("Imported alignment"));

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -994,6 +994,7 @@ export component MainWindow inherits Window {
     callback export_polygons_shp();
     callback export_las();
     callback export_e57();
+    callback export_landxml();
     callback export_landxml_surface();
     callback export_landxml_alignment();
     callback export_landxml_sections();
@@ -1065,6 +1066,7 @@ export component MainWindow inherits Window {
                 MenuItem { title: "Polygon SHP"; activated => { root.export_polygons_shp(); }}
                 MenuItem { title: "LAS"; activated => { root.export_las(); }}
                 MenuItem { title: "E57"; activated => { root.export_e57(); }}
+                MenuItem { title: "LandXML"; activated => { root.export_landxml(); }}
                 MenuItem { title: "LandXML Surface"; activated => { root.export_landxml_surface(); }}
                 MenuItem { title: "LandXML Alignment"; activated => { root.export_landxml_alignment(); }}
                 MenuItem { title: "LandXML Sections"; activated => { root.export_landxml_sections(); }}


### PR DESCRIPTION
## Summary
- expose menu actions for LandXML in `ui/main.slint`
- support exporting LandXML surfaces, alignments and points
- load imported LandXML data into points DB

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_68790857ce508328a63c8ea5ebbe1e38