### PR TITLE
Add LOD support and vertex caching in truck gui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 version = "0.1.0"
+
+[workspace.dev-dependencies]
+criterion = "0.5"

--- a/benches/truck_gui.rs
+++ b/benches/truck_gui.rs
@@ -1,0 +1,25 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use truck_cad_engine::TruckCadEngine;
+use truck_modeling::base::Point3;
+
+fn build_engine(count: usize) -> TruckCadEngine {
+    let mut engine = TruckCadEngine::new(800, 600);
+    let vertices: Vec<_> = (0..50)
+        .map(|i| Point3::new((i % 10) as f64, (i / 10) as f64, 0.0))
+        .collect();
+    let triangles: Vec<[usize; 3]> = (0..47).map(|i| [i, i + 1, i + 2]).collect();
+    for _ in 0..count {
+        engine.add_surface(&vertices, &triangles);
+    }
+    engine
+}
+
+fn bench_render(c: &mut Criterion) {
+    let mut engine = build_engine(200);
+    c.bench_function("render_no_lod", |b| b.iter(|| engine.render_to_image()));
+    engine.enable_lod(30.0);
+    c.bench_function("render_lod", |b| b.iter(|| engine.render_to_image()));
+}
+
+criterion_group!(benches, bench_render);
+criterion_main!(benches);

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -113,6 +113,7 @@ static FONT: Lazy<Font<'static>> = Lazy::new(|| Font::try_from_bytes(FONT_DATA).
 fn main() -> Result<(), slint::PlatformError> {
     let mut cmd_font: Option<String> = None;
     let mut cmd_macro_dir: Option<String> = None;
+    let mut cmd_lod: Option<f64> = None;
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -126,6 +127,13 @@ fn main() -> Result<(), slint::PlatformError> {
                     cmd_macro_dir = Some(p);
                 }
             }
