### PR TITLE
Add COGO intersection/offset tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9368,6 +9368,7 @@ dependencies = [
  "log",
  "once_cell",
  "open",
+ "pipe_network",
  "pyo3",
  "pyo3-build-config",
  "rfd",
@@ -9385,6 +9386,7 @@ dependencies = [
  "tiny-skia",
  "truck-meshalgo",
  "truck-modeling",
+ "truck-rendimpl",
  "truck_cad_engine",
 ]
 

--- a/survey_cad/src/surveying/cogo.rs
+++ b/survey_cad/src/surveying/cogo.rs
@@ -52,6 +52,61 @@ pub fn bearing_bearing_intersection(p1: Point, b1: f64, p2: Point, b2: f64) -> O
     line_intersection(p1, p1_end, p2, p2_end)
 }
 
+pub fn bearing_distance_intersection(
+    start: Point,
+    bearing: f64,
+    center: Point,
+    radius: f64,
+) -> Option<Vec<Point>> {
+    let dx = bearing.cos();
+    let dy = bearing.sin();
+    let fx = start.x - center.x;
+    let fy = start.y - center.y;
+    let b = fx * dx + fy * dy;
+    let c = fx * fx + fy * fy - radius * radius;
+    let disc = b * b - c;
+    if disc < 0.0 {
+        return None;
+    }
+    let sqrt_disc = disc.sqrt();
+    let mut pts = Vec::new();
+    for t in [-b - sqrt_disc, -b + sqrt_disc] {
+        if disc.abs() < f64::EPSILON && !pts.is_empty() {
+            break;
+        }
+        pts.push(Point::new(start.x + t * dx, start.y + t * dy));
+    }
+    Some(pts)
+}
+
+pub fn deflection_angle(a: Point, b: Point, c: Point) -> f64 {
+    let ang1 = bearing(b, a);
+    let ang2 = bearing(b, c);
+    let mut phi = ang2 - ang1;
+    while phi <= -std::f64::consts::PI {
+        phi += 2.0 * std::f64::consts::PI;
+    }
+    while phi > std::f64::consts::PI {
+        phi -= 2.0 * std::f64::consts::PI;
+    }
+    phi
+}
+
+pub fn point_offset(start: Point, end: Point, distance: f64, offset: f64) -> Point {
+    let dx = end.x - start.x;
+    let dy = end.y - start.y;
+    let len = (dx * dx + dy * dy).sqrt();
+    if len.abs() < f64::EPSILON {
+        return start;
+    }
+    let t = distance / len;
+    let x = start.x + t * dx;
+    let y = start.y + t * dy;
+    let nx = -dy / len;
+    let ny = dx / len;
+    Point::new(x + offset * nx, y + offset * ny)
+}
+
 /// Calculates the intersection points of two circles. Each circle is defined by
 /// its center and radius. Returns `None` if the circles do not intersect or are
 /// coincident.

--- a/survey_cad/src/surveying/mod.rs
+++ b/survey_cad/src/surveying/mod.rs
@@ -3,7 +3,16 @@
 use crate::geometry::{self, Point};
 
 pub mod cogo;
