### PR TITLE
Add pipe network editor

### DIFF
--- a/survey_cad_truck_gui/Cargo.toml
+++ b/survey_cad_truck_gui/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 shell-words = "1.1"
 dirs = "6"
+pipe_network = { path = "../pipe_network" }
 pyo3 = { version = "0.21", features = ["auto-initialize", "abi3-py311"], optional = true }
 survey_cad_python = { path = "../survey_cad_python", default-features = false, optional = true }
 open = "5"

--- a/survey_cad_truck_gui/src/lib.rs
+++ b/survey_cad_truck_gui/src/lib.rs
@@ -3,3 +3,4 @@ pub mod truck_backend;
 pub mod ui_state;
 pub mod geometry;
 pub mod snap;
+pub mod pipe_editor;

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -65,6 +65,7 @@ mod ui_state;
 mod workspace;
 mod dialogs;
 mod geometry;
+mod pipe_editor;
 
 use commands::{
     record_macro, spawn_line, spawn_point, Command, CommandStack, Context, MacroPlaying,
@@ -78,6 +79,7 @@ pub use inspector::{
     has_selection, show_context_menu, show_inspector_for_point, show_inspector_for_polygon,
 };
 pub use io_utils::{read_arc_csv, read_line_csv, read_points_list};
+use crate::pipe_editor::{PipeEditor, Pipe, Structure};
 use once_cell::sync::Lazy;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
@@ -198,6 +200,7 @@ fn main() -> Result<(), slint::PlatformError> {
     let polylines = Rc::new(RefCell::new(Vec::<Polyline>::new()));
     let arcs = Rc::new(RefCell::new(Vec::<Arc>::new()));
     let dimensions = Rc::new(RefCell::new(Vec::<LinearDimension>::new()));
+    let pipe_editor = Rc::new(RefCell::new(PipeEditor::new(backend.clone())));
     let surfaces = Rc::new(RefCell::new(Vec::<Tin>::new()));
     let surface_groups = Rc::new(RefCell::new(Vec::<SurfaceGroup>::new()));
     let surface_units = Rc::new(RefCell::new(Vec::<String>::new()));
@@ -3893,6 +3896,196 @@ fn main() -> Result<(), slint::PlatformError> {
                 }
             });
             dlg.show().unwrap();