+            "--lod" => {
+                if let Some(v) = args.next() {
+                    if let Ok(d) = v.parse::<f64>() {
+                        cmd_lod = Some(d);
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -137,6 +145,10 @@ fn main() -> Result<(), slint::PlatformError> {
     }
     if let Some(p) = cmd_macro_dir {
         cfg.macro_dir = Some(p);
+        save_config(&cfg);
+    }
+    if let Some(d) = cmd_lod {
+        cfg.lod_distance = Some(d);
         save_config(&cfg);
     }
     let config = Rc::new(RefCell::new(cfg));
@@ -154,6 +166,9 @@ fn main() -> Result<(), slint::PlatformError> {
         config.borrow().window_width,
         config.borrow().window_height,
     )));
+    if let Some(d) = config.borrow().lod_distance {
+        backend.borrow_mut().set_lod(true, d);
+    }
     // Always populate the font database with the system fonts first so that the
     // embedded font can complement, rather than replace, them. This ensures
     // that built-in controls can resolve their default fonts while we still
@@ -1548,9 +1563,7 @@ fn main() -> Result<(), slint::PlatformError> {
                     commands::ParsedCommand::Deflection { a, b, c } => {
                         let ang = survey_cad::surveying::deflection_angle(a, b, c);
                         if let Some(app) = weak.upgrade() {
-                            app.set_status(SharedString::from(format!(
-                                "Deflection: {ang:.3} rad"
-                            )));
+                            app.set_status(SharedString::from(format!("Deflection: {ang:.3} rad")));
                         }
                     }
                     commands::ParsedCommand::PointOffset {

--- a/survey_cad_truck_gui/src/truck_backend.rs
+++ b/survey_cad_truck_gui/src/truck_backend.rs
@@ -1,6 +1,6 @@
 use slint::Image;
 use truck_cad_engine::TruckCadEngine;
-use truck_modeling::base::{Point3, Vector3, Vector4, Matrix4, Rad, InnerSpace, Transform};
+use truck_modeling::base::{InnerSpace, Matrix4, Point3, Rad, Transform, Vector3, Vector4};
 use truck_modeling::topology::Solid;
 use truck_rendimpl::PolygonState;
 
@@ -150,6 +150,14 @@ impl TruckBackend {
 
     pub fn render(&mut self) -> Image {
         self.engine.render_to_image()
+    }
+
+    pub fn set_lod(&mut self, enabled: bool, distance: f64) {
+        if enabled {
+            self.engine.enable_lod(distance);
+        } else {
+            self.engine.disable_lod();
+        }
     }
 
     pub fn rotate(&mut self, dx: f64, dy: f64) {
@@ -576,9 +584,12 @@ impl TruckBackend {
         self.hide_handles();
         let origin = self.object_center(&target);
         let ids = [
-            self.engine.add_point_marker(origin + Vector3::unit_x() * GIZMO_SIZE),
-            self.engine.add_point_marker(origin + Vector3::unit_y() * GIZMO_SIZE),
-            self.engine.add_point_marker(origin + Vector3::unit_z() * GIZMO_SIZE),
+            self.engine
+                .add_point_marker(origin + Vector3::unit_x() * GIZMO_SIZE),
+            self.engine
+                .add_point_marker(origin + Vector3::unit_y() * GIZMO_SIZE),
+            self.engine
+                .add_point_marker(origin + Vector3::unit_z() * GIZMO_SIZE),
         ]
         .to_vec();
         self.gizmo_origin = Some(origin);
@@ -650,14 +661,22 @@ impl TruckBackend {
                             let start_vec = (axis * GIZMO_SIZE).normalize();
                             let new_vec = (new_pos - origin).normalize();
                             let angle = start_vec.angle(new_vec);
-                            let sign = if start_vec.cross(new_vec).dot(axis) < 0.0 { -1.0 } else { 1.0 };
+                            let sign = if start_vec.cross(new_vec).dot(axis) < 0.0 {
+                                -1.0
+                            } else {
+                                1.0
+                            };
                             self.rotate_object(&obj, origin, axis, angle.0 * sign);
                             self.gizmo_origin = Some(self.object_center(&obj));
                         }
                         GizmoMode::Scale => {
                             let start_len = GIZMO_SIZE;
                             let new_len = (new_pos - origin).dot(axis);
-                            let factor = if start_len.abs() < f64::EPSILON { 1.0 } else { new_len / start_len };
+                            let factor = if start_len.abs() < f64::EPSILON {
+                                1.0
+                            } else {
+                                new_len / start_len
+                            };
                             self.scale_object(&obj, origin, factor);
                             self.gizmo_origin = Some(self.object_center(&obj));
                         }
@@ -989,7 +1008,12 @@ impl TruckBackend {
 
     fn object_center(&self, obj: &HitObject) -> Point3 {
         match *obj {
-            HitObject::Point(i) => self.geometry.points.get(i).cloned().unwrap_or(Point3::new(0.0, 0.0, 0.0)),
+            HitObject::Point(i) => self
+                .geometry
+                .points
+                .get(i)
+                .cloned()
+                .unwrap_or(Point3::new(0.0, 0.0, 0.0)),
             HitObject::Line(i) => {
                 if let Some((a, b, _, _)) = self.geometry.lines.get(i) {
                     let v = Vector3::new(a.x + b.x, a.y + b.y, a.z + b.z) * 0.5;

--- a/survey_cad_truck_gui/src/ui_state.rs
+++ b/survey_cad_truck_gui/src/ui_state.rs
@@ -26,15 +26,32 @@ pub struct CursorFeedback {
 pub enum DrawingMode {
     #[default]
     None,
-    Line { start: Option<Point> },
-    Polygon { vertices: Vec<Point> },
+    Line {
+        start: Option<Point>,
+    },
+    Polygon {
+        vertices: Vec<Point>,
+    },
     /// Center, start and end order
-    ArcCenter { center: Option<Point>, radius: Option<f64>, start_angle: Option<f64> },
+    ArcCenter {
+        center: Option<Point>,
+        radius: Option<f64>,
+        start_angle: Option<f64>,
+    },
     /// Three point arc
-    ArcThreePoint { p1: Option<Point>, p2: Option<Point> },
+    ArcThreePoint {
+        p1: Option<Point>,
+        p2: Option<Point>,
+    },
     /// Start, end, then radius via third click
-    ArcStartEndRadius { start: Option<Point>, end: Option<Point>, radius: Option<f64> },
-    Dimension { start: Option<Point> },
+    ArcStartEndRadius {
+        start: Option<Point>,
+        end: Option<Point>,
+        radius: Option<f64>,
+    },
+    Dimension {
+        start: Option<Point>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Default)]
@@ -94,6 +111,8 @@ pub struct Config {
     #[serde(default)]
     pub macro_dir: Option<String>,
     #[serde(default)]
+    pub lod_distance: Option<f64>,
+    #[serde(default)]
     pub crs_epsg: u32,
 }
 
@@ -110,6 +129,7 @@ impl Default for Config {
             theme: Theme::default(),
             font_path: None,
             macro_dir: None,
+            lod_distance: None,
             crs_epsg: 4326,
         }
     }

--- a/truck_cad_engine/src/lib.rs
+++ b/truck_cad_engine/src/lib.rs
@@ -14,18 +14,41 @@ pub struct TruckCadEngine {
     point_markers: Vec<Option<PolygonInstance>>,
     lines: Vec<Option<WireFrameInstance>>,
     surfaces: Vec<Option<Surface>>,
+    lod_enabled: bool,
+    lod_distance: f64,
 }
 
 struct Surface {
     instance: PolygonInstance,
     vertices: Vec<truck::base::Point3>,
     triangles: Vec<[usize; 3]>,
+    center: truck::base::Point3,
+    radius: f64,
+    visible: bool,
 }
 
 impl TruckCadEngine {
+    fn compute_bounds(verts: &[truck::base::Point3]) -> (truck::base::Point3, f64) {
+        if verts.is_empty() {
+            return (truck::base::Point3::new(0.0, 0.0, 0.0), 0.0);
+        }
+        let mut sum = truck::base::Vector3::new(0.0, 0.0, 0.0);
+        for v in verts {
+            sum += v.to_vec();
+        }
+        let center = truck::base::Point3::from_vec(sum / verts.len() as f64);
+        let mut radius = 0.0;
+        for v in verts {
+            let d = (*v - center).magnitude();
+            if d > radius {
+                radius = d;
+            }
+        }
+        (center, radius)
+    }
+
     fn rebuild_surface_internal(&mut self, surface_id: usize) {
         if let Some(Some(surface)) = self.surfaces.get_mut(surface_id) {
-            self.scene.remove_object(&surface.instance);
             let attrs = StandardAttributes {
                 positions: surface.vertices.clone(),
                 ..Default::default()
@@ -55,11 +78,14 @@ impl TruckCadEngine {
                 .collect();
             let faces = Faces::from_tri_and_quad_faces(tri_faces, Vec::new());
             let mesh = PolygonMesh::new(attrs, faces);
-            let new_inst = self
+            let mut new_inst = self
                 .creator
                 .create_instance(&mesh, &PolygonState::default());
-            self.scene.add_object(&new_inst);
-            surface.instance = new_inst;
+            surface.instance.swap_vertex(&mut new_inst);
+            self.scene.update_vertex_buffer(&surface.instance);
+            let (c, r) = Self::compute_bounds(&surface.vertices);
+            surface.center = c;
+            surface.radius = r;
         }
     }
 }
@@ -84,6 +110,8 @@ impl TruckCadEngine {
             point_markers: Vec::new(),
             lines: Vec::new(),
             surfaces: Vec::new(),
+            lod_enabled: false,
+            lod_distance: 100.0,
         }
     }
 
@@ -117,7 +145,10 @@ impl TruckCadEngine {
         for (verts, tris) in meshes {
             let offset = vertices.len();
             vertices.extend_from_slice(verts);
-            triangles.extend(tris.iter().map(|t| [t[0] + offset, t[1] + offset, t[2] + offset]));
+            triangles.extend(
+                tris.iter()
+                    .map(|t| [t[0] + offset, t[1] + offset, t[2] + offset]),
+            );
         }
         if vertices.is_empty() {
             return;
@@ -130,9 +161,21 @@ impl TruckCadEngine {
             .iter()
             .map(|t| {
                 [
-                    StandardVertex { pos: t[0], uv: None, nor: None },
-                    StandardVertex { pos: t[1], uv: None, nor: None },
-                    StandardVertex { pos: t[2], uv: None, nor: None },
+                    StandardVertex {
+                        pos: t[0],
+                        uv: None,
+                        nor: None,
+                    },
+                    StandardVertex {
+                        pos: t[1],
+                        uv: None,
+                        nor: None,
+                    },
+                    StandardVertex {
+                        pos: t[2],
+                        uv: None,
+                        nor: None,
+                    },
                 ]
             })
             .collect();
@@ -266,10 +309,14 @@ impl TruckCadEngine {
             .creator
             .create_instance(&mesh, &PolygonState::default());
         self.scene.add_object(&instance);
+        let (c, r) = Self::compute_bounds(vertices);
         self.surfaces.push(Some(Surface {
             instance,
             vertices: vertices.to_vec(),
             triangles: triangles.to_vec(),
+            center: c,
+            radius: r,
+            visible: true,
         }));
         self.surfaces.len() - 1
     }
@@ -282,7 +329,6 @@ impl TruckCadEngine {
         triangles: &[[usize; 3]],
     ) {
         if let Some(Some(surface)) = self.surfaces.get_mut(id) {
-            self.scene.remove_object(&surface.instance);
             let attrs = StandardAttributes {
                 positions: vertices.to_vec(),
                 ..Default::default()
@@ -311,13 +357,16 @@ impl TruckCadEngine {
                 .collect();
             let faces = Faces::from_tri_and_quad_faces(tri_faces, Vec::new());
             let mesh = PolygonMesh::new(attrs, faces);
-            let new_inst = self
+            let mut new_inst = self
                 .creator
                 .create_instance(&mesh, &PolygonState::default());
-            self.scene.add_object(&new_inst);
-            surface.instance = new_inst;
+            surface.instance.swap_vertex(&mut new_inst);
+            self.scene.update_vertex_buffer(&surface.instance);
             surface.vertices = vertices.to_vec();
             surface.triangles = triangles.to_vec();
+            let (c, r) = Self::compute_bounds(vertices);
+            surface.center = c;
+            surface.radius = r;
         }
     }
 
@@ -410,6 +459,7 @@ impl TruckCadEngine {
 
     /// Render the scene into a [`slint::Image`].
     pub fn render_to_image(&mut self) -> Image {
+        self.update_lod();
         let bytes = block_on(self.scene.render_to_buffer());
         let (w, h) = self.scene.descriptor().render_texture.canvas_size;
         let buffer = SharedPixelBuffer::<Rgba8Pixel>::clone_from_slice(&bytes, w, h);
@@ -445,6 +495,15 @@ impl TruckCadEngine {
         camera.matrix = Matrix4::from_translation(dir * (delta * 0.002)) * camera.matrix;
     }
 
+    pub fn enable_lod(&mut self, distance: f64) {
+        self.lod_enabled = true;
+        self.lod_distance = distance;
+    }
+
+    pub fn disable_lod(&mut self) {
+        self.lod_enabled = false;
+    }
+
     /// Resize the render target.
     pub fn resize(&mut self, width: u32, height: u32) {
         let mut desc = self.scene.descriptor_mut();
@@ -459,6 +518,31 @@ impl TruckCadEngine {
     /// Returns the size of the render target.
     pub fn canvas_size(&self) -> (u32, u32) {
         self.scene.descriptor().render_texture.canvas_size
+    }
+
+    fn update_lod(&mut self) {
+        if !self.lod_enabled {
+            for surf in &mut self.surfaces {
+                if let Some(s) = surf {
+                    if !s.visible {
+                        self.scene.set_visibility(&s.instance, true);
+                        s.visible = true;
+                    }
+                }
+            }
+            return;
+        }
+        let cam_pos = self.camera().position();
+        for surf in &mut self.surfaces {
+            if let Some(s) = surf {
+                let dist = (s.center - cam_pos).magnitude();
+                let vis = dist < self.lod_distance;
+                if vis != s.visible {
+                    self.scene.set_visibility(&s.instance, vis);
+                    s.visible = vis;
+                }
+            }
+        }
     }
 
     /// Project a 3D point to screen coordinates (pixels).


### PR DESCRIPTION
## Summary
- improve truck CAD engine to reuse buffers instead of recreating meshes
- add optional level of detail (LOD) based on camera distance
- expose LOD control in truck GUI backend and CLI
- add benchmark comparing rendering with and without LOD

## Testing
- `rustfmt truck_cad_engine/src/lib.rs survey_cad_truck_gui/src/truck_backend.rs survey_cad_truck_gui/src/ui_state.rs survey_cad_truck_gui/src/main.rs benches/truck_gui.rs`


------
https://chatgpt.com/codex/tasks/task_e_6883b9c50b6083289b49d8837fc3c2aa