-pub use cogo::{bearing, forward, line_intersection};
+pub use cogo::{
+    bearing,
+    forward,
+    line_intersection,
+    line_bearing_intersection,
+    bearing_bearing_intersection,
+    bearing_distance_intersection,
+    deflection_angle,
+    point_offset,
+};
 
 pub mod adjustment;
 pub use adjustment::{

--- a/survey_cad/tests/cogo_extended.rs
+++ b/survey_cad/tests/cogo_extended.rs
@@ -1,0 +1,33 @@
+use survey_cad::geometry::Point;
+use survey_cad::surveying::{
+    bearing_bearing_intersection, bearing_distance_intersection, deflection_angle, point_offset,
+};
+
+#[test]
+fn bearing_distance_simple() {
+    let start = Point::new(0.0, 0.0);
+    let center = Point::new(1.0, 1.0);
+    let res = bearing_distance_intersection(start, 0.0, center, 1.0).unwrap();
+    assert_eq!(res.len(), 1);
+    let p = res[0];
+    assert!((p.x - 1.0).abs() < 1e-6);
+    assert!(p.y.abs() < 1e-6);
+}
+
+#[test]
+fn deflection_angle_right() {
+    let a = Point::new(0.0, 0.0);
+    let b = Point::new(1.0, 0.0);
+    let c = Point::new(1.0, 1.0);
+    let ang = deflection_angle(a, b, c).abs();
+    assert!((ang - std::f64::consts::FRAC_PI_2).abs() < 1e-6);
+}
+
+#[test]
+fn point_offset_basic() {
+    let a = Point::new(0.0, 0.0);
+    let b = Point::new(10.0, 0.0);
+    let p = point_offset(a, b, 5.0, 2.0);
+    assert!((p.x - 5.0).abs() < 1e-6);
+    assert!((p.y - 2.0).abs() < 1e-6);
+}

--- a/survey_cad_truck_gui/src/commands.rs
+++ b/survey_cad_truck_gui/src/commands.rs
@@ -51,6 +51,10 @@ pub enum ParsedCommand {
     Line(Point, Point),
     Circle { center: Point, radius: f64 },
     Arc { p1: Point, p2: Point, p3: Point },
+    BearingBearing { p1: Point, b1: f64, p2: Point, b2: f64 },
+    BearingDistance { p1: Point, b1: f64, p2: Point, d2: f64 },
+    Deflection { a: Point, b: Point, c: Point },
+    PointOffset { a: Point, b: Point, distance: f64, offset: f64 },
     Load(String),
     Export(String),
     Undo,
@@ -93,6 +97,42 @@ pub fn parse_command(cmd: &str) -> Option<ParsedCommand> {
                 p2: Point::new(x2, y2),
                 p3: Point::new(x3, y3),
             })
+        }
+        "bb" if parts.len() >= 7 => {
+            let x1 = parts[1].parse().ok()?;
+            let y1 = parts[2].parse().ok()?;
+            let b1 = parts[3].parse().ok()?;
+            let x2 = parts[4].parse().ok()?;
+            let y2 = parts[5].parse().ok()?;
+            let b2 = parts[6].parse().ok()?;
+            Some(ParsedCommand::BearingBearing { p1: Point::new(x1, y1), b1, p2: Point::new(x2, y2), b2 })
+        }
+        "bd" if parts.len() >= 7 => {
+            let x1 = parts[1].parse().ok()?;
+            let y1 = parts[2].parse().ok()?;
+            let b1 = parts[3].parse().ok()?;
+            let x2 = parts[4].parse().ok()?;
+            let y2 = parts[5].parse().ok()?;
+            let d2 = parts[6].parse().ok()?;
+            Some(ParsedCommand::BearingDistance { p1: Point::new(x1, y1), b1, p2: Point::new(x2, y2), d2 })
+        }
+        "defl" if parts.len() >= 7 => {
+            let x1 = parts[1].parse().ok()?;
+            let y1 = parts[2].parse().ok()?;
+            let x2 = parts[3].parse().ok()?;
+            let y2 = parts[4].parse().ok()?;
+            let x3 = parts[5].parse().ok()?;
+            let y3 = parts[6].parse().ok()?;
+            Some(ParsedCommand::Deflection { a: Point::new(x1, y1), b: Point::new(x2, y2), c: Point::new(x3, y3) })
+        }
+        "offset" if parts.len() >= 7 => {
+            let x1 = parts[1].parse().ok()?;
+            let y1 = parts[2].parse().ok()?;
+            let x2 = parts[3].parse().ok()?;
+            let y2 = parts[4].parse().ok()?;
+            let dist = parts[5].parse().ok()?;
+            let off = parts[6].parse().ok()?;
+            Some(ParsedCommand::PointOffset { a: Point::new(x1, y1), b: Point::new(x2, y2), distance: dist, offset: off })
         }
         "load" if parts.len() >= 2 => {
             Some(ParsedCommand::Load(parts[1..].join(" ")))

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -497,6 +497,160 @@ fn main() -> Result<(), slint::PlatformError> {
 
     {
         let weak = app.as_weak();
+        let point_db = point_db.clone();
+        let point_styles = point_style_indices.clone();
+        let backend = backend.clone();
+        let command_stack = command_stack.clone();
+        app.on_bearing_bearing(move || {
+            let dlg = BearingBearingDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            let db = point_db.clone();
+            let styles = point_styles.clone();
+            let be = backend.clone();
+            let stack = command_stack.clone();
+            let weak2 = weak.clone();
+            dlg.on_accept(move || {
+                if let Some(d) = dlg_weak.upgrade() {
+                    let res = (|| {
+                        let x1 = d.get_x1().parse::<f64>().ok()?;
+                        let y1 = d.get_y1().parse::<f64>().ok()?;
+                        let b1 = d.get_b1().parse::<f64>().ok()?;
+                        let x2 = d.get_x2().parse::<f64>().ok()?;
+                        let y2 = d.get_y2().parse::<f64>().ok()?;
+                        let b2 = d.get_b2().parse::<f64>().ok()?;
+                        survey_cad::surveying::bearing_bearing_intersection(Point::new(x1, y1), b1, Point::new(x2, y2), b2)
+                    })();
+                    if let Some(pt) = res {
+                        spawn_point(&db, &styles, &be, pt);
+                        stack.borrow_mut().push(Command::RemovePoint { index: db.borrow().len() - 1, point: pt });
+                    } else if let Some(app) = weak2.upgrade() {
+                        app.set_status(SharedString::from("No intersection"));
+                    }
+                    let _ = d.hide();
+                }
+            });
+            let dlg_weak2 = dlg.as_weak();
+            dlg.on_cancel(move || { if let Some(d) = dlg_weak2.upgrade() { let _ = d.hide(); } });
+            dlg.show().unwrap();
+        });
+    }
+
+    {
+        let weak = app.as_weak();
+        let point_db = point_db.clone();
+        let point_styles = point_style_indices.clone();
+        let backend = backend.clone();
+        let command_stack = command_stack.clone();
+        app.on_bearing_distance(move || {
+            let dlg = BearingDistanceDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            let db = point_db.clone();
+            let styles = point_styles.clone();
+            let be = backend.clone();
+            let stack = command_stack.clone();
+            let weak2 = weak.clone();
+            dlg.on_accept(move || {
+                if let Some(d) = dlg_weak.upgrade() {
+                    let res = (|| {
+                        let x1 = d.get_x1().parse::<f64>().ok()?;
+                        let y1 = d.get_y1().parse::<f64>().ok()?;
+                        let b1 = d.get_b1().parse::<f64>().ok()?;
+                        let x2 = d.get_x2().parse::<f64>().ok()?;
+                        let y2 = d.get_y2().parse::<f64>().ok()?;
+                        let d2 = d.get_d2().parse::<f64>().ok()?;
+                        survey_cad::surveying::bearing_distance_intersection(Point::new(x1, y1), b1, Point::new(x2, y2), d2)
+                    })();
+                    if let Some(pts) = res {
+                        for pt in pts {
+                            spawn_point(&db, &styles, &be, pt);
+                            stack.borrow_mut().push(Command::RemovePoint { index: db.borrow().len() - 1, point: pt });
+                        }
+                    } else if let Some(app) = weak2.upgrade() {
+                        app.set_status(SharedString::from("No intersection"));
+                    }
+                    let _ = d.hide();
+                }
+            });
+            let dlg_weak2 = dlg.as_weak();
+            dlg.on_cancel(move || { if let Some(d) = dlg_weak2.upgrade() { let _ = d.hide(); } });
+            dlg.show().unwrap();
+        });
+    }
+
+    {
+        let weak = app.as_weak();
+        app.on_deflection_angle_tool(move || {
+            let dlg = DeflectionAngleDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            let weak2 = weak.clone();
+            dlg.on_accept(move || {
+                if let Some(d) = dlg_weak.upgrade() {
+                    let res = (|| {
+                        let x1 = d.get_x1().parse::<f64>().ok()?;
+                        let y1 = d.get_y1().parse::<f64>().ok()?;
+                        let x2 = d.get_x2().parse::<f64>().ok()?;
+                        let y2 = d.get_y2().parse::<f64>().ok()?;
+                        let x3 = d.get_x3().parse::<f64>().ok()?;
+                        let y3 = d.get_y3().parse::<f64>().ok()?;
+                        Some(survey_cad::surveying::deflection_angle(Point::new(x1, y1), Point::new(x2, y2), Point::new(x3, y3)))
+                    })();
+                    if let Some(app) = weak2.upgrade() {
+                        if let Some(a) = res {
+                            app.set_status(SharedString::from(format!("Deflection: {:.3} rad", a)));
+                        } else {
+                            app.set_status(SharedString::from("Invalid input"));
+                        }
+                    }
+                    let _ = d.hide();
+                }
+            });
+            let dlg_weak2 = dlg.as_weak();
+            dlg.on_cancel(move || { if let Some(d) = dlg_weak2.upgrade() { let _ = d.hide(); } });
+            dlg.show().unwrap();
+        });
+    }
+
+    {
+        let weak = app.as_weak();
+        let point_db = point_db.clone();
+        let point_styles = point_style_indices.clone();
+        let backend = backend.clone();
+        let command_stack = command_stack.clone();
+        app.on_point_offset_tool(move || {
+            let dlg = PointOffsetDialog::new().unwrap();
+            let dlg_weak = dlg.as_weak();
+            let db = point_db.clone();
+            let styles = point_styles.clone();
+            let be = backend.clone();
+            let stack = command_stack.clone();
+            let weak2 = weak.clone();
+            dlg.on_accept(move || {
+                if let Some(d) = dlg_weak.upgrade() {
+                    let res = (|| {
+                        let x1 = d.get_x1().parse::<f64>().ok()?;
+                        let y1 = d.get_y1().parse::<f64>().ok()?;
+                        let x2 = d.get_x2().parse::<f64>().ok()?;
+                        let y2 = d.get_y2().parse::<f64>().ok()?;
+                        let dist = d.get_distance().parse::<f64>().ok()?;
+                        let off = d.get_offset().parse::<f64>().ok()?;
+                        Some(survey_cad::surveying::point_offset(Point::new(x1, y1), Point::new(x2, y2), dist, off))
+                    })();
+                    if let Some(pt) = res {
+                        spawn_point(&db, &styles, &be, pt);
+                        stack.borrow_mut().push(Command::RemovePoint { index: db.borrow().len() - 1, point: pt });
+                    } else if let Some(app) = weak2.upgrade() {
+                        app.set_status(SharedString::from("Invalid input"));
+                    }
+                    let _ = d.hide();
+                }
+            });
+            let dlg_weak2 = dlg.as_weak();
+            dlg.on_cancel(move || { if let Some(d) = dlg_weak2.upgrade() { let _ = d.hide(); } });
+            dlg.show().unwrap();
+        });
+    }
+    {
+        let weak = app.as_weak();
         app.on_menu_hovered(move |txt| {
             if let Some(app) = weak.upgrade() {
                 app.set_status(txt.clone());

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -485,6 +485,94 @@ export component VolumeAnalysisDialog inherits Window {
     }
 }
 
+export component BearingBearingDialog inherits Window {
+    in-out property <string> x1;
+    in-out property <string> y1;
+    in-out property <string> b1;
+    in-out property <string> x2;
+    in-out property <string> y2;
+    in-out property <string> b2;
+    callback accept();
+    callback cancel();
+    title: "Bearing/Bearing";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox { Text { color: #FFFFFF; text: "X1:"; } LineEdit { text <=> root.x1; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Y1:"; } LineEdit { text <=> root.y1; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "B1:"; } LineEdit { text <=> root.b1; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "X2:"; } LineEdit { text <=> root.x2; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Y2:"; } LineEdit { text <=> root.y2; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "B2:"; } LineEdit { text <=> root.b2; } }
+        HorizontalBox { spacing: 6px; Button { text: "OK"; clicked => { root.accept(); } } Button { text: "Cancel"; clicked => { root.cancel(); } } }
+    }
+}
+
+export component BearingDistanceDialog inherits Window {
+    in-out property <string> x1;
+    in-out property <string> y1;
+    in-out property <string> b1;
+    in-out property <string> x2;
+    in-out property <string> y2;
+    in-out property <string> d2;
+    callback accept();
+    callback cancel();
+    title: "Bearing/Distance";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox { Text { color: #FFFFFF; text: "X1:"; } LineEdit { text <=> root.x1; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Y1:"; } LineEdit { text <=> root.y1; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "B1:"; } LineEdit { text <=> root.b1; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "X2:"; } LineEdit { text <=> root.x2; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Y2:"; } LineEdit { text <=> root.y2; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "D2:"; } LineEdit { text <=> root.d2; } }
+        HorizontalBox { spacing: 6px; Button { text: "OK"; clicked => { root.accept(); } } Button { text: "Cancel"; clicked => { root.cancel(); } } }
+    }
+}
+
+export component DeflectionAngleDialog inherits Window {
+    in-out property <string> x1;
+    in-out property <string> y1;
+    in-out property <string> x2;
+    in-out property <string> y2;
+    in-out property <string> x3;
+    in-out property <string> y3;
+    callback accept();
+    callback cancel();
+    title: "Deflection Angle";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox { Text { color: #FFFFFF; text: "X1:"; } LineEdit { text <=> root.x1; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Y1:"; } LineEdit { text <=> root.y1; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "X2:"; } LineEdit { text <=> root.x2; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Y2:"; } LineEdit { text <=> root.y2; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "X3:"; } LineEdit { text <=> root.x3; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Y3:"; } LineEdit { text <=> root.y3; } }
+        HorizontalBox { spacing: 6px; Button { text: "OK"; clicked => { root.accept(); } } Button { text: "Cancel"; clicked => { root.cancel(); } } }
+    }
+}
+
+export component PointOffsetDialog inherits Window {
+    in-out property <string> x1;
+    in-out property <string> y1;
+    in-out property <string> x2;
+    in-out property <string> y2;
+    in-out property <string> distance;
+    in-out property <string> offset;
+    callback accept();
+    callback cancel();
+    title: "Point Offset";
+    VerticalBox {
+        spacing: 6px;
+        HorizontalBox { Text { color: #FFFFFF; text: "X1:"; } LineEdit { text <=> root.x1; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Y1:"; } LineEdit { text <=> root.y1; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "X2:"; } LineEdit { text <=> root.x2; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Y2:"; } LineEdit { text <=> root.y2; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Dist:"; } LineEdit { text <=> root.distance; } }
+        HorizontalBox { Text { color: #FFFFFF; text: "Off:"; } LineEdit { text <=> root.offset; } }
+        HorizontalBox { spacing: 6px; Button { text: "OK"; clicked => { root.accept(); } } Button { text: "Cancel"; clicked => { root.cancel(); } } }
+    }
+}
+
 export component DesignSectionDialog inherits Window {
     in-out property <string> start_station;
     in-out property <string> end_station;
@@ -1065,6 +1153,10 @@ export component MainWindow inherits Window {
     callback level_elevation_tool();
     callback corridor_volume();
     callback volume_analysis();
+    callback bearing_bearing();
+    callback bearing_distance();
+    callback deflection_angle_tool();
+    callback point_offset_tool();
     callback design_cross_sections();
     callback view_cross_sections();
     callback superelevation_editor();
@@ -1213,6 +1305,10 @@ export component MainWindow inherits Window {
             MenuItem { title: "Station Distance"; activated => { root.station_distance(); }}
             MenuItem { title: "Traverse Area"; activated => { root.traverse_area(); }}
             MenuItem { title: "Level Elevation"; activated => { root.level_elevation_tool(); }}
+            MenuItem { title: "Bearing/Bearing"; activated => { root.bearing_bearing(); }}
+            MenuItem { title: "Bearing/Distance"; activated => { root.bearing_distance(); }}
+            MenuItem { title: "Deflection Angle"; activated => { root.deflection_angle_tool(); }}
+            MenuItem { title: "Point Offset"; activated => { root.point_offset_tool(); }}
             MenuItem { title: "Corridor Volume"; activated => { root.corridor_volume(); }}
             MenuItem { title: "Volume Analysis"; activated => { root.volume_analysis(); }}
             MenuItem { title: "Superelevation..."; activated => { root.superelevation_editor(); }}


### PR DESCRIPTION
## Summary
- extend surveying utilities with bearing-distance intersection, deflection angle, and point offset functions
- expose new commands in truck GUI command parser
- register dialogs and callbacks for bearing/bearing, bearing/distance, deflection angle, and point offset tools
- add integration tests for the new COGO functions

## Testing
- `cargo test -p survey_cad --lib tests/cogo_extended.rs --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688396b6bfdc8328b24bcc888846ebd1