### PR TITLE
Fix clippy warnings

### DIFF
--- a/survey_cad_truck_gui/src/commands.rs
+++ b/survey_cad_truck_gui/src/commands.rs
@@ -5,7 +5,6 @@ use std::rc::Rc;
 use survey_cad::geometry::{Point, LinearDimension};
 use survey_cad::point_database::PointDatabase;
 use truck_modeling::base::Point3;
-use shell_words;
 
 use crate::truck_backend::TruckBackend;
 

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -1238,10 +1238,8 @@ fn main() -> Result<(), slint::PlatformError> {
             if !txt.is_empty() {
                 for i in (0..history_model.row_count()).rev() {
                     if let Some(e) = history_model.row_data(i) {
-                        if e.as_str().starts_with(txt.as_str()) {
-                            if !list.contains(&e) {
-                                list.push(e.clone());
-                            }
+                        if e.as_str().starts_with(txt.as_str()) && !list.contains(&e) {
+                            list.push(e.clone());
                         }
                         if list.len() >= 5 {
                             break;


### PR DESCRIPTION
## Summary
- remove redundant `use shell_words;`
- collapse nested if in command history suggestions

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo clippy -p survey_cad_truck_gui -- -D warnings`
- `cargo test -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_687e93a88fb883289f05ecaf0c5b7705