### PR TITLE
Implement volume analysis dialog

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -3517,6 +3517,71 @@ fn main() -> Result<(), slint::PlatformError> {
 
     {
         let weak = app.as_weak();
+        let surfaces_clone = surfaces.clone();
+        let alignments_clone = alignments.clone();
+        app.on_volume_analysis(move || {
+            let dlg = VolumeAnalysisDialog::new().unwrap();
+            dlg.set_width_value("10".into());
+            dlg.set_interval_value("10".into());
+            dlg.set_offset_step_value("1".into());
+            dlg.set_volumes_model(Rc::new(VecModel::<VolumeRow>::from(Vec::new())).into());
+            dlg.set_cut_value("".into());
+            dlg.set_fill_value("".into());
+            let dlg_weak = dlg.as_weak();
+            let weak2 = weak.clone();
+            let surfs = surfaces_clone.clone();
+            let aligns = alignments_clone.clone();
+            dlg.on_compute(move || {
+                if let Some(d) = dlg_weak.upgrade() {
+                    let res = (|| {
+                        let width = d.get_width_value().parse::<f64>().ok()?;
+                        let interval = d.get_interval_value().parse::<f64>().ok()?;
+                        let step = d.get_offset_step_value().parse::<f64>().ok()?;
+                        let surfs = surfs.borrow();
+                        let aligns = aligns.borrow();
+                        if surfs.len() < 2 || aligns.is_empty() {
+                            return None;
+                        }
+                        let design = &surfs[0];
+                        let ground = &surfs[1];
+                        let al = &aligns[0];
+                        let haul = corridor::corridor_mass_haul(design, ground, al, width, interval, step);
+                        let (cut, fill) = corridor::corridor_cut_fill(design, ground, al, width, interval, step);
+                        Some((haul, cut, fill))
+                    })();
+                    if let Some(app) = weak2.upgrade() {
+                        if let Some((haul, cut, fill)) = res {
+                            let model = Rc::new(VecModel::<VolumeRow>::from(
+                                haul
+                                    .iter()
+                                    .map(|(s, v)| VolumeRow {
+                                        station: SharedString::from(format!("{s:.2}")),
+                                        volume: SharedString::from(format!("{v:.3}")),
+                                    })
+                                    .collect::<Vec<_>>(),
+                            ));
+                            d.set_volumes_model(model.into());
+                            d.set_cut_value(SharedString::from(format!("{cut:.3}")));
+                            d.set_fill_value(SharedString::from(format!("{fill:.3}")));
+                            app.set_status(SharedString::from("Volume analysis complete"));
+                        } else {
+                            app.set_status(SharedString::from("Invalid input or missing data"));
+                        }
+                    }
+                }
+            });
+            let dlg_weak2 = dlg.as_weak();
+            dlg.on_close(move || {
+                if let Some(d) = dlg_weak2.upgrade() {
+                    let _ = d.hide();
+                }
+            });
+            dlg.show().unwrap();
+        });
+    }
+
+    {
+        let weak = app.as_weak();
         let point_db = point_db.clone();
         let lines = lines.clone();
         let polygons = polygons.clone();

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -429,6 +429,62 @@ export component CorridorVolumeDialog inherits Window {
     }
 }
 
+export struct VolumeRow {
+    station: string,
+    volume: string,
+}
+
+export component VolumeAnalysisDialog inherits Window {
+    in-out property <string> width_value;
+    in-out property <string> interval_value;
+    in-out property <string> offset_step_value;
+    in-out property <[VolumeRow]> volumes_model;
+    in-out property <string> cut_value;
+    in-out property <string> fill_value;
+    callback compute();
+    callback close();
+    title: "Volume Analysis";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox {
+            Text { color: #FFFFFF; text: "Width:"; }
+            LineEdit { text <=> root.width_value; }
+        }
+        HorizontalBox {
+            Text { color: #FFFFFF; text: "Interval:"; }
+            LineEdit { text <=> root.interval_value; }
+        }
+        HorizontalBox {
+            Text { color: #FFFFFF; text: "Offset Step:"; }
+            LineEdit { text <=> root.offset_step_value; }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Button { text: "Compute"; clicked => { root.compute(); } }
+            Button { text: "Close"; clicked => { root.close(); } }
+        }
+        Rectangle {
+            width: 100%;
+            height: 150px;
+            ListView {
+                vertical-stretch: 1;
+                for row in root.volumes_model : HorizontalBox {
+                    spacing: 8px;
+                    Text { color: #FFFFFF; text: row.station; width: 80px; }
+                    Text { color: #FFFFFF; text: row.volume; width: 80px; }
+                }
+            }
+        }
+        HorizontalBox {
+            spacing: 6px;
+            Text { color: #FFFFFF; text: "Cut:"; }
+            Text { color: #FFFFFF; text: root.cut_value; }
+            Text { color: #FFFFFF; text: "Fill:"; }
+            Text { color: #FFFFFF; text: root.fill_value; }
+        }
+    }
+}
+
 export component DesignSectionDialog inherits Window {
     in-out property <string> start_station;
     in-out property <string> end_station;
@@ -1008,6 +1064,7 @@ export component MainWindow inherits Window {
     callback traverse_area();
     callback level_elevation_tool();
     callback corridor_volume();
+    callback volume_analysis();
     callback design_cross_sections();
     callback view_cross_sections();
     callback superelevation_editor();
@@ -1157,6 +1214,7 @@ export component MainWindow inherits Window {
             MenuItem { title: "Traverse Area"; activated => { root.traverse_area(); }}
             MenuItem { title: "Level Elevation"; activated => { root.level_elevation_tool(); }}
             MenuItem { title: "Corridor Volume"; activated => { root.corridor_volume(); }}
+            MenuItem { title: "Volume Analysis"; activated => { root.volume_analysis(); }}
             MenuItem { title: "Superelevation..."; activated => { root.superelevation_editor(); }}
             MenuItem { title: "Design Sections"; activated => { root.design_cross_sections(); }}
             MenuItem { title: "Cross Sections"; activated => { root.view_cross_sections(); }}


### PR DESCRIPTION
## Summary
- add VolumeAnalysisDialog in slint UI
- expose `volume_analysis` callback and menu item
- compute mass haul and cut/fill volume in Rust

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo test -p survey_cad_truck_gui`

------
https://chatgpt.com/codex/tasks/task_e_687f9129ad34832888374ff6ada9bc32