### PR TITLE
Fix collapsible if-let in truck backend

### DIFF
--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -570,10 +570,10 @@ impl TruckBackend {
                 *end = p;
             }
         }
-        if let Some(elem) = alignment.horizontal.elements.get_mut(handle_idx) {
-            if let HorizontalElement::Tangent { start, .. } = elem {
-                *start = p;
-            }
+        if let Some(HorizontalElement::Tangent { start, .. }) =
+            alignment.horizontal.elements.get_mut(handle_idx)
+        {
+            *start = p;
         }
     }
 


### PR DESCRIPTION
## Summary
- simplify nested `if let` in truck_backend to satisfy clippy

## Testing
- `cargo clippy -p survey_cad_truck_gui -- -D warnings`
- `cargo test --help`

------
https://chatgpt.com/codex/tasks/task_e_68792a4e69b0832892d861d08a05a526