### PR TITLE
Add field book CSV import

### DIFF
--- a/survey_cad_truck_gui/src/io_utils.rs
+++ b/survey_cad_truck_gui/src/io_utils.rs
@@ -52,3 +52,104 @@ pub fn read_arc_csv(path: &str) -> std::io::Result<Arc> {
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     Ok(Arc::new(Point::new(cx, cy), r, sa, ea))
 }
+
+use std::collections::BTreeMap;
+use survey_cad::crs::Crs;
+use survey_cad::surveying::field_code::{CodeAction, FieldCode};
+
+pub fn read_field_book_csv(
+    path: &str,
+    dst_epsg: u32,
+) -> std::io::Result<(Vec<Point>, Vec<(Point, Point)>)> {
+    let lines = survey_cad::io::read_lines(path)?;
+    if lines.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    let header: Vec<String> = lines[0].split(',').map(|s| s.trim().to_string()).collect();
+    let mut start = 0usize;
+    let mut x_idx = 0usize;
+    let mut y_idx = 1usize;
+    let mut code_idx: Option<usize> = None;
+    let lower: Vec<String> = header.iter().map(|s| s.to_lowercase()).collect();
+    if lower
+        .iter()
+        .any(|h| h.contains('e') || h.contains("north") || h.contains("code"))
+        && lower.iter().any(|h| h.chars().any(|c| c.is_alphabetic()))
+    {
+        start = 1;
+        for (i, h) in lower.iter().enumerate() {
+            if h.contains("east") || h == "e" || h == "x" {
+                x_idx = i;
+            } else if h.contains("north") || h == "n" || h == "y" {
+                y_idx = i;
+            } else if h.contains("code") || h.contains("desc") {
+                code_idx = Some(i);
+            }
+        }
+    }
+    let mut pts_codes: Vec<(Point, String)> = Vec::new();
+    for line in lines.iter().skip(start) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.split(',').collect();
+        if parts.len() <= x_idx || parts.len() <= y_idx {
+            continue;
+        }
+        let x: f64 = parts[x_idx]
+            .trim()
+            .parse()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let y: f64 = parts[y_idx]
+            .trim()
+            .parse()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let code = code_idx
+            .and_then(|i| parts.get(i))
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        pts_codes.push((Point::new(x, y), code));
+    }
+    let src = Crs::from_epsg(4326);
+    let dst = Crs::from_epsg(dst_epsg);
+    for (p, _) in &mut pts_codes {
+        if let Some((x, y)) = src.transform_point(&dst, p.x, p.y) {
+            p.x = x;
+            p.y = y;
+        }
+    }
+    let mut active: BTreeMap<String, Point> = BTreeMap::new();
+    let mut out_lines = Vec::new();
+    for (pt, codes) in &pts_codes {
+        for raw in codes
+            .split(|c: char| c == ' ' || c == ';')
+            .filter(|s| !s.is_empty())
+        {
+            let fc = FieldCode::parse(raw);
+            if fc.code.is_empty() {
+                continue;
+            }
+            match fc.action {
+                CodeAction::Begin => {
+                    active.insert(fc.code, *pt);
+                }
+                CodeAction::Continue => {
+                    if let Some(prev) = active.get_mut(&fc.code) {
+                        out_lines.push((*prev, *pt));
+                        *prev = *pt;
+                    } else {
+                        active.insert(fc.code, *pt);
+                    }
+                }
+                CodeAction::End => {
+                    if let Some(prev) = active.remove(&fc.code) {
+                        out_lines.push((prev, *pt));
+                    }
+                }
+                CodeAction::None => {}
+            }
+        }
+    }
+    let pts: Vec<Point> = pts_codes.into_iter().map(|(p, _)| p).collect();
+    Ok((pts, out_lines))
+}

--- a/survey_cad_truck_gui/src/main.rs
+++ b/survey_cad_truck_gui/src/main.rs
@@ -109,7 +109,7 @@ use error::GuiError;
 pub use inspector::{
     has_selection, show_context_menu, show_inspector_for_point, show_inspector_for_polygon,
 };
-pub use io_utils::{read_arc_csv, read_line_csv, read_points_list};
+pub use io_utils::{read_arc_csv, read_field_book_csv, read_line_csv, read_points_list};
 use once_cell::sync::Lazy;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
