### PR TITLE
Fix style_defs_save compile error

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -998,7 +998,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         point_db: point_db.clone(),
                         point_styles: point_styles.clone(),
                         lines: lines_ref.clone(),
-                        line_styles: style_defs_save.borrow().clone(),
+                        line_styles: line_styles.clone(),
                         backend: backend_render.clone(),
                         render_image: Rc::new(render_image.clone()),
                         weak: weak.clone(),


### PR DESCRIPTION
## Summary
- fix reference to `style_defs_save` when running quick scripts

## Testing
- `cargo check -p survey_cad_truck_gui` *(fails: build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6880d35e72408328b4bd1748365156fa