### PR TITLE
Fix config test for lod distance

### DIFF
--- a/survey_cad_truck_gui/tests/config.rs
+++ b/survey_cad_truck_gui/tests/config.rs
@@ -28,6 +28,7 @@ fn save_and_load_config() {
         theme: Theme::default(),
         font_path: Some("font/path".into()),
         macro_dir: Some("/tmp/macros".into()),
+        lod_distance: Some(100.0),
         crs_epsg: 4326,
     };
 


### PR DESCRIPTION
## Summary
- update config test to set the `lod_distance` field

## Testing
- `cargo test -p survey_cad_truck_gui --features gui-tests` *(fails: could not compile crates due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68876ce16e308328a3bfc5e331aff82c