@@ -1025,7 +1025,10 @@ fn main() -> Result<(), slint::PlatformError> {
         let zoom_ml = zoom.clone();
         app.on_show_macro_list(move || {
             let items: Vec<String> = collect_scripts(Path::new(&*macro_dir), &["txt", "py"]);
-            let items_ss: Vec<SharedString> = items.iter().map(|s| SharedString::from(s.clone())).collect();
+            let items_ss: Vec<SharedString> = items
+                .iter()
+                .map(|s| SharedString::from(s.clone()))
+                .collect();
 
             let dlg = MacroListDialog::new().unwrap();
             dlg.set_files(Rc::new(VecModel::from(items_ss.clone())).into());
@@ -4332,6 +4335,68 @@ fn main() -> Result<(), slint::PlatformError> {
 
     {
         let weak = app.as_weak();
+        let point_db = point_db.clone();
+        let lines_ref = lines.clone();
+        let render_image = render_image.clone();
+        let backend_render = backend.clone();
+        let workspace_crs = workspace_crs.clone();
+        app.on_import_field_book(move || {
+            if let Some(path) = rfd::FileDialog::new()
+                .add_filter("CSV", &["csv"])
+                .pick_file()
+            {
+                if let Some(p) = path.to_str() {
+                    match read_field_book_csv(p, *workspace_crs.borrow()) {
+                        Ok((pts, lns)) => {
+                            let len = {
+                                let mut db = point_db.borrow_mut();
+                                db.clear();
+                                db.extend(pts);
+                                let mut li = lines_ref.borrow_mut();
+                                li.clear();
+                                li.extend(lns);
+                                backend_render.borrow_mut().clear();
+                                for pt in db.iter() {
+                                    backend_render.borrow_mut().add_point(pt.x, pt.y, 0.0);
+                                }
+                                for (s, e) in li.iter() {
+                                    backend_render.borrow_mut().add_line(
+                                        [s.x, s.y, 0.0],
+                                        [e.x, e.y, 0.0],
+                                        [1.0, 1.0, 1.0, 1.0],
+                                        1.0,
+                                    );
+                                }
+                                db.len()
+                            };
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Imported {len} points"
+                                )));
+                                if app.get_workspace_mode() == 0 {
+                                    crate::set_workspace_image_result(&app, &render_image);
+                                } else {
+                                    let image = backend_render.borrow_mut().render();
+                                    app.set_workspace_texture(image);
+                                }
+                                app.window().request_redraw();
+                            }
+                        }
+                        Err(e) => {
+                            if let Some(app) = weak.upgrade() {
+                                app.set_status(SharedString::from(format!(
+                                    "Failed to import: {e}"
+                                )));
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    {
+        let weak = app.as_weak();
         let alignments = alignments.clone();
         let backend = backend.clone();
         app.on_design_cross_sections(move || {
@@ -6873,14 +6938,13 @@ fn main() -> Result<(), slint::PlatformError> {
         let style_defs = line_label_styles.clone();
         app.on_line_label_style_manager(move || {
             let dlg = LineLabelStyleManager::new().unwrap();
-            let style_names: Vec<SharedString> =
-                style_defs.iter().map(|(n, _)| SharedString::from(n.clone())).collect();
+            let style_names: Vec<SharedString> = style_defs
+                .iter()
+                .map(|(n, _)| SharedString::from(n.clone()))
+                .collect();
             dlg.set_styles_model(Rc::new(VecModel::from(style_names)).into());
-            let preview = crate::render::line_label_style_preview(
-                line_label_style.borrow().clone(),
-                40,
-                20,
-            );
+            let preview =
+                crate::render::line_label_style_preview(line_label_style.borrow().clone(), 40, 20);
             let rows = vec![LineLabelRow {
                 start: SharedString::from(""),
                 end: SharedString::from(""),
@@ -6931,8 +6995,10 @@ fn main() -> Result<(), slint::PlatformError> {
         let style_defs = point_label_styles.clone();
         app.on_point_label_style_manager(move || {
             let dlg = PointLabelStyleManager::new().unwrap();
-            let style_names: Vec<SharedString> =
-                style_defs.iter().map(|(n, _)| SharedString::from(n.clone())).collect();
+            let style_names: Vec<SharedString> = style_defs
+                .iter()
+                .map(|(n, _)| SharedString::from(n.clone()))
+                .collect();
             dlg.set_styles_model(Rc::new(VecModel::from(style_names)).into());
             let preview = crate::render::point_label_style_preview(
                 point_label_style.borrow().clone(),

--- a/survey_cad_truck_gui/ui/main.slint
+++ b/survey_cad_truck_gui/ui/main.slint
@@ -1204,6 +1204,7 @@ export component MainWindow inherits Window {
     callback export_landxml_sections();
     callback import_landxml_surface();
     callback import_landxml_alignment();
+    callback import_field_book();
     callback tin_add_vertex();
     callback tin_move_vertex();
     callback tin_delete_vertex();
@@ -1315,6 +1316,7 @@ export component MainWindow inherits Window {
             MenuItem { title: "Design Sections"; activated => { root.design_cross_sections(); }}
             MenuItem { title: "Cross Sections"; activated => { root.view_cross_sections(); }}
             MenuItem { title: "Extrude Polyline"; activated => { root.extrude_polyline(); }}
+            MenuItem { title: "Import Field Book"; activated => { root.import_field_book(); }}
         }
         Menu {
             title: "TIN";


### PR DESCRIPTION
## Summary
- add import_field_book callback to GUI and menu
- parse field-book CSVs with code-based linework
- update workspace via new import

## Testing
- `cargo check -p survey_cad_truck_gui`
- `cargo test -p survey_cad_truck_gui --no-run`

------
https://chatgpt.com/codex/tasks/task_e_688a2160148083288ad3502f28583864