+        });
+    }
+
+    {
+        let pipe_editor = pipe_editor.clone();
+        let weak = app.as_weak();
+        app.on_pipe_editor(move || {
+            let dlg_s = StructureManager::new().unwrap();
+            let dlg_p = PipeManager::new().unwrap();
+
+            let structs = pipe_editor
+                .borrow()
+                .network
+                .structures
+                .iter()
+                .map(|s| StructureRow {
+                    id: SharedString::from(s.id.clone()),
+                    x: SharedString::from(format!("{:.2}", s.x)),
+                    y: SharedString::from(format!("{:.2}", s.y)),
+                    z: SharedString::from(format!("{:.2}", s.z)),
+                })
+                .collect::<Vec<_>>();
+            let struct_model = Rc::new(VecModel::from(structs));
+            dlg_s.set_structures_model(struct_model.clone().into());
+            dlg_s.set_selected_index(-1);
+
+            let pipes = pipe_editor
+                .borrow()
+                .network
+                .pipes
+                .iter()
+                .map(|p| PipeRow {
+                    id: SharedString::from(p.id.clone()),
+                    from: SharedString::from(p.from.clone()),
+                    to: SharedString::from(p.to.clone()),
+                    diameter: SharedString::from(format!("{:.2}", p.diameter)),
+                })
+                .collect::<Vec<_>>();
+            let pipe_model = Rc::new(VecModel::from(pipes));
+            dlg_p.set_pipes_model(pipe_model.clone().into());
+            dlg_p.set_selected_index(-1);
+
+            {
+                let pipe_editor = pipe_editor.clone();
+                let struct_model = struct_model.clone();
+                dlg_s.on_add_structure(move || {
+                    let mut editor = pipe_editor.borrow_mut();
+                    let id = format!("S{}", editor.network.structures.len() + 1);
+                    editor.network.structures.push(Structure { id: id.clone(), x: 0.0, y: 0.0, z: 0.0 });
+                    struct_model.push(StructureRow { id: id.into(), x: "0".into(), y: "0".into(), z: "0".into() });
+                    editor.refresh_render();
+                });
+            }
+            {
+                let pipe_editor = pipe_editor.clone();
+                let struct_model = struct_model.clone();
+                dlg_s.on_remove_structure(move |idx| {
+                    if idx >= 0 {
+                        let mut editor = pipe_editor.borrow_mut();
+                        if (idx as usize) < editor.network.structures.len() {
+                            editor.network.structures.remove(idx as usize);
+                            struct_model.remove(idx as usize);
+                            editor.refresh_render();
+                        }
+                    }
+                });
+            }
+            {
+                let pipe_editor = pipe_editor.clone();
+                dlg_s.on_edit_id(move |idx, text| {
+                    if idx >= 0 {
+                        if let Some(s) = pipe_editor.borrow_mut().network.structures.get_mut(idx as usize) {
+                            s.id = text.to_string();
+                        }
+                    }
+                });
+            }
+            {
+                let pipe_editor = pipe_editor.clone();
+                dlg_s.on_edit_x(move |idx, text| {
+                    if let Ok(v) = text.parse::<f64>() {
+                        if let Some(s) = pipe_editor.borrow_mut().network.structures.get_mut(idx as usize) {
+                            s.x = v;
+                            pipe_editor.borrow_mut().refresh_render();
+                        }
+                    }
+                });
+            }
+            {
+                let pipe_editor = pipe_editor.clone();
+                dlg_s.on_edit_y(move |idx, text| {
+                    if let Ok(v) = text.parse::<f64>() {
+                        if let Some(s) = pipe_editor.borrow_mut().network.structures.get_mut(idx as usize) {
+                            s.y = v;
+                            pipe_editor.borrow_mut().refresh_render();
+                        }
+                    }
+                });
+            }
+            {
+                let pipe_editor = pipe_editor.clone();
+                dlg_s.on_edit_z(move |idx, text| {
+                    if let Ok(v) = text.parse::<f64>() {
+                        if let Some(s) = pipe_editor.borrow_mut().network.structures.get_mut(idx as usize) {
+                            s.z = v;
+                            pipe_editor.borrow_mut().refresh_render();
+                        }
+                    }
+                });
+            }
+
+            {
+                let pipe_editor = pipe_editor.clone();
+                let pipe_model = pipe_model.clone();
+                dlg_p.on_add_pipe(move || {
+                    let mut editor = pipe_editor.borrow_mut();
+                    let id = format!("P{}", editor.network.pipes.len() + 1);
+                    let from = editor.network.structures.first().map(|s| s.id.clone()).unwrap_or_default();
+                    let to = from.clone();
+                    editor.network.pipes.push(Pipe {
+                        id: id.clone(),
+                        from: from.clone(),
+                        to: to.clone(),
+                        diameter: 0.3,
+                        c: 100.0,
+                        start_invert: 0.0,
+                        end_invert: 0.0,
+                        design_flow: 0.0,
+                    });
+                    pipe_model.push(PipeRow { id: id.into(), from: from.into(), to: to.into(), diameter: "0.3".into() });
+                    editor.refresh_render();
+                });
+            }
+            {
+                let pipe_editor = pipe_editor.clone();
+                let pipe_model = pipe_model.clone();
+                dlg_p.on_remove_pipe(move |idx| {
+                    if idx >= 0 {
+                        let mut editor = pipe_editor.borrow_mut();
+                        if (idx as usize) < editor.network.pipes.len() {
+                            editor.network.pipes.remove(idx as usize);
+                            pipe_model.remove(idx as usize);
+                            editor.refresh_render();
+                        }
+                    }
+                });
+            }
+            {
+                let pipe_editor = pipe_editor.clone();
+                dlg_p.on_edit_id(move |idx, text| {
+                    if let Some(p) = pipe_editor.borrow_mut().network.pipes.get_mut(idx as usize) {
+                        p.id = text.to_string();
+                    }
+                });
+            }
+            {
+                let pipe_editor = pipe_editor.clone();
+                dlg_p.on_edit_from(move |idx, text| {
+                    if let Some(p) = pipe_editor.borrow_mut().network.pipes.get_mut(idx as usize) {
+                        p.from = text.to_string();
+                        pipe_editor.borrow_mut().refresh_render();
+                    }
+                });
+            }
+            {
+                let pipe_editor = pipe_editor.clone();
+                dlg_p.on_edit_to(move |idx, text| {
+                    if let Some(p) = pipe_editor.borrow_mut().network.pipes.get_mut(idx as usize) {
+                        p.to = text.to_string();
+                        pipe_editor.borrow_mut().refresh_render();
+                    }
+                });
+            }
+            {
+                let pipe_editor = pipe_editor.clone();
+                dlg_p.on_edit_diameter(move |idx, text| {
+                    if let Ok(v) = text.parse::<f64>() {
+                        if let Some(p) = pipe_editor.borrow_mut().network.pipes.get_mut(idx as usize) {
+                            p.diameter = v;
+                            pipe_editor.borrow_mut().refresh_render();
+                        }
+                    }
+                });
+            }
+
+            dlg_s.show().unwrap();
+            dlg_p.show().unwrap();
+            if let Some(app) = weak.upgrade() {
+                app.window().request_redraw();
+            }
         });
     }
 

