### PR TITLE
Fix Config initialization

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -2307,7 +2307,7 @@ fn main() -> Result<(), slint::PlatformError> {
                 *workspace_crs.borrow_mut() = epsg;
                 if let Some(idx) = crs_entries_rc
                     .iter()
-                    .position(|e| e.code == format!("EPSG:{}", epsg))
+                    .position(|e| e.code == format!("EPSG:{epsg}"))
                 {
                     app.set_crs_index(idx as i32);
                 }

--- a/survey_cad_truck_gui/tests/config.rs
+++ b/survey_cad_truck_gui/tests/config.rs
@@ -28,6 +28,7 @@ fn save_and_load_config() {
         theme: Theme::default(),
         font_path: Some("font/path".into()),
         macro_dir: Some("/tmp/macros".into()),
+        crs_epsg: 4326,
     };
 
     save_config(&cfg);


### PR DESCRIPTION
## Summary
- populate `crs_epsg` in test config
- silence clippy by inlining format variable

## Testing
- `cargo clippy -p survey_cad_truck_gui -- -D warnings`
- `cargo test -p survey_cad_truck_gui --no-run`

------
https://chatgpt.com/codex/tasks/task_e_687e58f758a083289dcb1fd22f113138