### PR TITLE
Add snap overlay and marker to truck gui

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -2,7 +2,7 @@
 
 use i_slint_common::sharedfontdb;
 use slint::platform::PointerEventButton;
-use slint::{Model, PhysicalSize, SharedString, VecModel, Image};
+use slint::{Image, Model, PhysicalSize, SharedString, VecModel};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Instant;
@@ -39,8 +39,8 @@ use truck_backend::{HitObject, TruckBackend};
 mod persistence;
 use persistence::{load_layers, load_styles, save_layers, save_styles, StyleSettings};
 mod commands;
-mod error;
 mod cross_section;
+mod error;
 mod inspector;
 mod io_utils;
 #[cfg(feature = "python")]
@@ -60,13 +60,14 @@ mod python {
         Err(GuiError::Msg("Python support disabled".into()))
     }
 }
-mod render;
-mod ui_state;
-mod workspace;
 mod dialogs;
 mod geometry;
 mod pipe_editor;
+mod render;
+mod ui_state;
+mod workspace;
 
+use crate::pipe_editor::{Pipe, PipeEditor, Structure};
 use commands::{
     record_macro, spawn_line, spawn_point, Command, CommandStack, Context, MacroPlaying,
     MacroRecorder,
@@ -75,11 +76,11 @@ pub use cross_section::{
     calc_section_params, grade_at, handle_positions, nearest_point, render_cross_section,
     screen_to_world, SectionParams,
 };
+use error::GuiError;
 pub use inspector::{
     has_selection, show_context_menu, show_inspector_for_point, show_inspector_for_polygon,
 };
 pub use io_utils::{read_arc_csv, read_line_csv, read_points_list};
-use crate::pipe_editor::{PipeEditor, Pipe, Structure};
 use once_cell::sync::Lazy;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
@@ -90,7 +91,6 @@ use render::{
     arc_from_start_end_radius, arc_from_three_points, polyline_to_solid, screen_to_workspace,
     workspace_to_screen, RenderState, RenderStyles, WorkspaceRenderData,
 };
-use error::GuiError;
 use rusttype::Font;
 use tiny_skia::Pixmap;
 use ui_state::{
@@ -1302,7 +1302,12 @@ fn main() -> Result<(), slint::PlatformError> {
                         });
                     }
                     commands::ParsedCommand::Circle { center, radius } => {
-                        arcs.borrow_mut().push(Arc::new(center, radius, 0.0, 2.0 * std::f64::consts::PI));
+                        arcs.borrow_mut().push(Arc::new(
+                            center,
+                            radius,
+                            0.0,
+                            2.0 * std::f64::consts::PI,
+                        ));
                     }
                     commands::ParsedCommand::Arc { p1, p2, p3 } => {
                         if let Some(a) = render::arc_from_three_points(p1, p2, p3) {
@@ -1322,15 +1327,24 @@ fn main() -> Result<(), slint::PlatformError> {
                             }
                             Err(e) => {
                                 if let Some(app) = weak.upgrade() {
-                                    app.set_status(SharedString::from(format!("Failed to load: {e}")));
+                                    app.set_status(SharedString::from(format!(
+                                        "Failed to load: {e}"
+                                    )));
                                 }
                             }
                         }
                     }
                     commands::ParsedCommand::Export(path) => {
-                        if let Err(e) = survey_cad::io::write_points_geojson(&path, &point_db.borrow(), None, None) {
+                        if let Err(e) = survey_cad::io::write_points_geojson(
+                            &path,
+                            &point_db.borrow(),
+                            None,
+                            None,
+                        ) {
                             if let Some(app) = weak.upgrade() {
-                                app.set_status(SharedString::from(format!("Failed to export: {e}")));
+                                app.set_status(SharedString::from(format!(
+                                    "Failed to export: {e}"
+                                )));
                             }
                         }
                     }
@@ -2110,7 +2124,6 @@ fn main() -> Result<(), slint::PlatformError> {
                         .screen_to_plane(x as f64, y as f64, pos.z);
                     if let Some(app_ref) = weak.upgrade() {
                         if app_ref.get_snap_to_entities() {
-                            let scene = backend_move.borrow().snap_scene();
                             let opts = snap::SnapOptions {
                                 snap_points: app_ref.get_snap_points(),
                                 snap_endpoints: app_ref.get_snap_endpoints(),
@@ -2120,9 +2133,8 @@ fn main() -> Result<(), slint::PlatformError> {
                                 snap_surfaces: app_ref.get_snap_surfaces(),
                                 snap_solids: app_ref.get_snap_solids(),
                             };
-                            if let Some(sp) = snap::resolve_snap_3d(
+                            if let Some(sp) = backend_move.borrow_mut().resolve_snap_3d(
                                 new_p,
-                                &scene,
                                 app_ref.get_snap_tolerance() as f64,
                                 opts,
                             ) {
@@ -2393,7 +2405,9 @@ fn main() -> Result<(), slint::PlatformError> {
         let surface_groups = surface_groups.clone();
         let alignment_groups = alignment_groups.clone();
         app.on_open_project(move || {
-            if let Some(path) = dialogs::open_project_file(last_dir.borrow().as_deref().map(Path::new)) {
+            if let Some(path) =
+                dialogs::open_project_file(last_dir.borrow().as_deref().map(Path::new))
+            {
                 *last_dir.borrow_mut() = path.parent().map(|p| p.to_string_lossy().to_string());
                 config_rc.borrow_mut().last_open_dir = last_dir.borrow().clone();
                 save_config(&config_rc.borrow());
@@ -4006,8 +4020,18 @@ fn main() -> Result<(), slint::PlatformError> {
                 dlg_s.on_add_structure(move || {
                     let mut editor = pipe_editor.borrow_mut();
                     let id = format!("S{}", editor.network.structures.len() + 1);
-                    editor.network.structures.push(Structure { id: id.clone(), x: 0.0, y: 0.0, z: 0.0 });
-                    struct_model.push(StructureRow { id: id.into(), x: "0".into(), y: "0".into(), z: "0".into() });
+                    editor.network.structures.push(Structure {
+                        id: id.clone(),
+                        x: 0.0,
+                        y: 0.0,
+                        z: 0.0,
+                    });
+                    struct_model.push(StructureRow {
+                        id: id.into(),
+                        x: "0".into(),
+                        y: "0".into(),
+                        z: "0".into(),
+                    });
                     editor.refresh_render();
                 });
             }
@@ -4029,7 +4053,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 let pipe_editor = pipe_editor.clone();
                 dlg_s.on_edit_id(move |idx, text| {
                     if idx >= 0 {
-                        if let Some(s) = pipe_editor.borrow_mut().network.structures.get_mut(idx as usize) {
+                        if let Some(s) = pipe_editor
+                            .borrow_mut()
+                            .network
+                            .structures
+                            .get_mut(idx as usize)
+                        {
                             s.id = text.to_string();
                         }
                     }
@@ -4039,7 +4068,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 let pipe_editor = pipe_editor.clone();
                 dlg_s.on_edit_x(move |idx, text| {
                     if let Ok(v) = text.parse::<f64>() {
-                        if let Some(s) = pipe_editor.borrow_mut().network.structures.get_mut(idx as usize) {
+                        if let Some(s) = pipe_editor
+                            .borrow_mut()
+                            .network
+                            .structures
+                            .get_mut(idx as usize)
+                        {
                             s.x = v;
                             pipe_editor.borrow_mut().refresh_render();
                         }
@@ -4050,7 +4084,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 let pipe_editor = pipe_editor.clone();
                 dlg_s.on_edit_y(move |idx, text| {
                     if let Ok(v) = text.parse::<f64>() {
-                        if let Some(s) = pipe_editor.borrow_mut().network.structures.get_mut(idx as usize) {
+                        if let Some(s) = pipe_editor
+                            .borrow_mut()
+                            .network
+                            .structures
+                            .get_mut(idx as usize)
+                        {
                             s.y = v;
                             pipe_editor.borrow_mut().refresh_render();
                         }
@@ -4061,7 +4100,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 let pipe_editor = pipe_editor.clone();
                 dlg_s.on_edit_z(move |idx, text| {
                     if let Ok(v) = text.parse::<f64>() {
-                        if let Some(s) = pipe_editor.borrow_mut().network.structures.get_mut(idx as usize) {
+                        if let Some(s) = pipe_editor
+                            .borrow_mut()
+                            .network
+                            .structures
+                            .get_mut(idx as usize)
+                        {
                             s.z = v;
                             pipe_editor.borrow_mut().refresh_render();
                         }
@@ -4075,7 +4119,12 @@ fn main() -> Result<(), slint::PlatformError> {
                 dlg_p.on_add_pipe(move || {
                     let mut editor = pipe_editor.borrow_mut();
                     let id = format!("P{}", editor.network.pipes.len() + 1);
-                    let from = editor.network.structures.first().map(|s| s.id.clone()).unwrap_or_default();
+                    let from = editor
+                        .network
+                        .structures
+                        .first()
+                        .map(|s| s.id.clone())
+                        .unwrap_or_default();
                     let to = from.clone();
                     editor.network.pipes.push(Pipe {
                         id: id.clone(),
@@ -4087,7 +4136,12 @@ fn main() -> Result<(), slint::PlatformError> {
                         end_invert: 0.0,
                         design_flow: 0.0,
                     });
-                    pipe_model.push(PipeRow { id: id.into(), from: from.into(), to: to.into(), diameter: "0.3".into() });
+                    pipe_model.push(PipeRow {
+                        id: id.into(),
+                        from: from.into(),
+                        to: to.into(),
+                        diameter: "0.3".into(),
+                    });
                     editor.refresh_render();
                 });
             }
@@ -4135,7 +4189,9 @@ fn main() -> Result<(), slint::PlatformError> {
                 let pipe_editor = pipe_editor.clone();
                 dlg_p.on_edit_diameter(move |idx, text| {
                     if let Ok(v) = text.parse::<f64>() {
-                        if let Some(p) = pipe_editor.borrow_mut().network.pipes.get_mut(idx as usize) {
+                        if let Some(p) =
+                            pipe_editor.borrow_mut().network.pipes.get_mut(idx as usize)
+                        {
                             p.diameter = v;
                             pipe_editor.borrow_mut().refresh_render();
                         }
@@ -4216,10 +4272,11 @@ fn main() -> Result<(), slint::PlatformError> {
                             if let Ok(img) = render_cross_section(&secs_b[i], 600, 300) {
                                 v.set_section_image(img);
                             }
-                            let handles: Vec<HandlePoint> = handle_positions(&secs_b[i], 600.0, 300.0)
-                                .into_iter()
-                                .map(|(x, y)| HandlePoint { x, y })
-                                .collect();
+                            let handles: Vec<HandlePoint> =
+                                handle_positions(&secs_b[i], 600.0, 300.0)
+                                    .into_iter()
+                                    .map(|(x, y)| HandlePoint { x, y })
+                                    .collect();
                             v.set_handles_model(Rc::new(VecModel::from(handles)).into());
                         }
                     }
@@ -4342,14 +4399,11 @@ fn main() -> Result<(), slint::PlatformError> {
                             surfaces_r.borrow_mut()[0] = tin;
                         }
                         if let Some(v) = viewer_weak.upgrade() {
-                            let handles: Vec<HandlePoint> = handle_positions(
-                                &secs_r.borrow()[*current.borrow()],
-                                600.0,
-                                300.0,
-                            )
-                            .into_iter()
-                            .map(|(hx, hy)| HandlePoint { x: hx, y: hy })
-                            .collect();
+                            let handles: Vec<HandlePoint> =
+                                handle_positions(&secs_r.borrow()[*current.borrow()], 600.0, 300.0)
+                                    .into_iter()
+                                    .map(|(hx, hy)| HandlePoint { x: hx, y: hy })
+                                    .collect();
                             v.set_handles_model(Rc::new(VecModel::from(handles)).into());
                         }
                     }
@@ -5782,9 +5836,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     let pts = point_db.borrow().points().to_vec();
                     let als = alignments.borrow().clone();
                     let surfs = surfaces.borrow().clone();
-                    if let Err(e) =
-                        survey_cad::io::landxml::write_landxml(p, &pts, &als, &surfs)
-                    {
+                    if let Err(e) = survey_cad::io::landxml::write_landxml(p, &pts, &als, &surfs) {
                         if let Some(app) = weak.upgrade() {
                             app.set_status(SharedString::from(format!("Failed to export: {e}")));
                         }
@@ -6868,12 +6920,15 @@ fn main() -> Result<(), slint::PlatformError> {
             dlg.set_color_b(SharedString::from(gs.color[2].to_string()));
             dlg.set_show_grid(gs.visible);
             dlg.set_auto_tin(config_ref.borrow().auto_tin);
-            dlg.set_crs_list(Rc::new(VecModel::from(
-                crs_entries_rc
-                    .iter()
-                    .map(|e| SharedString::from(format!("{} - {}", e.code, e.name)))
-                    .collect::<Vec<_>>(),
-            )).into());
+            dlg.set_crs_list(
+                Rc::new(VecModel::from(
+                    crs_entries_rc
+                        .iter()
+                        .map(|e| SharedString::from(format!("{} - {}", e.code, e.name)))
+                        .collect::<Vec<_>>(),
+                ))
+                .into(),
+            );
             let crs_idx = crs_entries_rc
                 .iter()
                 .position(|e| e.code == format!("EPSG:{}", *workspace_crs.borrow()))
@@ -6895,8 +6950,10 @@ fn main() -> Result<(), slint::PlatformError> {
                     fonts.push(fp);
                 }
             }
-            let font_items: Vec<SharedString> =
-                fonts.iter().map(|s| SharedString::from(s.as_str())).collect();
+            let font_items: Vec<SharedString> = fonts
+                .iter()
+                .map(|s| SharedString::from(s.as_str()))
+                .collect();
             dlg.set_font_list(Rc::new(VecModel::from(font_items)).into());
             let current_idx = config_ref
                 .borrow()

--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -46,7 +46,9 @@ struct SpatialItem {
 
 impl RTreeObject for SpatialItem {
     type Envelope = AABB<[f64; 3]>;
-    fn envelope(&self) -> Self::Envelope { self.bbox }
+    fn envelope(&self) -> Self::Envelope {
+        self.bbox
+    }
 }
 
 pub struct TruckBackend {
@@ -60,6 +62,7 @@ pub struct TruckBackend {
     hover_surface: Option<usize>,
     hover_handle: Option<usize>,
     spatial_index: RTree<SpatialItem>,
+    snap_point: Option<Point3>,
 }
 
 impl TruckBackend {
@@ -77,6 +80,7 @@ impl TruckBackend {
             hover_surface: None,
             hover_handle: None,
             spatial_index: RTree::new(),
+            snap_point: None,
         };
         backend.rebuild_index();
         backend
@@ -103,12 +107,24 @@ impl TruckBackend {
                 let mut min = [first.x, first.y, first.z];
                 let mut max = min;
                 for v in &surf.vertices {
-                    if v.x < min[0] { min[0] = v.x; }
-                    if v.y < min[1] { min[1] = v.y; }
-                    if v.z < min[2] { min[2] = v.z; }
-                    if v.x > max[0] { max[0] = v.x; }
-                    if v.y > max[1] { max[1] = v.y; }
-                    if v.z > max[2] { max[2] = v.z; }
+                    if v.x < min[0] {
+                        min[0] = v.x;
+                    }
+                    if v.y < min[1] {
+                        min[1] = v.y;
+                    }
+                    if v.z < min[2] {
+                        min[2] = v.z;
+                    }
+                    if v.x > max[0] {
+                        max[0] = v.x;
+                    }
+                    if v.y > max[1] {
+                        max[1] = v.y;
+                    }
+                    if v.z > max[2] {
+                        max[2] = v.z;
+                    }
                 }
                 self.spatial_index.insert(SpatialItem {
                     bbox: AABB::from_corners(min, max),
@@ -174,14 +190,13 @@ impl TruckBackend {
         self.rebuild_index();
     }
 
-    pub fn add_line(
-        &mut self,
-        a: [f64; 3],
-        b: [f64; 3],
-        color: [f32; 4],
-        weight: f32,
-    ) -> usize {
-        let col = Vector4::new(color[0] as f64, color[1] as f64, color[2] as f64, color[3] as f64);
+    pub fn add_line(&mut self, a: [f64; 3], b: [f64; 3], color: [f32; 4], weight: f32) -> usize {
+        let col = Vector4::new(
+            color[0] as f64,
+            color[1] as f64,
+            color[2] as f64,
+            color[3] as f64,
+        );
         let id = self.engine.add_line(
             Point3::new(a[0], a[1], a[2]),
             Point3::new(b[0], b[1], b[2]),
@@ -213,7 +228,12 @@ impl TruckBackend {
                 *id,
                 Point3::new(a[0], a[1], a[2]),
                 Point3::new(b[0], b[1], b[2]),
-                Vector4::new(color[0] as f64, color[1] as f64, color[2] as f64, color[3] as f64),
+                Vector4::new(
+                    color[0] as f64,
+                    color[1] as f64,
+                    color[2] as f64,
+                    color[3] as f64,
+                ),
                 weight,
             );
         }
@@ -221,7 +241,12 @@ impl TruckBackend {
             idx,
             Point3::new(a[0], a[1], a[2]),
             Point3::new(b[0], b[1], b[2]),
-            Vector4::new(color[0] as f64, color[1] as f64, color[2] as f64, color[3] as f64),
+            Vector4::new(
+                color[0] as f64,
+                color[1] as f64,
+                color[2] as f64,
+                color[3] as f64,
+            ),
             weight,
         );
         self.rebuild_index();
@@ -240,7 +265,12 @@ impl TruckBackend {
     /// Add multiple lines at once.
     pub fn add_lines(&mut self, lines: &[LineInput]) {
         for (a, b, color, weight) in lines {
-            let col = Vector4::new(color[0] as f64, color[1] as f64, color[2] as f64, color[3] as f64);
+            let col = Vector4::new(
+                color[0] as f64,
+                color[1] as f64,
+                color[2] as f64,
+                color[3] as f64,
+            );
             let id = self.engine.add_line(
                 Point3::new(a[0], a[1], a[2]),
                 Point3::new(b[0], b[1], b[2]),
@@ -259,18 +289,27 @@ impl TruckBackend {
     }
 
     /// Add a dimension represented as a simple line between two points.
-    pub fn add_dimension(&mut self, a: [f64; 3], b: [f64; 3], color: [f32; 4], weight: f32) -> usize {
+    pub fn add_dimension(
+        &mut self,
+        a: [f64; 3],
+        b: [f64; 3],
+        color: [f32; 4],
+        weight: f32,
+    ) -> usize {
         let id = self.engine.add_line(
             Point3::new(a[0], a[1], a[2]),
             Point3::new(b[0], b[1], b[2]),
-            Vector4::new(color[0] as f64, color[1] as f64, color[2] as f64, color[3] as f64),
+            Vector4::new(
+                color[0] as f64,
+                color[1] as f64,
+                color[2] as f64,
+                color[3] as f64,
+            ),
             weight,
         );
         self.dimension_ids.push(Some(id));
-        self.geometry.add_dimension(
-            Point3::new(a[0], a[1], a[2]),
-            Point3::new(b[0], b[1], b[2]),
-        )
+        self.geometry
+            .add_dimension(Point3::new(a[0], a[1], a[2]), Point3::new(b[0], b[1], b[2]))
     }
 
     /// Remove an existing dimension.
@@ -477,8 +516,16 @@ impl TruckBackend {
         let va = &align.vertical;
         if let Some(first) = va.elements.first() {
             let (s, z) = match first {
-                VerticalElement::Grade { start_station, start_elev, .. } => (*start_station, *start_elev),
-                VerticalElement::Parabola { start_station, start_elev, .. } => (*start_station, *start_elev),
+                VerticalElement::Grade {
+                    start_station,
+                    start_elev,
+                    ..
+                } => (*start_station, *start_elev),
+                VerticalElement::Parabola {
+                    start_station,
+                    start_elev,
+                    ..
+                } => (*start_station, *start_elev),
             };
             if let Some(p) = align.horizontal.point_at(s) {
                 ids.push(self.engine.add_point_marker(Point3::new(p.x, p.y, z)));
@@ -486,8 +533,18 @@ impl TruckBackend {
         }
         for e in &va.elements {
             let (s, z) = match e {
-                VerticalElement::Grade { end_station, end_elev, .. } => (*end_station, *end_elev),
-                VerticalElement::Parabola { start_station, end_station, start_elev, start_grade, end_grade } => {
+                VerticalElement::Grade {
+                    end_station,
+                    end_elev,
+                    ..
+                } => (*end_station, *end_elev),
+                VerticalElement::Parabola {
+                    start_station,
+                    end_station,
+                    start_elev,
+                    start_grade,
+                    end_grade,
+                } => {
                     let l = end_station - start_station;
                     let dz = start_grade * l + 0.5 * (end_grade - start_grade) * l;
                     (*end_station, start_elev + dz)
@@ -527,7 +584,8 @@ impl TruckBackend {
                     }
                 }
                 HandleTarget::Line(idx) => {
-                    let (p0, p1, col, weight) = if let Some(line) = self.geometry.lines.get_mut(idx) {
+                    let (p0, p1, col, weight) = if let Some(line) = self.geometry.lines.get_mut(idx)
+                    {
                         if handle_idx == 0 {
                             line.0 = new_pos;
                         } else if handle_idx == 1 {
@@ -552,7 +610,12 @@ impl TruckBackend {
     }
 
     /// Move a horizontal alignment PI handle.
-    pub fn move_alignment_pi_handle(&mut self, alignment: &mut Alignment, handle_idx: usize, pos: Point3) {
+    pub fn move_alignment_pi_handle(
+        &mut self,
+        alignment: &mut Alignment,
+        handle_idx: usize,
+        pos: Point3,
+    ) {
         use survey_cad::alignment::HorizontalElement;
         if let Some((HandleTarget::AlignmentPi, ref handles)) = self.handles {
             if let Some(id) = handles.get(handle_idx) {
@@ -561,12 +624,16 @@ impl TruckBackend {
         }
         let p = Point::new(pos.x, pos.y);
         if handle_idx == 0 {
-            if let Some(HorizontalElement::Tangent { start, .. }) = alignment.horizontal.elements.get_mut(0) {
+            if let Some(HorizontalElement::Tangent { start, .. }) =
+                alignment.horizontal.elements.get_mut(0)
+            {
                 *start = p;
             }
         }
         if handle_idx > 0 {
-            if let Some(HorizontalElement::Tangent { end, .. }) = alignment.horizontal.elements.get_mut(handle_idx - 1) {
+            if let Some(HorizontalElement::Tangent { end, .. }) =
+                alignment.horizontal.elements.get_mut(handle_idx - 1)
+            {
                 *end = p;
             }
         }
@@ -595,11 +662,19 @@ impl TruckBackend {
         let elev = pos.z;
         if idx == 0 {
             match &mut valign.elements[0] {
-                VerticalElement::Grade { start_station, start_elev, .. } => {
+                VerticalElement::Grade {
+                    start_station,
+                    start_elev,
+                    ..
+                } => {
                     *start_station = station;
                     *start_elev = elev;
                 }
-                VerticalElement::Parabola { start_station, start_elev, .. } => {
+                VerticalElement::Parabola {
+                    start_station,
+                    start_elev,
+                    ..
+                } => {
                     *start_station = station;
                     *start_elev = elev;
                 }
@@ -608,7 +683,11 @@ impl TruckBackend {
         if idx > 0 {
             if let Some(prev) = valign.elements.get_mut(idx - 1) {
                 match prev {
-                    VerticalElement::Grade { end_station, end_elev, .. } => {
+                    VerticalElement::Grade {
+                        end_station,
+                        end_elev,
+                        ..
+                    } => {
                         *end_station = station;
                         *end_elev = elev;
                     }
@@ -620,11 +699,19 @@ impl TruckBackend {
         }
         if let Some(cur) = valign.elements.get_mut(idx) {
             match cur {
-                VerticalElement::Grade { start_station, start_elev, .. } => {
+                VerticalElement::Grade {
+                    start_station,
+                    start_elev,
+                    ..
+                } => {
                     *start_station = station;
                     *start_elev = elev;
                 }
-                VerticalElement::Parabola { start_station, start_elev, .. } => {
+                VerticalElement::Parabola {
+                    start_station,
+                    start_elev,
+                    ..
+                } => {
                     *start_station = station;
                     *start_elev = elev;
                 }
@@ -732,6 +819,26 @@ impl TruckBackend {
         }
     }
 
+    pub fn resolve_snap_3d(
+        &mut self,
+        target: Point3,
+        tol: f64,
+        opts: crate::snap::SnapOptions,
+    ) -> Option<Point3> {
+        let scene = self.snap_scene();
+        let res = crate::snap::resolve_snap_3d(target, &scene, tol, opts);
+        self.snap_point = res;
+        res
+    }
+
+    pub fn snap_point(&self) -> Option<Point3> {
+        self.snap_point
+    }
+
+    pub fn clear_snap_point(&mut self) {
+        self.snap_point = None;
+    }
+
     pub fn hit_test(&mut self, x: f64, y: f64) -> Option<HitObject> {
         let mut result = None;
         let mut best_z = f64::INFINITY;
@@ -781,9 +888,15 @@ impl TruckBackend {
         let mut cand_surfaces = HashSet::new();
         for c in candidates {
             match c.elem {
-                SpatialElement::Point(i) => { cand_points.insert(i); }
-                SpatialElement::Line(i) => { cand_lines.insert(i); }
-                SpatialElement::Surface(i) => { cand_surfaces.insert(i); }
+                SpatialElement::Point(i) => {
+                    cand_points.insert(i);
+                }
+                SpatialElement::Line(i) => {
+                    cand_lines.insert(i);
+                }
+                SpatialElement::Surface(i) => {
+                    cand_surfaces.insert(i);
+                }
             }
         }
 
@@ -801,10 +914,9 @@ impl TruckBackend {
 
         for i in cand_lines {
             if let Some(&(a, b, _, _)) = self.geometry.lines.as_slice().get(i) {
-                if let (Some((ax, ay, az)), Some((bx, by, bz))) = (
-                    self.engine.project_point(a),
-                    self.engine.project_point(b),
-                ) {
+                if let (Some((ax, ay, az)), Some((bx, by, bz))) =
+                    (self.engine.project_point(a), self.engine.project_point(b))
+                {
                     let t = ((x - ax) * (bx - ax) + (y - ay) * (by - ay))
                         / ((bx - ax).powi(2) + (by - ay).powi(2));
                     if (0.0..=1.0).contains(&t) {
@@ -954,4 +1066,4 @@ impl TruckBackend {
 
         result
     }
-    }
+}

--- a/survey_cad_truck_gui/src/workspace.rs
+++ b/survey_cad_truck_gui/src/workspace.rs
@@ -10,11 +10,11 @@ use survey_cad::geometry::{Line, LineAnnotation, LineType};
 use survey_cad::io::project::GridSettings;
 use survey_cad::styles::{format_dms, HatchPattern, LineLabelPosition};
 
+use crate::error::GuiError;
 use crate::render::{draw_text, RenderState, RenderStyles, WorkspaceRenderData};
 use crate::truck_backend::TruckBackend;
 use crate::ui_state::DrawingMode;
 use crate::{MainWindow, FONT};
-use crate::error::GuiError;
 
 pub fn render_workspace(
     data: &WorkspaceRenderData,
@@ -339,6 +339,29 @@ pub fn render_workspace(
         pb.line_to(cf.pos.0 + 5.0, cf.pos.1);
         pb.move_to(cf.pos.0, cf.pos.1 - 5.0);
         pb.line_to(cf.pos.0, cf.pos.1 + 5.0);
+        if let Some(path) = pb.finish() {
+            pixmap.stroke_path(
+                &path,
+                &paint,
+                &Stroke {
+                    width: 1.0,
+                    ..Stroke::default()
+                },
+                Transform::identity(),
+                None,
+            );
+        }
+    }
+
+    if let Some(sp) = *state.snap_target.borrow() {
+        paint.set_color(Color::from_rgba8(255, 255, 0, 255));
+        let sx = tx(sp.x as f32);
+        let sy = ty(sp.y as f32);
+        let mut pb = PathBuilder::new();
+        pb.move_to(sx - 4.0, sy);
+        pb.line_to(sx + 4.0, sy);
+        pb.move_to(sx, sy - 4.0);
+        pb.line_to(sx, sy + 4.0);
         if let Some(path) = pb.finish() {
             pixmap.stroke_path(
                 &path,

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -877,6 +877,37 @@ export component SnapSettingsDialog inherits Window {
     }
 }
 
+component SnapIcon {
+    in-out property <bool> active;
+    in property <string> tip;
+    callback toggled(bool);
+    width: 24px; height: 24px;
+    Image { source: @image-url("../assets/icons/snap.png"); colorize: root.active ? #FFFFFF : #777777; width: 100%; height: 100%; }
+    TouchArea { width: 100%; height: 100%; clicked => { root.active = !root.active; root.toggled(root.active); } }
+}
+
+export component SnapOverlay {
+    in-out property <bool> snap_grid;
+    in-out property <bool> snap_objects;
+    in-out property <bool> snap_points;
+    in-out property <bool> snap_endpoints;
+    in-out property <bool> snap_intersections;
+    callback snap_grid_changed(bool);
+    callback snap_objects_changed(bool);
+    callback snap_points_changed(bool);
+    callback snap_endpoints_changed(bool);
+    callback snap_intersections_changed(bool);
+    HorizontalBox {
+        spacing: 4px;
+        SnapIcon { tip: "Grid"; active <=> root.snap_grid; toggled(b) => { root.snap_grid_changed(b); } }
+        SnapIcon { tip: "Objects"; active <=> root.snap_objects; toggled(b) => { root.snap_objects_changed(b); } }
+        SnapIcon { tip: "Points"; active <=> root.snap_points; toggled(b) => { root.snap_points_changed(b); } }
+        SnapIcon { tip: "Ends"; active <=> root.snap_endpoints; toggled(b) => { root.snap_endpoints_changed(b); } }
+        SnapIcon { tip: "Intersections"; active <=> root.snap_intersections; toggled(b) => { root.snap_intersections_changed(b); } }
+    }
+    background: transparent;
+}
+
 export component MacroListDialog inherits Window {
     in-out property <[string]> files;
     in-out property <int> selected_index;
@@ -1259,7 +1290,20 @@ export component MainWindow inherits Window {
                 pointer_released() => { root.workspace_pointer_released(); }
                 scrolled(dx, dy) => { root.workspace_scrolled(dx, dy); }
             }
-        } 
+            SnapOverlay {
+                x: 4px; y: 4px;
+                snap_grid <=> root.snap_to_grid;
+                snap_objects <=> root.snap_to_entities;
+                snap_points <=> root.snap_points;
+                snap_endpoints <=> root.snap_endpoints;
+                snap_intersections <=> root.snap_intersections;
+                snap_grid_changed(b) => { root.snap_grid_changed(b); }
+                snap_objects_changed(b) => { root.snap_objects_changed(b); }
+                snap_points_changed(b) => { root.snap_points_changed(b); }
+                snap_endpoints_changed(b) => { root.snap_endpoints_changed(b); }
+                snap_intersections_changed(b) => { root.snap_intersections_changed(b); }
+            }
+        }
 
         command_line := CommandLine {
             width: 100%;


### PR DESCRIPTION
## Summary
- show snap options via new `SnapOverlay` in `main.slint`
- record snap points in `TruckBackend` and expose helpers
- draw snap marker in workspace renderer
- use backend helper when snapping handles

## Testing
- `cargo fmt --manifest-path survey_cad_truck_gui/Cargo.toml`
- `cargo check -Znext-lockfile-bump` *(fails: feature `edition2024` is not stabilized)*

------
https://chatgpt.com/codex/tasks/task_e_687f7c56c6048328aa6991f54eacc990