### PR TITLE
Fix deflection status formatting

### DIFF
--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -624,7 +624,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     })();
                     if let Some(app) = weak2.upgrade() {
                         if let Some(a) = res {
-                            app.set_status(SharedString::from(format!("Deflection: {:.3} rad", a)));
+                            app.set_status(SharedString::from(format!("Deflection: {a:.3} rad")));
                         } else {
                             app.set_status(SharedString::from("Invalid input"));
                         }
@@ -1549,8 +1549,7 @@ fn main() -> Result<(), slint::PlatformError> {
                         let ang = survey_cad::surveying::deflection_angle(a, b, c);
                         if let Some(app) = weak.upgrade() {
                             app.set_status(SharedString::from(format!(
-                                "Deflection: {:.3} rad",
-                                ang
+                                "Deflection: {ang:.3} rad"
                             )));
                         }
                     }


### PR DESCRIPTION
## Summary
- fix `format!` usages for deflection angle display to pass clippy

## Testing
- `cargo clippy -p survey_cad_truck_gui --tests -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_6883a9e3babc8328b918c0737e9ad6b4