### PR TITLE
Fix SnapOverlay background

### DIFF
--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -886,7 +886,7 @@ component SnapIcon {
     TouchArea { width: 100%; height: 100%; clicked => { root.active = !root.active; root.toggled(root.active); } }
 }
 
-export component SnapOverlay {
+export component SnapOverlay inherits Rectangle {
     in-out property <bool> snap_grid;
     in-out property <bool> snap_objects;
     in-out property <bool> snap_points;


### PR DESCRIPTION
## Summary
- give SnapOverlay a Rectangle base so `background` property is valid

## Testing
- `cargo check --package survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_687f85eed4d48328bf5892442658cad5