--- a/survey_cad_truck_gui/src/pipe_editor.rs
+++ b/survey_cad_truck_gui/src/pipe_editor.rs
@@ -1,0 +1,68 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub use pipe_network::{Network, Pipe, Structure};
+
+use crate::truck_backend::TruckBackend;
+
+pub struct PipeEditor {
+    pub network: Network,
+    backend: Rc<RefCell<TruckBackend>>,
+    structure_points: Vec<usize>,
+    pipe_lines: Vec<usize>,
+}
+
+impl PipeEditor {
+    pub fn new(backend: Rc<RefCell<TruckBackend>>) -> Self {
+        Self {
+            network: Network::default(),
+            backend,
+            structure_points: Vec::new(),
+            pipe_lines: Vec::new(),
+        }
+    }
+
+    pub fn set_network(&mut self, net: Network) {
+        self.clear_render();
+        self.network = net;
+        self.refresh_render();
+    }
+
+    pub fn refresh_render(&mut self) {
+        self.clear_render();
+        for s in &self.network.structures {
+            let idx = self.backend.borrow_mut().add_point(s.x, s.y, s.z);
+            self.structure_points.push(idx);
+        }
+        for p in &self.network.pipes {
+            let start = self
+                .network
+                .structures
+                .iter()
+                .find(|s| s.id == p.from);
+            let end = self
+                .network
+                .structures
+                .iter()
+                .find(|s| s.id == p.to);
+            if let (Some(a), Some(b)) = (start, end) {
+                let idx = self.backend.borrow_mut().add_line(
+                    [a.x, a.y, a.z],
+                    [b.x, b.y, b.z],
+                    [0.0, 1.0, 0.0, 1.0],
+                    1.0,
+                );
+                self.pipe_lines.push(idx);
+            }
+        }
+    }
+
+    pub fn clear_render(&mut self) {
+        for idx in self.pipe_lines.drain(..).rev() {
+            self.backend.borrow_mut().remove_line(idx);
+        }
+        for idx in self.structure_points.drain(..).rev() {
+            self.backend.borrow_mut().remove_point(idx);
+        }
+    }
+}

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -11,6 +11,8 @@ export { SuperelevationEditor } from "superelevation_editor.slint";
 export { EntityInspector } from "entity_inspector.slint";
 export { ImportProgressDialog } from "import_progress.slint";
 export { ScriptPanel } from "script_panel.slint";
+export { StructureManager } from "structure_manager.slint";
+export { PipeManager } from "pipe_manager.slint";
 
 // Button used in toolbars that emits hover events
 component ToolButton {
@@ -84,6 +86,7 @@ component Ribbon inherits TabWidget {
     callback design_cross_sections();
     callback view_cross_sections();
     callback extrude_polyline();
+    callback pipe_editor();
     callback clear_workspace();
     callback view_changed(int);
     callback cogo_selected(int);
@@ -136,7 +139,15 @@ component Ribbon inherits TabWidget {
             ToolButton { tip: "Corridor Volume"; icon: @image-url("../assets/icons/corridor_volume.png"); clicked => { root.corridor_volume(); } hovered(t) => { root.button_hovered(t); } }
             ToolButton { tip: "Edit Superelevation"; icon: @image-url("../assets/icons/superelevation.png"); clicked => { root.superelevation_editor(); } hovered(t) => { root.button_hovered(t); } }
             ToolButton { tip: "Design Cross Sections"; icon: @image-url("../assets/icons/design_sections.png"); clicked => { root.design_cross_sections(); } hovered(t) => { root.button_hovered(t); } }
-            ToolButton { tip: "View Cross Sections"; icon: @image-url("../assets/icons/cross_sections.png"); clicked => { root.view_cross_sections(); } hovered(t) => { root.button_hovered(t); } }
+        ToolButton { tip: "View Cross Sections"; icon: @image-url("../assets/icons/cross_sections.png"); clicked => { root.view_cross_sections(); } hovered(t) => { root.button_hovered(t); } }
+        }
+    }
+
+    Tab {
+        title: "Pipe Network";
+        HorizontalBox {
+            spacing: 6px;
+            ToolButton { tip: "Pipe Editor"; icon: @image-url("../assets/icons/inspector.png"); clicked => { root.pipe_editor(); } hovered(t) => { root.button_hovered(t); } }
         }
     }
 
@@ -1021,6 +1032,7 @@ export component MainWindow inherits Window {
     callback rotate_entity();
     callback delete_selected();
     callback extrude_polyline();
+    callback pipe_editor();
     callback zoom_in();
     callback zoom_out();
     callback snap_settings();
@@ -1192,6 +1204,7 @@ export component MainWindow inherits Window {
             design_cross_sections => { root.design_cross_sections(); }
             view_cross_sections => { root.view_cross_sections(); }
             extrude_polyline => { root.extrude_polyline(); }
+            pipe_editor => { root.pipe_editor(); }
             clear_workspace => { root.clear_workspace(); }
             view_changed(i) => { root.view_changed(i); }
             cogo_selected(i) => { root.cogo_selected(i); }

--- a/survey_cad_truck_gui/ui/pipe_manager.slint
+++ b/survey_cad_truck_gui/ui/pipe_manager.slint
@@ -1,0 +1,60 @@
+export struct PipeRow {
+    id: string,
+    from: string,
+    to: string,
+    diameter: string,
+}
+
+import { Button, VerticalBox, HorizontalBox, LineEdit, ListView } from "std-widgets.slint";
+
+export component PipeManager inherits Window {
+    in-out property <[PipeRow]> pipes_model;
+    in-out property <int> selected_index;
+    callback add_pipe();
+    callback remove_pipe(int);
+    callback edit_id(int, string);
+    callback edit_from(int, string);
+    callback edit_to(int, string);
+    callback edit_diameter(int, string);
+    title: "Pipes";
+    width: 500px;
+    height: 300px;
+
+    VerticalBox {
+        spacing: 4px;
+        Rectangle {
+            width: 100%;
+            height: 20px;
+            border-width: 1px;
+            border-color: #808080;
+            HorizontalBox {
+                spacing: 8px;
+                Text { color: #FFFFFF; text: "ID"; width: 60px; }
+                Text { color: #FFFFFF; text: "From"; width: 80px; }
+                Text { color: #FFFFFF; text: "To"; width: 80px; }
+                Text { color: #FFFFFF; text: "Dia"; width: 60px; }
+            }
+        }
+        ListView {
+            vertical-stretch: 1;
+            for row[i] in root.pipes_model : Rectangle {
+                property <bool> selected: root.selected_index == i;
+                background: selected ? #404040 : transparent;
+                height: 24px;
+                HorizontalBox {
+                    spacing: 8px;
+                    LineEdit { text: row.id; width: 60px; edited(text) => { root.edit_id(i, text); } }
+                    LineEdit { text: row.from; width: 80px; edited(text) => { root.edit_from(i, text); } }
+                    LineEdit { text: row.to; width: 80px; edited(text) => { root.edit_to(i, text); } }
+                    LineEdit { text: row.diameter; width: 60px; edited(text) => { root.edit_diameter(i, text); } }
+                }
+                TouchArea { width: 100%; height: 100%; clicked => { root.selected_index = i; } }
+            }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "Add"; clicked => { root.add_pipe(); } }
+            Button { text: "Remove"; clicked => { root.remove_pipe(root.selected_index); } }
+        }
+    }
+}

--- a/survey_cad_truck_gui/ui/structure_manager.slint
+++ b/survey_cad_truck_gui/ui/structure_manager.slint
@@ -1,0 +1,60 @@
+export struct StructureRow {
+    id: string,
+    x: string,
+    y: string,
+    z: string,
+}
+
+import { Button, VerticalBox, HorizontalBox, LineEdit, ListView } from "std-widgets.slint";
+
+export component StructureManager inherits Window {
+    in-out property <[StructureRow]> structures_model;
+    in-out property <int> selected_index;
+    callback add_structure();
+    callback remove_structure(int);
+    callback edit_id(int, string);
+    callback edit_x(int, string);
+    callback edit_y(int, string);
+    callback edit_z(int, string);
+    title: "Structures";
+    width: 400px;
+    height: 300px;
+
+    VerticalBox {
+        spacing: 4px;
+        Rectangle {
+            width: 100%;
+            height: 20px;
+            border-width: 1px;
+            border-color: #808080;
+            HorizontalBox {
+                spacing: 8px;
+                Text { color: #FFFFFF; text: "ID"; width: 60px; }
+                Text { color: #FFFFFF; text: "X"; width: 80px; }
+                Text { color: #FFFFFF; text: "Y"; width: 80px; }
+                Text { color: #FFFFFF; text: "Z"; width: 80px; }
+            }
+        }
+        ListView {
+            vertical-stretch: 1;
+            for row[i] in root.structures_model : Rectangle {
+                property <bool> selected: root.selected_index == i;
+                background: selected ? #404040 : transparent;
+                height: 24px;
+                HorizontalBox {
+                    spacing: 8px;
+                    LineEdit { text: row.id; width: 60px; edited(text) => { root.edit_id(i, text); } }
+                    LineEdit { text: row.x; width: 80px; edited(text) => { root.edit_x(i, text); } }
+                    LineEdit { text: row.y; width: 80px; edited(text) => { root.edit_y(i, text); } }
+                    LineEdit { text: row.z; width: 80px; edited(text) => { root.edit_z(i, text); } }
+                }
+                TouchArea { width: 100%; height: 100%; clicked => { root.selected_index = i; } }
+            }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "Add"; clicked => { root.add_structure(); } }
+            Button { text: "Remove"; clicked => { root.remove_structure(root.selected_index); } }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add slint components for editing structures and pipes
- add PipeEditor wrapper around pipe_network types with TruckBackend rendering
- expose pipe editor from GUI ribbon

## Testing
- `cargo check -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_687938ae510c8328a3376a995968e017